### PR TITLE
README: remove toc, update target date

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,7 @@ development kit (SDK) for the Model Context Protocol (MCP).
 **WARNING**: The SDK is currently unstable and subject to breaking changes.
 Please test it out and file bug reports or API proposals. The [TODO](#todo)
 section below outlines outstanding release blockers. We aim to release a stable
-version of the SDK in mid July, 2025.
-
-	1. [Package documentation](#package-documentation)
-	1. [Example](#example)
-	1. [TODO](#todo)
-	1. [Design](#design)
-	1. [Acknowledgements](#acknowledgements)
-	1. [License](#license)
+version of the SDK in August, 2025.
 
 ## Package documentation
 

--- a/internal/readme/README.src.md
+++ b/internal/readme/README.src.md
@@ -11,9 +11,7 @@ development kit (SDK) for the Model Context Protocol (MCP).
 **WARNING**: The SDK is currently unstable and subject to breaking changes.
 Please test it out and file bug reports or API proposals. The [TODO](#todo)
 section below outlines outstanding release blockers. We aim to release a stable
-version of the SDK in mid July, 2025.
-
-%toc
+version of the SDK in August, 2025.
 
 ## Package documentation
 


### PR DESCRIPTION
Update the README to remove the table of contents, and update the target stability date from 'mid July' to 'August': mid July does not allow enough time for testing.