### PR TITLE
mcp, internal/readme: fix go generate

### DIFF
--- a/internal/readme/build.sh
+++ b/internal/readme/build.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 # Build README.md from the files in this directory.
-# Must be invoked from the internal/cmp directory.
+# Must be invoked from the mcp directory.
 
-cd internal/readme
+cd ../internal/readme
 
 outfile=../../README.md
 

--- a/mcp/mcp.go
+++ b/mcp/mcp.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:generate go run generate.go
-//go:generate ./internal/readme/build.sh
+//go:generate ../internal/readme/build.sh
 
 // The mcp package provides an SDK for writing model context protocol clients
 // and servers.


### PR DESCRIPTION
Adjust paths so `go generate` works.
