### PR TITLE
mcp,design: revert 'content' back to an interface type

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -269,7 +269,7 @@ These types will be included in the `mcp` package, but will be unexported unless
 
 For user-provided data, we use `json.RawMessage` or `map[string]any`, depending on the use case.
 
-For union types, which can't be represented in Go (specifically `Content` and `ResourceContents`), we prefer distinguished unions: struct types with fields corresponding to the union of all properties for union elements.
+For union types, which can't be represented in Go, we use an interface for `Content` (implemented by types like `TextContent`). For other union types like `ResourceContents`, we use a struct with optional fields.
 
 For brevity, only a few examples are shown here:
 
@@ -284,20 +284,16 @@ type CallToolResult struct {
 	IsError bool      `json:"isError,omitempty"`
 }
 
-// Content is the wire format for content.
-//
-// The Type field distinguishes the type of the content.
-// At most one of Text, MIMEType, Data, and Resource is non-zero.
-type Content struct {
-	Type     string            `json:"type"`
-	Text     string            `json:"text,omitempty"`
-	MIMEType string            `json:"mimeType,omitempty"`
-	Data     []byte            `json:"data,omitempty"`
-	Resource *ResourceContents `json:"resource,omitempty"`
+// A Content is a [TextContent], [ImageContent], [AudioContent] or
+// [EmbeddedResource].
+type Content interface {
+	// (unexported methods)
 }
 
-// NewTextContent creates a [Content] with text.
-func NewTextContent(text string) *Content
+// TextContent is a textual content.
+type TextContent struct {
+	Text string
+}
 // etc.
 ```
 

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -24,8 +24,8 @@ type HiArgs struct {
 
 func SayHi(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[HiArgs]) (*mcp.CallToolResultFor[struct{}], error) {
 	return &mcp.CallToolResultFor[struct{}]{
-		Content: []*mcp.ContentBlock{
-			mcp.NewTextContent("Hi " + params.Name),
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "Hi " + params.Name},
 		},
 	}, nil
 }
@@ -36,7 +36,7 @@ func PromptHi(ctx context.Context, ss *mcp.ServerSession, params *mcp.GetPromptP
 	return &mcp.GetPromptResult{
 		Description: "Code review prompt",
 		Messages: []*mcp.PromptMessage{
-			{Role: "user", Content: mcp.NewTextContent("Say hi to " + params.Arguments["name"])},
+			{Role: "user", Content: &mcp.TextContent{Text: "Say hi to " + params.Arguments["name"]}},
 		},
 	}, nil
 }
@@ -93,6 +93,8 @@ func handleEmbeddedResource(_ context.Context, _ *mcp.ServerSession, params *mcp
 		return nil, fmt.Errorf("no embedded resource named %q", key)
 	}
 	return &mcp.ReadResourceResult{
-		Contents: []*mcp.ResourceContents{mcp.NewTextResourceContents(params.URI, "text/plain", text)},
+		Contents: []*mcp.ResourceContents{
+			{URI: params.URI, MIMEType: "text/plain", Text: text},
+		},
 	}, nil
 }

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -21,8 +21,8 @@ type SayHiParams struct {
 
 func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[SayHiParams]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []*mcp.ContentBlock{
-			mcp.NewTextContent("Hi " + params.Name),
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "Hi " + params.Name},
 		},
 	}, nil
 }

--- a/internal/readme/client/client.go
+++ b/internal/readme/client/client.go
@@ -40,7 +40,7 @@ func main() {
 		log.Fatal("tool failed")
 	}
 	for _, c := range res.Content {
-		log.Print(c.Text)
+		log.Print(c.(*mcp.TextContent).Text)
 	}
 }
 

--- a/internal/readme/server/server.go
+++ b/internal/readme/server/server.go
@@ -18,7 +18,7 @@ type HiParams struct {
 
 func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[HiParams]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []*mcp.ContentBlock{mcp.NewTextContent("Hi " + params.Name)},
+		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + params.Name}},
 	}, nil
 }
 

--- a/mcp/cmd_test.go
+++ b/mcp/cmd_test.go
@@ -70,7 +70,9 @@ func TestCmdTransport(t *testing.T) {
 		log.Fatal(err)
 	}
 	want := &mcp.CallToolResult{
-		Content: []*mcp.ContentBlock{{Type: "text", Text: "Hi user"}},
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "Hi user"},
+		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("greet returned unexpected content (-want +got):\n%s", diff)

--- a/mcp/features_test.go
+++ b/mcp/features_test.go
@@ -20,8 +20,8 @@ type SayHiParams struct {
 
 func SayHi(ctx context.Context, cc *ServerSession, params *CallToolParamsFor[SayHiParams]) (*CallToolResultFor[any], error) {
 	return &CallToolResultFor[any]{
-		Content: []*ContentBlock{
-			NewTextContent("Hi " + params.Name),
+		Content: []Content{
+			&TextContent{Text: "Hi " + params.Name},
 		},
 	}, nil
 }

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -34,7 +34,7 @@ func sayHi(ctx context.Context, ss *ServerSession, params *CallToolParamsFor[hiP
 	if err := ss.Ping(ctx, nil); err != nil {
 		return nil, fmt.Errorf("ping failed: %v", err)
 	}
-	return &CallToolResultFor[any]{Content: []*ContentBlock{NewTextContent("hi " + params.Arguments.Name)}}, nil
+	return &CallToolResultFor[any]{Content: []Content{&TextContent{Text: "hi " + params.Arguments.Name}}}, nil
 }
 
 func TestEndToEnd(t *testing.T) {
@@ -142,7 +142,7 @@ func TestEndToEnd(t *testing.T) {
 		wantReview := &GetPromptResult{
 			Description: "Code review prompt",
 			Messages: []*PromptMessage{{
-				Content: NewTextContent("Please review the following code: 1+1"),
+				Content: &TextContent{Text: "Please review the following code: 1+1"},
 				Role:    "user",
 			}},
 		}
@@ -195,7 +195,9 @@ func TestEndToEnd(t *testing.T) {
 			t.Fatal(err)
 		}
 		wantHi := &CallToolResult{
-			Content: []*ContentBlock{{Type: "text", Text: "hi user"}},
+			Content: []Content{
+				&TextContent{Text: "hi user"},
+			},
 		}
 		if diff := cmp.Diff(wantHi, gotHi); diff != "" {
 			t.Errorf("tools/call 'greet' mismatch (-want +got):\n%s", diff)
@@ -212,7 +214,9 @@ func TestEndToEnd(t *testing.T) {
 		}
 		wantFail := &CallToolResult{
 			IsError: true,
-			Content: []*ContentBlock{{Type: "text", Text: errTestFailure.Error()}},
+			Content: []Content{
+				&TextContent{Text: errTestFailure.Error()},
+			},
 		}
 		if diff := cmp.Diff(wantFail, gotFail); diff != "" {
 			t.Errorf("tools/call 'fail' mismatch (-want +got):\n%s", diff)
@@ -451,7 +455,7 @@ var (
 				return &GetPromptResult{
 					Description: "Code review prompt",
 					Messages: []*PromptMessage{
-						{Role: "user", Content: NewTextContent("Please review the following code: " + params.Arguments["Code"])},
+						{Role: "user", Content: &TextContent{Text: "Please review the following code: " + params.Arguments["Code"]}},
 					},
 				}, nil
 			},
@@ -505,7 +509,9 @@ func handleEmbeddedResource(_ context.Context, _ *ServerSession, params *ReadRes
 		return nil, fmt.Errorf("no embedded resource named %q", key)
 	}
 	return &ReadResourceResult{
-		Contents: []*ResourceContents{NewTextResourceContents(params.URI, "text/plain", text)},
+		Contents: []*ResourceContents{
+			{URI: params.URI, MIMEType: "text/plain", Text: text},
+		},
 	}, nil
 }
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -412,7 +412,9 @@ func fileResourceHandler(dir string) ResourceHandler {
 			return nil, err
 		}
 		// TODO(jba): figure out mime type. Omit for now: Server.readResource will fill it in.
-		return &ReadResourceResult{Contents: []*ResourceContents{NewBlobResourceContents(params.URI, "", data)}}, nil
+		return &ReadResourceResult{Contents: []*ResourceContents{
+			&ResourceContents{URI: params.URI, Blob: data},
+		}}, nil
 	}
 }
 

--- a/mcp/server_example_test.go
+++ b/mcp/server_example_test.go
@@ -18,8 +18,8 @@ type SayHiParams struct {
 
 func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[SayHiParams]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []*mcp.ContentBlock{
-			mcp.NewTextContent("Hi " + params.Arguments.Name),
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "Hi " + params.Arguments.Name},
 		},
 	}, nil
 }
@@ -49,7 +49,7 @@ func ExampleServer() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(res.Content[0].Text)
+	fmt.Println(res.Content[0].(*mcp.TextContent).Text)
 
 	clientSession.Close()
 	serverSession.Wait()

--- a/mcp/sse_example_test.go
+++ b/mcp/sse_example_test.go
@@ -20,7 +20,9 @@ type AddParams struct {
 
 func Add(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[AddParams]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []*mcp.ContentBlock{mcp.NewTextContent(fmt.Sprintf("%d", params.Arguments.X+params.Arguments.Y))},
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: fmt.Sprintf("%d", params.Arguments.X+params.Arguments.Y)},
+		},
 	}, nil
 }
 
@@ -48,7 +50,7 @@ func ExampleSSEHandler() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(res.Content[0].Text)
+	fmt.Println(res.Content[0].(*mcp.TextContent).Text)
 
 	// Output: 3
 }

--- a/mcp/sse_test.go
+++ b/mcp/sse_test.go
@@ -53,7 +53,9 @@ func TestSSEServer(t *testing.T) {
 				t.Fatal(err)
 			}
 			wantHi := &CallToolResult{
-				Content: []*ContentBlock{{Type: "text", Text: "hi user"}},
+				Content: []Content{
+					&TextContent{Text: "hi user"},
+				},
 			}
 			if diff := cmp.Diff(wantHi, gotHi); diff != "" {
 				t.Errorf("tools/call 'greet' mismatch (-want +got):\n%s", diff)

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -82,7 +82,9 @@ func TestStreamableTransports(t *testing.T) {
 
 	// 5. Verify that the correct response is received.
 	want := &CallToolResult{
-		Content: []*ContentBlock{{Type: "text", Text: "hi streamy"}},
+		Content: []Content{
+			&TextContent{Text: "hi streamy"},
+		},
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("CallTool() returned unexpected content (-want +got):\n%s", diff)

--- a/mcp/testdata/conformance/server/prompts.txtar
+++ b/mcp/testdata/conformance/server/prompts.txtar
@@ -24,7 +24,6 @@ code_review
 	"jsonrpc": "2.0",
 	"id": 1,
 	"result": {
-		"_meta": {},
 		"capabilities": {
 			"completions": {},
 			"logging": {},
@@ -49,7 +48,6 @@ code_review
 	"jsonrpc": "2.0",
 	"id": 2,
 	"result": {
-		"_meta": {},
 		"tools": []
 	}
 }
@@ -57,7 +55,6 @@ code_review
 	"jsonrpc": "2.0",
 	"id": 4,
 	"result": {
-		"_meta": {},
 		"prompts": [
 			{
 				"arguments": [

--- a/mcp/testdata/conformance/server/resources.txtar
+++ b/mcp/testdata/conformance/server/resources.txtar
@@ -44,7 +44,6 @@ info.txt
 	"jsonrpc": "2.0",
 	"id": 1,
 	"result": {
-		"_meta": {},
 		"capabilities": {
 			"completions": {},
 			"logging": {},
@@ -69,7 +68,6 @@ info.txt
 	"jsonrpc": "2.0",
 	"id": 2,
 	"result": {
-		"_meta": {},
 		"resources": [
 			{
 				"mimeType": "text/plain",
@@ -88,7 +86,6 @@ info.txt
 	"jsonrpc": "2.0",
 	"id": 3,
 	"result": {
-		"_meta": {},
 		"contents": [
 			{
 				"uri": "embedded:info",
@@ -107,7 +104,6 @@ info.txt
 	"jsonrpc": "2.0",
 	"id": 3,
 	"result": {
-		"_meta": {},
 		"contents": [
 			{
 				"uri": "file:///info.txt",

--- a/mcp/testdata/conformance/server/tools.txtar
+++ b/mcp/testdata/conformance/server/tools.txtar
@@ -27,7 +27,6 @@ greet
 	"jsonrpc": "2.0",
 	"id": 1,
 	"result": {
-		"_meta": {},
 		"capabilities": {
 			"completions": {},
 			"logging": {},
@@ -52,7 +51,6 @@ greet
 	"jsonrpc": "2.0",
 	"id": 2,
 	"result": {
-		"_meta": {},
 		"tools": [
 			{
 				"description": "say hi",
@@ -79,7 +77,6 @@ greet
 	"jsonrpc": "2.0",
 	"id": 3,
 	"result": {
-		"_meta": {},
 		"resources": []
 	}
 }
@@ -87,7 +84,6 @@ greet
 	"jsonrpc": "2.0",
 	"id": 4,
 	"result": {
-		"_meta": {},
 		"prompts": []
 	}
 }

--- a/mcp/testdata/conformance/server/version-latest.txtar
+++ b/mcp/testdata/conformance/server/version-latest.txtar
@@ -17,7 +17,6 @@ response with its latest supported version.
 	"jsonrpc": "2.0",
 	"id": 1,
 	"result": {
-		"_meta": {},
 		"capabilities": {
 			"completions": {},
 			"logging": {},

--- a/mcp/testdata/conformance/server/version-older.txtar
+++ b/mcp/testdata/conformance/server/version-older.txtar
@@ -17,7 +17,6 @@ support.
 	"jsonrpc": "2.0",
 	"id": 1,
 	"result": {
-		"_meta": {},
 		"capabilities": {
 			"completions": {},
 			"logging": {},

--- a/mcp/tool.go
+++ b/mcp/tool.go
@@ -132,7 +132,7 @@ func newRawHandler(st *ServerTool) rawToolHandler {
 		// rather than returned as jsonrpc2 server errors.
 		if err != nil {
 			return &CallToolResult{
-				Content: []*ContentBlock{NewTextContent(err.Error())},
+				Content: []Content{&TextContent{Text: err.Error()}},
 				IsError: true,
 			}, nil
 		}


### PR DESCRIPTION
After some experience with the flattened version of Content, we see that
it can easily lead to incorrect usage and is a harder API to read.
Therefore, this CL changes back to a design similar to what we had prior
to https://go.dev/cl/672415, though opting to promote content
unmarshalling to the protocol types that use it, which leads to an
overall simpler api.