### PR TITLE
mcp: rename LoggingMessage to Log

### DIFF
--- a/mcp/logging.go
+++ b/mcp/logging.go
@@ -185,5 +185,5 @@ func (h *LoggingHandler) handle(ctx context.Context, r slog.Record) error {
 	// documentation says not to.
 	// In this case logging is a service to clients, not a means for debugging the
 	// server, so we want to cancel the log message.
-	return h.ss.LoggingMessage(ctx, params)
+	return h.ss.Log(ctx, params)
 }

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -370,7 +370,7 @@ func TestEndToEnd(t *testing.T) {
 
 			mustLog := func(level LoggingLevel, data any) {
 				t.Helper()
-				if err := ss.LoggingMessage(ctx, &LoggingMessageParams{
+				if err := ss.Log(ctx, &LoggingMessageParams{
 					Logger: "test",
 					Level:  level,
 					Data:   data,

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -413,7 +413,7 @@ func fileResourceHandler(dir string) ResourceHandler {
 		}
 		// TODO(jba): figure out mime type. Omit for now: Server.readResource will fill it in.
 		return &ReadResourceResult{Contents: []*ResourceContents{
-			&ResourceContents{URI: params.URI, Blob: data},
+			{URI: params.URI, Blob: data},
 		}}, nil
 	}
 }
@@ -510,12 +510,10 @@ func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessag
 	return handleSend[*CreateMessageResult](ctx, ss, methodCreateMessage, orZero[Params](params))
 }
 
-// LoggingMessage sends a logging message to the client.
+// Log sends a log message to the client.
 // The message is not sent if the client has not called SetLevel, or if its level
 // is below that of the last SetLevel.
-//
-// TODO(jba): rename to Log or LogMessage. A logging message is the thing that is sent to logging.
-func (ss *ServerSession) LoggingMessage(ctx context.Context, params *LoggingMessageParams) error {
+func (ss *ServerSession) Log(ctx context.Context, params *LoggingMessageParams) error {
 	ss.mu.Lock()
 	logLevel := ss.logLevel
 	ss.mu.Unlock()


### PR DESCRIPTION
Use a verb for this method name.