### PR TITLE
feat(ci): Add check to ensure `go fmt` has been ran

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,25 @@ on:
   
 permissions:
   contents: read
-  
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Check formatting
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "The following files are not properly formatted:"
+          echo "$unformatted"
+          exit 1
+        fi
+        echo "All Go files are properly formatted"
+  
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/mcp/client_list_test.go
+++ b/mcp/client_list_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/modelcontextprotocol/go-sdk/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestList(t *testing.T) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

I noticed that some of the files weren't formatted (`go fmt` left dirty files on `main`), so I went ahead and added a `lint` CI job. We can add more linting things later if folks want, but validating formatting seemed like a nice first step.

I pushed a separate commit with `go fmt ./...` ran alone (just to make it clear what was automated changes vs manual ones).

## How Has This Been Tested?

N/A

## Breaking Changes

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
