### PR TITLE
[WIP] Use interfaces for Tool definitions

### DIFF
--- a/mcp/cmd_test.go
+++ b/mcp/cmd_test.go
@@ -31,7 +31,7 @@ func runServer() {
 	ctx := context.Background()
 
 	server := mcp.NewServer("greeter", "v0.0.1", nil)
-	server.AddTools(mcp.NewServerTool("greet", "say hi", SayHi))
+	server.AddTools(mcp.NewServerTool[*SayHiParams, *SayHiResult]("greet", "say hi", SayHi))
 
 	if err := server.Run(ctx, mcp.NewStdioTransport()); err != nil {
 		log.Fatal(err)

--- a/mcp/sse_test.go
+++ b/mcp/sse_test.go
@@ -20,7 +20,7 @@ func TestSSEServer(t *testing.T) {
 		t.Run(fmt.Sprintf("closeServerFirst=%t", closeServerFirst), func(t *testing.T) {
 			ctx := context.Background()
 			server := NewServer("testServer", "v1.0.0", nil)
-			server.AddTools(NewServerTool("greet", "say hi", sayHi))
+			server.AddTools(NewServerTool[*hiParams, *hiResult]("greet", "say hi", sayHi))
 
 			sseHandler := NewSSEHandler(func(*http.Request) *Server { return server })
 

--- a/mcp/tool_test.go
+++ b/mcp/tool_test.go
@@ -7,6 +7,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -16,19 +17,98 @@ import (
 )
 
 // testToolHandler is used for type inference in TestNewServerTool.
-func testToolHandler[T any](context.Context, *ServerSession, *CallToolParamsFor[T]) (*CallToolResultFor[any], error) {
+func testToolHandler[T ToolInput](context.Context, *ServerSession, *CallToolParamsFor[json.RawMessage]) (T, error) {
 	panic("not implemented")
 }
 
+type Basic struct {
+	Name string `json:"name"`
+}
+
+func (b Basic) Result() (*CallToolResult, error) {
+	return &CallToolResult{
+		Content: []Content{&TextContent{Text: b.Name}},
+	}, nil
+}
+
+func (b Basic) Schema() (*jsonschema.Schema, error) {
+	return jsonschema.For[Basic]()
+}
+
+func (b Basic) SetParams(raw json.RawMessage) error {
+	return json.Unmarshal(raw, &b)
+}
+
+type EnumExample struct{ Name string }
+
+func (e EnumExample) Result() (*CallToolResult, error) {
+	return &CallToolResult{
+		Content: []Content{&TextContent{Text: e.Name}},
+	}, nil
+}
+
+func (e EnumExample) Schema() (*jsonschema.Schema, error) {
+	return jsonschema.For[EnumExample]()
+}
+
+func (e EnumExample) SetParams(raw json.RawMessage) error {
+	return json.Unmarshal(raw, &e)
+}
+
+type RequiredExample struct {
+	Name     string `json:"name"`
+	Language string `json:"language"`
+	X        int    `json:"x,omitempty"`
+	Y        int    `json:"y,omitempty"`
+}
+
+func (r RequiredExample) Result() (*CallToolResult, error) {
+	return &CallToolResult{
+		Content: []Content{
+			&TextContent{Text: r.Name},
+			&TextContent{Text: r.Language},
+		},
+	}, nil
+}
+
+func (r RequiredExample) Schema() (*jsonschema.Schema, error) {
+	return jsonschema.For[RequiredExample]()
+}
+
+func (r RequiredExample) SetParams(raw json.RawMessage) error {
+	return json.Unmarshal(raw, &r)
+}
+
+type testTool struct {
+	X int `json:"x,omitempty"`
+	Y int `json:"y,omitempty"`
+}
+
+func (t testTool) Result() (*CallToolResult, error) {
+	return &CallToolResult{
+		Content: []Content{
+			&TextContent{Text: fmt.Sprintf("X: %d", t.X)},
+			&TextContent{Text: fmt.Sprintf("Y: %d", t.Y)},
+		},
+	}, nil
+}
+
+func (t testTool) Schema() (*jsonschema.Schema, error) {
+	return jsonschema.For[testTool]()
+}
+
+func (t testTool) SetParams(raw json.RawMessage) error {
+	return json.Unmarshal(raw, &t)
+}
+
 func TestNewServerTool(t *testing.T) {
+
 	tests := []struct {
 		tool *ServerTool
 		want *jsonschema.Schema
 	}{
 		{
-			NewServerTool("basic", "", testToolHandler[struct {
-				Name string `json:"name"`
-			}]),
+			NewServerTool[Basic]("basic", "", testToolHandler[Basic]),
 			&jsonschema.Schema{
 				Type:     "object",
 				Required: []string{"name"},
@@ -39,7 +119,7 @@ func TestNewServerTool(t *testing.T) {
 			},
 		},
 		{
-			NewServerTool("enum", "", testToolHandler[struct{ Name string }], Input(
+			NewServerTool[EnumExample]("enum", "", testToolHandler[EnumExample], Input(
 				Property("Name", Enum("x", "y", "z")),
 			)),
 			&jsonschema.Schema{
@@ -52,12 +132,7 @@ func TestNewServerTool(t *testing.T) {
 			},
 		},
 		{
-			NewServerTool("required", "", testToolHandler[struct {
-				Name     string `json:"name"`
-				Language string `json:"language"`
-				X        int    `json:"x,omitempty"`
-				Y        int    `json:"y,omitempty"`
-			}], Input(
+			NewServerTool[RequiredExample]("required", "", testToolHandler[RequiredExample], Input(
 				Property("x", Required(true)))),
 			&jsonschema.Schema{
 				Type:     "object",
@@ -72,10 +147,7 @@ func TestNewServerTool(t *testing.T) {
 			},
 		},
 		{
-			NewServerTool("set_schema", "", testToolHandler[struct {
-				X int `json:"x,omitempty"`
-				Y int `json:"y,omitempty"`
-			}], Input(
+			NewServerTool[testTool]("set_schema", "", testToolHandler[testTool], Input(
 				Schema(&jsonschema.Schema{Type: "object"})),
 			),
 			&jsonschema.Schema{


### PR DESCRIPTION
## Motivation and Context

This PR is an experiment to see how using interfaces could look, so that the `in` and `out` types are in control of how their schema is generated, how their params are parsed and how their results are returned.

Related discussion and issues:
- https://github.com/modelcontextprotocol/go-sdk/discussions/37
- https://github.com/modelcontextprotocol/go-sdk/issues/20

The primary change is to update `NewServerTool` and `ToolHandlerFor` to work with interfaces rather than pure generics:

```golang
// A ToolInput is a tool definition defining the input of a tool.
type ToolInput interface {
	// Schema returns the JSON schema for the tool's input.
	Schema() (*jsonschema.Schema, error)
	// SetParams sets the parameters for the tool's input from raw JSON.
	SetParams(json.RawMessage) error
}

// A ToolOutput is an interface defining the output of a tool.
type ToolOutput interface {
	// Schema returns the JSON schema for the tool's output.
	// Schema() (*jsonschema.Schema, error) // TODO implement output schema in future
	// Result returns the result of the tool's execution.
	Result() (*CallToolResult, error)
}

```

**Note: this change is not fully fleshed out yet, as of opening this PR it is the minimum change to get everything building, and doesn't finish fleshing out all the ideas that become possible with this change, nor does it fully sell the benefits.**

## How Has This Been Tested?

All test cases have been updated

## Breaking Changes

Yes, this is an extremely breaking change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
