### PR TITLE
internal/readme: fix server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ type HiParams struct {
 
 func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[HiParams]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + params.Name}},
+		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + params.Arguments.Name}},
 	}, nil
 }
 

--- a/internal/readme/server/server.go
+++ b/internal/readme/server/server.go
@@ -18,7 +18,7 @@ type HiParams struct {
 
 func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[HiParams]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + params.Name}},
+		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + params.Arguments.Name}},
 	}, nil
 }
 


### PR DESCRIPTION
Fix an example using params.Name instead of params.Arguments.Name. All credit due to @A11Might for noticing this. Sending a separate PR to keep the internal/readme source consistent.