### PR TITLE
Fix typos

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -863,7 +863,7 @@ type ServerOptions struct {
 }
 ```
 
-#### Securty Considerations
+#### Security Considerations
 
 Implementors of the CompletionHandler MUST adhere to the following security guidelines:
 
@@ -952,7 +952,7 @@ In addition to the `List` methods, the SDK provides an iterator method for each 
 
 # Governance and Community
 
-While the sections above propose an initial implementation of the Go SDK, MCP is evolving rapidly. SDKs need to keep pace, by implementing changes to the spec, fixing bugs, and accomodating new and emerging use-cases. This section proposes how the SDK project can be managed so that it can change safely and transparently.
+While the sections above propose an initial implementation of the Go SDK, MCP is evolving rapidly. SDKs need to keep pace, by implementing changes to the spec, fixing bugs, and accommodating new and emerging use-cases. This section proposes how the SDK project can be managed so that it can change safely and transparently.
 
 Initially, the Go SDK repository will be administered by the Go team and Anthropic, and they will be the Approvers (the set of people able to merge PRs to the SDK). The policies here are also intended to satisfy necessary constraints of the Go team's participation in the project.
 
@@ -980,7 +980,7 @@ A proposal is an issue that proposes a new API for the SDK, or a change to the s
 
 Proposals that are straightforward and uncontroversial may be approved based on GitHub discussion. However, proposals that are deemed to be sufficiently unclear or complicated will be deferred to a regular steering meeting (see below).
 
-This process is similar to the [Go proposal process](https://github.com/golang/proposal), but is necessarily lighter weight to accomodate the greater rate of change expected for the SDK.
+This process is similar to the [Go proposal process](https://github.com/golang/proposal), but is necessarily lighter weight to accommodate the greater rate of change expected for the SDK.
 
 ### Steering meetings
 

--- a/mcp/logging.go
+++ b/mcp/logging.go
@@ -137,7 +137,7 @@ func (h *LoggingHandler) WithGroup(name string) slog.Handler {
 }
 
 // Handle implements [slog.Handler.Handle] by writing the Record to a JSONHandler,
-// then calling [ServerSession.LoggingMesssage] with the result.
+// then calling [ServerSession.LoggingMessage] with the result.
 func (h *LoggingHandler) Handle(ctx context.Context, r slog.Record) error {
 	err := h.handle(ctx, r)
 	// TODO(jba): find a way to surface the error.

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -254,7 +254,7 @@ func (s *StreamableServerTransport) Connect(context.Context) (Connection, error)
 //
 // Currently, this is implemented in [ServerSession.handle]. This is not ideal,
 // because it means that a user of the MCP package couldn't implement the
-// streamable transport, as they'd lack this priviledged access.
+// streamable transport, as they'd lack this privileged access.
 //
 // If we ever wanted to expose this mechanism, we have a few options:
 //  1. Make ServerSession an interface, and provide an implementation of


### PR DESCRIPTION
This pull request addresses multiple minor documentation and code comment fixes to correct typos and improve clarity. These changes do not introduce functional modifications but enhance readability and professionalism.

### Documentation Fixes:

* Corrected a typo in the "Security Considerations" section header in `design/design.md`. ("Securty" → "Security")
* Fixed spelling errors in the "Governance and Community" section of `design/design.md`. ("accomodating" → "accommodating")
* Updated the "Proposals" section in `design/design.md` to fix a typo. ("accomodate" → "accommodate")

### Code Comment Fixes:

* Corrected a typo in a comment in `mcp/logging.go`. ("LoggingMesssage" → "LoggingMessage")
* Fixed a typo in a comment in `mcp/streamable.go`. ("priviledged" → "privileged")

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This PR is for fixing some typos in the repo

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
by code diff

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
