### PR TITLE
mcp: add Session.ID

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -142,6 +142,18 @@ type ClientSession struct {
 	client           *Client
 	initializeResult *InitializeResult
 	keepaliveCancel  context.CancelFunc
+	sessionIDFunc    func() string
+}
+
+func (cs *ClientSession) setSessionIDFunc(f func() string) {
+	cs.sessionIDFunc = f
+}
+
+func (cs *ClientSession) ID() string {
+	if cs.sessionIDFunc == nil {
+		return ""
+	}
+	return cs.sessionIDFunc()
 }
 
 // Close performs a graceful close of the connection, preventing new requests

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -142,18 +142,18 @@ type ClientSession struct {
 	client           *Client
 	initializeResult *InitializeResult
 	keepaliveCancel  context.CancelFunc
-	sessionIDFunc    func() string
+	mcpConn          Connection
 }
 
-func (cs *ClientSession) setSessionIDFunc(f func() string) {
-	cs.sessionIDFunc = f
+func (cs *ClientSession) setConn(c Connection) {
+	cs.mcpConn = c
 }
 
 func (cs *ClientSession) ID() string {
-	if cs.sessionIDFunc == nil {
+	if cs.mcpConn == nil {
 		return ""
 	}
-	return cs.sessionIDFunc()
+	return cs.mcpConn.SessionID()
 }
 
 // Close performs a graceful close of the connection, preventing new requests

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -496,7 +496,7 @@ func (ss *ServerSession) NotifyProgress(ctx context.Context, params *ProgressNot
 type ServerSession struct {
 	server           *Server
 	conn             *jsonrpc2.Connection
-	sessionIDFunc    func() string
+	mcpConn          Connection
 	mu               sync.Mutex
 	logLevel         LoggingLevel
 	initializeParams *InitializeParams
@@ -504,15 +504,15 @@ type ServerSession struct {
 	keepaliveCancel  context.CancelFunc
 }
 
-func (ss *ServerSession) setSessionIDFunc(f func() string) {
-	ss.sessionIDFunc = f
+func (ss *ServerSession) setConn(c Connection) {
+	ss.mcpConn = c
 }
 
 func (ss *ServerSession) ID() string {
-	if ss.sessionIDFunc == nil {
+	if ss.mcpConn == nil {
 		return ""
 	}
-	return ss.sessionIDFunc()
+	return ss.mcpConn.SessionID()
 }
 
 // Ping pings the client.

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -496,11 +496,23 @@ func (ss *ServerSession) NotifyProgress(ctx context.Context, params *ProgressNot
 type ServerSession struct {
 	server           *Server
 	conn             *jsonrpc2.Connection
+	sessionIDFunc    func() string
 	mu               sync.Mutex
 	logLevel         LoggingLevel
 	initializeParams *InitializeParams
 	initialized      bool
 	keepaliveCancel  context.CancelFunc
+}
+
+func (ss *ServerSession) setSessionIDFunc(f func() string) {
+	ss.sessionIDFunc = f
+}
+
+func (ss *ServerSession) ID() string {
+	if ss.sessionIDFunc == nil {
+		return ""
+	}
+	return ss.sessionIDFunc()
 }
 
 // Ping pings the client.

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -36,6 +36,9 @@ type methodHandler any // MethodHandler[*ClientSession] | MethodHandler[*ServerS
 // A Session is either a ClientSession or a ServerSession.
 type Session interface {
 	*ClientSession | *ServerSession
+	// ID returns the session ID, or the empty string if there is none.
+	ID() string
+
 	sendingMethodInfos() map[string]methodInfo
 	receivingMethodInfos() map[string]methodInfo
 	sendingMethodHandler() methodHandler

--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -263,6 +263,9 @@ type sseServerConn struct {
 	t *SSEServerTransport
 }
 
+// TODO(jba): get the session ID. (Not urgent because SSE transports have been removed from the spec.)
+func (s sseServerConn) sessionID() string { return "" }
+
 // Read implements jsonrpc2.Reader.
 func (s sseServerConn) Read(ctx context.Context) (JSONRPCMessage, error) {
 	select {
@@ -517,6 +520,9 @@ type sseClientConn struct {
 	closed bool          // set when the stream is closed
 	done   chan struct{} // closed when the stream is closed
 }
+
+// TODO(jba): get the session ID. (Not urgent because SSE transports have been removed from the spec.)
+func (c *sseClientConn) sessionID() string { return "" }
 
 func (c *sseClientConn) isDone() bool {
 	c.mu.Lock()

--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -264,7 +264,7 @@ type sseServerConn struct {
 }
 
 // TODO(jba): get the session ID. (Not urgent because SSE transports have been removed from the spec.)
-func (s sseServerConn) sessionID() string { return "" }
+func (s sseServerConn) SessionID() string { return "" }
 
 // Read implements jsonrpc2.Reader.
 func (s sseServerConn) Read(ctx context.Context) (JSONRPCMessage, error) {
@@ -522,7 +522,7 @@ type sseClientConn struct {
 }
 
 // TODO(jba): get the session ID. (Not urgent because SSE transports have been removed from the spec.)
-func (c *sseClientConn) sessionID() string { return "" }
+func (c *sseClientConn) SessionID() string { return "" }
 
 func (c *sseClientConn) isDone() bool {
 	c.mu.Lock()

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -161,6 +161,10 @@ func NewStreamableServerTransport(sessionID string) *StreamableServerTransport {
 	}
 }
 
+func (t *StreamableServerTransport) sessionID() string {
+	return t.id
+}
+
 // A StreamableServerTransport implements the [Transport] interface for a
 // single session.
 type StreamableServerTransport struct {
@@ -331,7 +335,7 @@ func (t *StreamableServerTransport) servePOST(w http.ResponseWriter, req *http.R
 		http.Error(w, fmt.Sprintf("malformed payload: %v", err), http.StatusBadRequest)
 		return
 	}
-	var requests = make(map[JSONRPCID]struct{})
+	requests := make(map[JSONRPCID]struct{})
 	for _, msg := range incoming {
 		if req, ok := msg.(*JSONRPCRequest); ok && req.ID.IsValid() {
 			requests[req.ID] = struct{}{}
@@ -624,18 +628,24 @@ func (t *StreamableClientTransport) Connect(ctx context.Context) (Connection, er
 }
 
 type streamableClientConn struct {
-	url       string
-	sessionID string
-	client    *http.Client
-	incoming  chan []byte
-	done      chan struct{}
+	url      string
+	client   *http.Client
+	incoming chan []byte
+	done     chan struct{}
 
 	closeOnce sync.Once
 	closeErr  error
 
-	mu sync.Mutex
+	mu         sync.Mutex
+	_sessionID string
 	// bodies map[*http.Response]io.Closer
 	err error
+}
+
+func (c *streamableClientConn) sessionID() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c._sessionID
 }
 
 // Read implements the [Connection] interface.
@@ -658,7 +668,7 @@ func (s *streamableClientConn) Write(ctx context.Context, msg JSONRPCMessage) er
 		return s.err
 	}
 
-	sessionID := s.sessionID
+	sessionID := s._sessionID
 	if sessionID == "" {
 		// Hold lock for the first request.
 		defer s.mu.Unlock()
@@ -681,7 +691,7 @@ func (s *streamableClientConn) Write(ctx context.Context, msg JSONRPCMessage) er
 
 	if sessionID == "" {
 		// locked
-		s.sessionID = gotSessionID
+		s._sessionID = gotSessionID
 	}
 
 	return nil
@@ -753,7 +763,7 @@ func (s *streamableClientConn) Close() error {
 		if err != nil {
 			s.closeErr = err
 		} else {
-			req.Header.Set("Mcp-Session-Id", s.sessionID)
+			req.Header.Set("Mcp-Session-Id", s._sessionID)
 			if _, err := s.client.Do(req); err != nil {
 				s.closeErr = err
 			}

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -161,7 +161,7 @@ func NewStreamableServerTransport(sessionID string) *StreamableServerTransport {
 	}
 }
 
-func (t *StreamableServerTransport) sessionID() string {
+func (t *StreamableServerTransport) SessionID() string {
 	return t.id
 }
 
@@ -642,7 +642,7 @@ type streamableClientConn struct {
 	err error
 }
 
-func (c *streamableClientConn) sessionID() string {
+func (c *streamableClientConn) SessionID() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c._sessionID

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -69,7 +69,10 @@ func TestStreamableTransports(t *testing.T) {
 		t.Fatalf("client.Connect() failed: %v", err)
 	}
 	defer session.Close()
-
+	sid := session.ID()
+	if sid == "" {
+		t.Error("empty session ID")
+	}
 	// 4. The client calls the "greet" tool.
 	params := &CallToolParams{
 		Name:      "greet",
@@ -78,6 +81,9 @@ func TestStreamableTransports(t *testing.T) {
 	got, err := session.CallTool(ctx, params)
 	if err != nil {
 		t.Fatalf("CallTool() failed: %v", err)
+	}
+	if g := session.ID(); g != sid {
+		t.Errorf("session ID: got %q, want %q", g, sid)
 	}
 
 	// 5. Verify that the correct response is received.


### PR DESCRIPTION
Support retrieving the session ID from client and server sessions.

For #65.
