### PR TITLE
mcp: new API for features

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ import (
 )
 
 type HiParams struct {
-	Name string `json:"name"`
+	Name string `json:"name", mcp:"the name of the person to greet"`
 }
 
 func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[HiParams]) (*mcp.CallToolResultFor[any], error) {
@@ -111,11 +111,8 @@ func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParam
 func main() {
 	// Create a server with a single tool.
 	server := mcp.NewServer("greeter", "v1.0.0", nil)
-	server.AddTools(
-		mcp.NewServerTool("greet", "say hi", SayHi, mcp.Input(
-			mcp.Property("name", mcp.Description("the name of the person to greet")),
-		)),
-	)
+
+	mcp.AddTool(server, &mcp.Tool{Name: "greet", Description: "say hi"}, SayHi)
 	// Run the server over stdin/stdout, until the client disconnects
 	if err := server.Run(context.Background(), mcp.NewStdioTransport()); err != nil {
 		log.Fatal(err)

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -35,12 +35,12 @@ func main() {
 	}
 
 	server1 := mcp.NewServer("greeter1", "v0.0.1", nil)
-	server1.AddTools(mcp.NewServerTool("greet1", "say hi", SayHi))
+	mcp.AddTool(server1, &mcp.Tool{Name: "greet1", Description: "say hi"}, SayHi)
 
 	server2 := mcp.NewServer("greeter2", "v0.0.1", nil)
-	server2.AddTools(mcp.NewServerTool("greet2", "say hello", SayHi))
+	mcp.AddTool(server2, &mcp.Tool{Name: "greet2", Description: "say hello"}, SayHi)
 
-	log.Printf("MCP servers serving at %s\n", *httpAddr)
+	log.Printf("MCP servers serving at %s", *httpAddr)
 	handler := mcp.NewSSEHandler(func(request *http.Request) *mcp.Server {
 		url := request.URL.Path
 		log.Printf("Handling request for URL %s\n", url)

--- a/internal/readme/server/server.go
+++ b/internal/readme/server/server.go
@@ -13,7 +13,7 @@ import (
 )
 
 type HiParams struct {
-	Name string `json:"name"`
+	Name string `json:"name", mcp:"the name of the person to greet"`
 }
 
 func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[HiParams]) (*mcp.CallToolResultFor[any], error) {
@@ -25,11 +25,8 @@ func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParam
 func main() {
 	// Create a server with a single tool.
 	server := mcp.NewServer("greeter", "v1.0.0", nil)
-	server.AddTools(
-		mcp.NewServerTool("greet", "say hi", SayHi, mcp.Input(
-			mcp.Property("name", mcp.Description("the name of the person to greet")),
-		)),
-	)
+
+	mcp.AddTool(server, &mcp.Tool{Name: "greet", Description: "say hi"}, SayHi)
 	// Run the server over stdin/stdout, until the client disconnects
 	if err := server.Run(context.Background(), mcp.NewStdioTransport()); err != nil {
 		log.Fatal(err)

--- a/mcp/client_list_test.go
+++ b/mcp/client_list_test.go
@@ -24,10 +24,8 @@ func TestList(t *testing.T) {
 	t.Run("tools", func(t *testing.T) {
 		var wantTools []*mcp.Tool
 		for _, name := range []string{"apple", "banana", "cherry"} {
-			wantTools = append(wantTools, &mcp.Tool{Name: name, Description: name + " tool"})
-		}
-
-		for _, t := range wantTools {
+			t := &mcp.Tool{Name: name, Description: name + " tool"}
+			wantTools = append(wantTools, t)
 			mcp.AddTool(server, t, SayHi)
 		}
 		t.Run("list", func(t *testing.T) {
@@ -45,12 +43,13 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("resources", func(t *testing.T) {
-		resourceA := &mcp.ServerResource{Resource: &mcp.Resource{URI: "http://apple"}}
-		resourceB := &mcp.ServerResource{Resource: &mcp.Resource{URI: "http://banana"}}
-		resourceC := &mcp.ServerResource{Resource: &mcp.Resource{URI: "http://cherry"}}
-		wantResources := []*mcp.Resource{resourceA.Resource, resourceB.Resource, resourceC.Resource}
-		resources := []*mcp.ServerResource{resourceA, resourceB, resourceC}
-		server.AddResources(resources...)
+		var wantResources []*mcp.Resource
+		for _, name := range []string{"apple", "banana", "cherry"} {
+			r := &mcp.Resource{URI: "http://" + name}
+			wantResources = append(wantResources, r)
+			server.AddResource(r, nil)
+		}
+
 		t.Run("list", func(t *testing.T) {
 			res, err := clientSession.ListResources(ctx, nil)
 			if err != nil {
@@ -66,15 +65,12 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("templates", func(t *testing.T) {
-		resourceTmplA := &mcp.ServerResourceTemplate{ResourceTemplate: &mcp.ResourceTemplate{URITemplate: "http://apple/{x}"}}
-		resourceTmplB := &mcp.ServerResourceTemplate{ResourceTemplate: &mcp.ResourceTemplate{URITemplate: "http://banana/{x}"}}
-		resourceTmplC := &mcp.ServerResourceTemplate{ResourceTemplate: &mcp.ResourceTemplate{URITemplate: "http://cherry/{x}"}}
-		wantResourceTemplates := []*mcp.ResourceTemplate{
-			resourceTmplA.ResourceTemplate, resourceTmplB.ResourceTemplate,
-			resourceTmplC.ResourceTemplate,
+		var wantResourceTemplates []*mcp.ResourceTemplate
+		for _, name := range []string{"apple", "banana", "cherry"} {
+			rt := &mcp.ResourceTemplate{URITemplate: "http://" + name + "/{x}"}
+			wantResourceTemplates = append(wantResourceTemplates, rt)
+			server.AddResourceTemplate(rt, nil)
 		}
-		resourceTemplates := []*mcp.ServerResourceTemplate{resourceTmplA, resourceTmplB, resourceTmplC}
-		server.AddResourceTemplates(resourceTemplates...)
 		t.Run("list", func(t *testing.T) {
 			res, err := clientSession.ListResourceTemplates(ctx, nil)
 			if err != nil {
@@ -90,12 +86,12 @@ func TestList(t *testing.T) {
 	})
 
 	t.Run("prompts", func(t *testing.T) {
-		promptA := newServerPrompt("apple", "apple prompt")
-		promptB := newServerPrompt("banana", "banana prompt")
-		promptC := newServerPrompt("cherry", "cherry prompt")
-		wantPrompts := []*mcp.Prompt{promptA.Prompt, promptB.Prompt, promptC.Prompt}
-		prompts := []*mcp.ServerPrompt{promptA, promptB, promptC}
-		server.AddPrompts(prompts...)
+		var wantPrompts []*mcp.Prompt
+		for _, name := range []string{"apple", "banana", "cherry"} {
+			p := &mcp.Prompt{Name: name, Description: name + " prompt"}
+			wantPrompts = append(wantPrompts, p)
+			server.AddPrompt(p, testPromptHandler)
+		}
 		t.Run("list", func(t *testing.T) {
 			res, err := clientSession.ListPrompts(ctx, nil)
 			if err != nil {
@@ -125,14 +121,6 @@ func testIterator[T any](ctx context.Context, t *testing.T, seq iter.Seq2[*T, er
 	}
 }
 
-// testPromptHandler is used for type inference newServerPrompt.
 func testPromptHandler(context.Context, *mcp.ServerSession, *mcp.GetPromptParams) (*mcp.GetPromptResult, error) {
 	panic("not implemented")
-}
-
-func newServerPrompt(name, desc string) *mcp.ServerPrompt {
-	return &mcp.ServerPrompt{
-		Prompt:  &mcp.Prompt{Name: name, Description: desc},
-		Handler: testPromptHandler,
-	}
 }

--- a/mcp/client_list_test.go
+++ b/mcp/client_list_test.go
@@ -22,12 +22,14 @@ func TestList(t *testing.T) {
 	defer serverSession.Close()
 
 	t.Run("tools", func(t *testing.T) {
-		toolA := mcp.NewServerTool("apple", "apple tool", SayHi)
-		toolB := mcp.NewServerTool("banana", "banana tool", SayHi)
-		toolC := mcp.NewServerTool("cherry", "cherry tool", SayHi)
-		tools := []*mcp.ServerTool{toolA, toolB, toolC}
-		wantTools := []*mcp.Tool{toolA.Tool, toolB.Tool, toolC.Tool}
-		server.AddTools(tools...)
+		var wantTools []*mcp.Tool
+		for _, name := range []string{"apple", "banana", "cherry"} {
+			wantTools = append(wantTools, &mcp.Tool{Name: name, Description: name + " tool"})
+		}
+
+		for _, t := range wantTools {
+			mcp.AddTool(server, t, SayHi)
+		}
 		t.Run("list", func(t *testing.T) {
 			res, err := clientSession.ListTools(ctx, nil)
 			if err != nil {

--- a/mcp/cmd_test.go
+++ b/mcp/cmd_test.go
@@ -31,8 +31,7 @@ func runServer() {
 	ctx := context.Background()
 
 	server := mcp.NewServer("greeter", "v0.0.1", nil)
-	server.AddTools(mcp.NewServerTool("greet", "say hi", SayHi))
-
+	mcp.AddTool(server, &mcp.Tool{Name: "greet", Description: "say hi"}, SayHi)
 	if err := server.Run(ctx, mcp.NewStdioTransport()); err != nil {
 		log.Fatal(err)
 	}

--- a/mcp/features_test.go
+++ b/mcp/features_test.go
@@ -27,9 +27,9 @@ func SayHi(ctx context.Context, cc *ServerSession, params *CallToolParamsFor[Say
 }
 
 func TestFeatureSetOrder(t *testing.T) {
-	toolA := NewServerTool("apple", "apple tool", SayHi).Tool
-	toolB := NewServerTool("banana", "banana tool", SayHi).Tool
-	toolC := NewServerTool("cherry", "cherry tool", SayHi).Tool
+	toolA := &Tool{Name: "apple", Description: "apple tool"}
+	toolB := &Tool{Name: "banana", Description: "banana tool"}
+	toolC := &Tool{Name: "cherry", Description: "cherry tool"}
 
 	testCases := []struct {
 		tools []*Tool
@@ -52,9 +52,9 @@ func TestFeatureSetOrder(t *testing.T) {
 }
 
 func TestFeatureSetAbove(t *testing.T) {
-	toolA := NewServerTool("apple", "apple tool", SayHi).Tool
-	toolB := NewServerTool("banana", "banana tool", SayHi).Tool
-	toolC := NewServerTool("cherry", "cherry tool", SayHi).Tool
+	toolA := &Tool{Name: "apple", Description: "apple tool"}
+	toolB := &Tool{Name: "banana", Description: "banana tool"}
+	toolC := &Tool{Name: "cherry", Description: "cherry tool"}
 
 	testCases := []struct {
 		tools []*Tool

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
@@ -29,6 +28,9 @@ import (
 type hiParams struct {
 	Name string
 }
+
+// TODO(jba): after schemas are stateless (WIP), this can be a variable.
+func greetTool() *Tool { return &Tool{Name: "greet", Description: "say hi"} }
 
 func sayHi(ctx context.Context, ss *ServerSession, params *CallToolParamsFor[hiParams]) (*CallToolResultFor[any], error) {
 	if err := ss.Ping(ctx, nil); err != nil {
@@ -63,7 +65,14 @@ func TestEndToEnd(t *testing.T) {
 		},
 	}
 	s := NewServer("testServer", "v1.0.0", sopts)
-	add(tools, s.AddTools, "greet", "fail")
+	AddTool(s, &Tool{
+		Name:        "greet",
+		Description: "say hi",
+	}, sayHi)
+	s.AddTool(&Tool{Name: "fail", InputSchema: &jsonschema.Schema{}},
+		func(context.Context, *ServerSession, *CallToolParamsFor[map[string]any]) (*CallToolResult, error) {
+			return nil, errTestFailure
+		})
 	add(prompts, s.AddPrompts, "code_review", "fail")
 	add(resources, s.AddResources, "info.txt", "fail.txt")
 
@@ -161,32 +170,7 @@ func TestEndToEnd(t *testing.T) {
 	})
 
 	t.Run("tools", func(t *testing.T) {
-		res, err := cs.ListTools(ctx, nil)
-		if err != nil {
-			t.Errorf("tools/list failed: %v", err)
-		}
-		wantTools := []*Tool{
-			{
-				Name:        "fail",
-				InputSchema: nil,
-			},
-			{
-				Name:        "greet",
-				Description: "say hi",
-				InputSchema: &jsonschema.Schema{
-					Type:     "object",
-					Required: []string{"Name"},
-					Properties: map[string]*jsonschema.Schema{
-						"Name": {Type: "string"},
-					},
-					AdditionalProperties: falseSchema(),
-				},
-			},
-		}
-		if diff := cmp.Diff(wantTools, res.Tools, cmpopts.IgnoreUnexported(jsonschema.Schema{})); diff != "" {
-			t.Fatalf("tools/list mismatch (-want +got):\n%s", diff)
-		}
-
+		// ListTools is tested in client_list_test.go.
 		gotHi, err := cs.CallTool(ctx, &CallToolParams{
 			Name:      "greet",
 			Arguments: map[string]any{"name": "user"},
@@ -222,7 +206,7 @@ func TestEndToEnd(t *testing.T) {
 			t.Errorf("tools/call 'fail' mismatch (-want +got):\n%s", diff)
 		}
 
-		s.AddTools(&ServerTool{Tool: &Tool{Name: "T"}, Handler: nopHandler})
+		s.AddTool(&Tool{Name: "T", InputSchema: &jsonschema.Schema{}}, nopHandler)
 		waitForNotification(t, "tools")
 		s.RemoveTools("T")
 		waitForNotification(t, "tools")
@@ -434,16 +418,6 @@ func TestEndToEnd(t *testing.T) {
 var (
 	errTestFailure = errors.New("mcp failure")
 
-	tools = map[string]*ServerTool{
-		"greet": NewServerTool("greet", "say hi", sayHi),
-		"fail": {
-			Tool: &Tool{Name: "fail"},
-			Handler: func(context.Context, *ServerSession, *CallToolParamsFor[map[string]any]) (*CallToolResult, error) {
-				return nil, errTestFailure
-			},
-		},
-	}
-
 	prompts = map[string]*ServerPrompt{
 		"code_review": {
 			Prompt: &Prompt{
@@ -540,21 +514,21 @@ func errorCode(err error) int64 {
 	return -1
 }
 
-// basicConnection returns a new basic client-server connection configured with
-// the provided tools.
+// basicConnection returns a new basic client-server connection, with the server
+// configured via the provided function.
 //
 // The caller should cancel either the client connection or server connection
 // when the connections are no longer needed.
-func basicConnection(t *testing.T, tools ...*ServerTool) (*ServerSession, *ClientSession) {
+func basicConnection(t *testing.T, config func(*Server)) (*ServerSession, *ClientSession) {
 	t.Helper()
 
 	ctx := context.Background()
 	ct, st := NewInMemoryTransports()
 
 	s := NewServer("testServer", "v1.0.0", nil)
-
-	// The 'greet' tool says hi.
-	s.AddTools(tools...)
+	if config != nil {
+		config(s)
+	}
 	ss, err := s.Connect(ctx, st)
 	if err != nil {
 		t.Fatal(err)
@@ -569,7 +543,9 @@ func basicConnection(t *testing.T, tools ...*ServerTool) (*ServerSession, *Clien
 }
 
 func TestServerClosing(t *testing.T) {
-	cc, cs := basicConnection(t, NewServerTool("greet", "say hi", sayHi))
+	cc, cs := basicConnection(t, func(s *Server) {
+		AddTool(s, greetTool(), sayHi)
+	})
 	defer cs.Close()
 
 	ctx := context.Background()
@@ -651,11 +627,9 @@ func TestCancellation(t *testing.T) {
 		}
 		return nil, nil
 	}
-	st := &ServerTool{
-		Tool:    &Tool{Name: "slow"},
-		Handler: slowRequest,
-	}
-	_, cs := basicConnection(t, st)
+	_, cs := basicConnection(t, func(s *Server) {
+		s.AddTool(&Tool{Name: "slow"}, slowRequest)
+	})
 	defer cs.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -852,7 +826,7 @@ func TestKeepAlive(t *testing.T) {
 		KeepAlive: 100 * time.Millisecond,
 	}
 	s := NewServer("testServer", "v1.0.0", serverOpts)
-	s.AddTools(NewServerTool("greet", "say hi", sayHi))
+	AddTool(s, greetTool(), sayHi)
 
 	ss, err := s.Connect(ctx, st)
 	if err != nil {
@@ -897,7 +871,7 @@ func TestKeepAliveFailure(t *testing.T) {
 
 	// Server without keepalive (to test one-sided keepalive)
 	s := NewServer("testServer", "v1.0.0", nil)
-	s.AddTools(NewServerTool("greet", "say hi", sayHi))
+	AddTool(s, greetTool(), sayHi)
 	ss, err := s.Connect(ctx, st)
 	if err != nil {
 		t.Fatal(err)

--- a/mcp/prompt.go
+++ b/mcp/prompt.go
@@ -11,8 +11,7 @@ import (
 // A PromptHandler handles a call to prompts/get.
 type PromptHandler func(context.Context, *ServerSession, *GetPromptParams) (*GetPromptResult, error)
 
-// A Prompt is a prompt definition bound to a prompt handler.
-type ServerPrompt struct {
-	Prompt  *Prompt
-	Handler PromptHandler
+type serverPrompt struct {
+	prompt  *Prompt
+	handler PromptHandler
 }

--- a/mcp/resource.go
+++ b/mcp/resource.go
@@ -20,16 +20,16 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/internal/util"
 )
 
-// A ServerResource associates a Resource with its handler.
-type ServerResource struct {
-	Resource *Resource
-	Handler  ResourceHandler
+// A serverResource associates a Resource with its handler.
+type serverResource struct {
+	resource *Resource
+	handler  ResourceHandler
 }
 
-// A ServerResourceTemplate associates a ResourceTemplate with its handler.
-type ServerResourceTemplate struct {
-	ResourceTemplate *ResourceTemplate
-	Handler          ResourceHandler
+// A serverResourceTemplate associates a ResourceTemplate with its handler.
+type serverResourceTemplate struct {
+	resourceTemplate *ResourceTemplate
+	handler          ResourceHandler
 }
 
 // A ResourceHandler is a function that reads a resource.
@@ -156,8 +156,8 @@ func fileRoot(root *Root) (_ string, err error) {
 
 // Matches reports whether the receiver's uri template matches the uri.
 // TODO: use "github.com/yosida95/uritemplate/v3"
-func (sr *ServerResourceTemplate) Matches(uri string) bool {
-	re, err := uriTemplateToRegexp(sr.ResourceTemplate.URITemplate)
+func (sr *serverResourceTemplate) Matches(uri string) bool {
+	re, err := uriTemplateToRegexp(sr.resourceTemplate.URITemplate)
 	if err != nil {
 		return false
 	}

--- a/mcp/server_example_test.go
+++ b/mcp/server_example_test.go
@@ -29,7 +29,7 @@ func ExampleServer() {
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
 
 	server := mcp.NewServer("greeter", "v0.0.1", nil)
-	server.AddTools(mcp.NewServerTool("greet", "say hi", SayHi))
+	mcp.AddTool(server, &mcp.Tool{Name: "greet", Description: "say hi"}, SayHi)
 
 	serverSession, err := server.Connect(ctx, serverTransport)
 	if err != nil {

--- a/mcp/shared_test.go
+++ b/mcp/shared_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TODO(jba): this shouldn't be in this file, but tool_test.go doesn't have access to unexported symbols.
-func TestNewServerToolValidate(t *testing.T) {
+func TestToolValidate(t *testing.T) {
 	// Check that the tool returned from NewServerTool properly validates its input schema.
 
 	type req struct {
@@ -26,9 +26,10 @@ func TestNewServerToolValidate(t *testing.T) {
 		return nil, nil
 	}
 
-	tool := NewServerTool("test", "test", dummyHandler)
-	// Need to add the tool to a server to get resolved schemas.
-	// s := NewServer("", "", nil)
+	st, err := newServerTool(&Tool{Name: "test", Description: "test"}, dummyHandler)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, tt := range []struct {
 		desc string
@@ -71,7 +72,7 @@ func TestNewServerToolValidate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = tool.rawHandler(context.Background(), nil,
+			_, err = st.handler(context.Background(), nil,
 				&CallToolParamsFor[json.RawMessage]{Arguments: json.RawMessage(raw)})
 			if err == nil && tt.want != "" {
 				t.Error("got success, wanted failure")

--- a/mcp/sse_example_test.go
+++ b/mcp/sse_example_test.go
@@ -28,7 +28,7 @@ func Add(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsF
 
 func ExampleSSEHandler() {
 	server := mcp.NewServer("adder", "v0.0.1", nil)
-	server.AddTools(mcp.NewServerTool("add", "add two numbers", Add))
+	mcp.AddTool(server, &mcp.Tool{Name: "add", Description: "add two numbers"}, Add)
 
 	handler := mcp.NewSSEHandler(func(*http.Request) *mcp.Server { return server })
 	httpServer := httptest.NewServer(handler)

--- a/mcp/sse_test.go
+++ b/mcp/sse_test.go
@@ -20,7 +20,7 @@ func TestSSEServer(t *testing.T) {
 		t.Run(fmt.Sprintf("closeServerFirst=%t", closeServerFirst), func(t *testing.T) {
 			ctx := context.Background()
 			server := NewServer("testServer", "v1.0.0", nil)
-			server.AddTools(NewServerTool("greet", "say hi", sayHi))
+			AddTool(server, &Tool{Name: "greet"}, sayHi)
 
 			sseHandler := NewSSEHandler(func(*http.Request) *Server { return server })
 

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -32,8 +32,7 @@ func TestStreamableTransports(t *testing.T) {
 
 	// 1. Create a server with a simple "greet" tool.
 	server := NewServer("testServer", "v1.0.0", nil)
-	server.AddTools(NewServerTool("greet", "say hi", sayHi))
-
+	AddTool(server, &Tool{Name: "greet", Description: "say hi"}, sayHi)
 	// 2. Start an httptest.Server with the StreamableHTTPHandler, wrapped in a
 	// cookie-checking middleware.
 	handler := NewStreamableHTTPHandler(func(req *http.Request) *Server { return server }, nil)
@@ -323,13 +322,12 @@ func TestStreamableServerTransport(t *testing.T) {
 			// Create a server containing a single tool, which runs the test tool
 			// behavior, if any.
 			server := NewServer("testServer", "v1.0.0", nil)
-			tool := NewServerTool("tool", "test tool", func(ctx context.Context, ss *ServerSession, params *CallToolParamsFor[any]) (*CallToolResultFor[any], error) {
+			AddTool(server, &Tool{Name: "tool"}, func(ctx context.Context, ss *ServerSession, params *CallToolParamsFor[any]) (*CallToolResultFor[any], error) {
 				if test.tool != nil {
 					test.tool(t, ctx, ss)
 				}
 				return &CallToolResultFor[any]{}, nil
 			})
-			server.AddTools(tool)
 
 			// Start the streamable handler.
 			handler := NewStreamableHTTPHandler(func(req *http.Request) *Server { return server }, nil)

--- a/mcp/tool.go
+++ b/mcp/tool.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"slices"
+	"reflect"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
@@ -17,8 +17,7 @@ import (
 // A ToolHandler handles a call to tools/call.
 // [CallToolParams.Arguments] will contain a map[string]any that has been validated
 // against the input schema.
-// TODO: Perhaps this should be an alias for ToolHandlerFor[map[string]any, map[string]any]?
-type ToolHandler func(context.Context, *ServerSession, *CallToolParamsFor[map[string]any]) (*CallToolResult, error)
+type ToolHandler = ToolHandlerFor[map[string]any, any]
 
 // A ToolHandlerFor handles a call to tools/call with typed arguments and results.
 type ToolHandlerFor[In, Out any] func(context.Context, *ServerSession, *CallToolParamsFor[In]) (*CallToolResultFor[Out], error)
@@ -26,62 +25,33 @@ type ToolHandlerFor[In, Out any] func(context.Context, *ServerSession, *CallTool
 // A rawToolHandler is like a ToolHandler, but takes the arguments as as json.RawMessage.
 type rawToolHandler = func(context.Context, *ServerSession, *CallToolParamsFor[json.RawMessage]) (*CallToolResult, error)
 
-// A ServerTool is a tool definition that is bound to a tool handler.
-type ServerTool struct {
-	Tool    *Tool
-	Handler ToolHandler
-	// Set in NewServerTool or Server.addToolsErr.
-	rawHandler rawToolHandler
-	// Resolved tool schemas. Set in Server.addToolsErr.
+// A serverTool is a tool definition that is bound to a tool handler.
+type serverTool struct {
+	tool    *Tool
+	handler rawToolHandler
+	// Resolved tool schemas. Set in newServerTool.
 	inputResolved, outputResolved *jsonschema.Resolved
 }
 
-// NewServerTool is a helper to make a tool using reflection on the given type parameters.
-// When the tool is called, CallToolParams.Arguments will be of type In.
-//
-// If provided, variadic [ToolOption] values may be used to customize the tool.
-//
-// The input schema for the tool is extracted from the request type for the
-// handler, and used to unmmarshal and validate requests to the handler. This
-// schema may be customized using the [Input] option.
-//
-// TODO(jba): check that structured content is set in response.
-func NewServerTool[In, Out any](name, description string, handler ToolHandlerFor[In, Out], opts ...ToolOption) *ServerTool {
-	st, err := newServerToolErr[In, Out](name, description, handler, opts...)
-	if err != nil {
-		panic(fmt.Errorf("NewServerTool(%q): %w", name, err))
-	}
-	return st
-}
+// newServerTool creates a serverTool from a tool and a handler.
+// If the tool doesn't have an input schema, it is inferred from In.
+// If the tool doesn't have an output schema and Out != any, it is inferred from Out.
+func newServerTool[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*serverTool, error) {
+	st := &serverTool{tool: t}
 
-func newServerToolErr[In, Out any](name, description string, handler ToolHandlerFor[In, Out], opts ...ToolOption) (*ServerTool, error) {
-	// TODO: check that In is a struct.
-	ischema, err := jsonschema.For[In]()
-	if err != nil {
+	if err := setSchema[In](&t.InputSchema, &st.inputResolved); err != nil {
 		return nil, err
 	}
-	// TODO: uncomment when output schemas drop.
-	// oschema, err := jsonschema.For[TRes]()
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	t := &ServerTool{
-		Tool: &Tool{
-			Name:        name,
-			Description: description,
-			InputSchema: ischema,
-			// OutputSchema: oschema,
-		},
-	}
-	for _, opt := range opts {
-		opt.set(t)
+	if reflect.TypeFor[Out]() != reflect.TypeFor[any]() {
+		if err := setSchema[Out](&t.OutputSchema, &st.outputResolved); err != nil {
+			return nil, err
+		}
 	}
 
-	t.rawHandler = func(ctx context.Context, ss *ServerSession, rparams *CallToolParamsFor[json.RawMessage]) (*CallToolResult, error) {
+	st.handler = func(ctx context.Context, ss *ServerSession, rparams *CallToolParamsFor[json.RawMessage]) (*CallToolResult, error) {
 		var args In
 		if rparams.Arguments != nil {
-			if err := unmarshalSchema(rparams.Arguments, t.inputResolved, &args); err != nil {
+			if err := unmarshalSchema(rparams.Arguments, st.inputResolved, &args); err != nil {
 				return nil, err
 			}
 		}
@@ -91,45 +61,7 @@ func newServerToolErr[In, Out any](name, description string, handler ToolHandler
 			Name:      rparams.Name,
 			Arguments: args,
 		}
-		res, err := handler(ctx, ss, params)
-		if err != nil {
-			return nil, err
-		}
-
-		var ctr CallToolResult
-		if res != nil {
-			// TODO(jba): future-proof this copy.
-			ctr.Meta = res.Meta
-			ctr.Content = res.Content
-			ctr.IsError = res.IsError
-		}
-		return &ctr, nil
-	}
-	return t, nil
-}
-
-// newRawHandler creates a rawToolHandler for tools not created through NewServerTool.
-// It unmarshals the arguments into a map[string]any and validates them against the
-// schema, then calls the ServerTool's handler.
-func newRawHandler(st *ServerTool) rawToolHandler {
-	if st.Handler == nil {
-		panic("st.Handler is nil")
-	}
-	return func(ctx context.Context, ss *ServerSession, rparams *CallToolParamsFor[json.RawMessage]) (*CallToolResult, error) {
-		// Unmarshal the args into what should be a map.
-		var args map[string]any
-		if rparams.Arguments != nil {
-			if err := unmarshalSchema(rparams.Arguments, st.inputResolved, &args); err != nil {
-				return nil, err
-			}
-		}
-		// TODO: generate copy
-		params := &CallToolParamsFor[map[string]any]{
-			Meta:      rparams.Meta,
-			Name:      rparams.Name,
-			Arguments: args,
-		}
-		res, err := st.Handler(ctx, ss, params)
+		res, err := h(ctx, ss, params)
 		// TODO(rfindley): investigate why server errors are embedded in this strange way,
 		// rather than returned as jsonrpc2 server errors.
 		if err != nil {
@@ -138,9 +70,67 @@ func newRawHandler(st *ServerTool) rawToolHandler {
 				IsError: true,
 			}, nil
 		}
-		return res, nil
+		var ctr CallToolResult
+		// TODO(jba): What if res == nil? Is that valid?
+		// TODO(jba): if t.OutputSchema != nil, check that StructuredContent is present and validates.
+		if res != nil {
+			// TODO(jba): future-proof this copy.
+			ctr.Meta = res.Meta
+			ctr.Content = res.Content
+			ctr.IsError = res.IsError
+			ctr.StructuredContent = res.StructuredContent
+		}
+		return &ctr, nil
 	}
+
+	return st, nil
 }
+
+func setSchema[T any](sfield **jsonschema.Schema, rfield **jsonschema.Resolved) error {
+	var err error
+	if *sfield == nil {
+		*sfield, err = jsonschema.For[T]()
+	}
+	if err != nil {
+		return err
+	}
+	*rfield, err = (*sfield).Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
+	return err
+}
+
+// newRawHandler creates a rawToolHandler for tools not created through NewServerTool.
+// It unmarshals the arguments into a map[string]any and validates them against the
+// schema, then calls the ServerTool's handler.
+// func newRawHandler(st *ServerTool) rawToolHandler {
+// 	if st.Handler == nil {
+// 		panic("st.Handler is nil")
+// 	}
+// 	return func(ctx context.Context, ss *ServerSession, rparams *CallToolParamsFor[json.RawMessage]) (*CallToolResult, error) {
+// 		// Unmarshal the args into what should be a map.
+// 		var args map[string]any
+// 		if rparams.Arguments != nil {
+// 			if err := unmarshalSchema(rparams.Arguments, st.inputResolved, &args); err != nil {
+// 				return nil, err
+// 			}
+// 		}
+// 		// TODO: generate copy
+// 		params := &CallToolParamsFor[map[string]any]{
+// 			Meta:      rparams.Meta,
+// 			Name:      rparams.Name,
+// 			Arguments: args,
+// 		}
+// 		res, err := st.Handler(ctx, ss, params)
+// 		// TODO(rfindley): investigate why server errors are embedded in this strange way,
+// 		// rather than returned as jsonrpc2 server errors.
+// 		if err != nil {
+// 			return &CallToolResult{
+// 				Content: []Content{&TextContent{Text: err.Error()}},
+// 				IsError: true,
+// 			}, nil
+// 		}
+// 		return res, nil
+// 	}
+// }
 
 // unmarshalSchema unmarshals data into v and validates the result according to
 // the given resolved schema.
@@ -167,105 +157,6 @@ func unmarshalSchema(data json.RawMessage, resolved *jsonschema.Resolved, v any)
 		}
 	}
 	return nil
-}
-
-// A ToolOption configures the behavior of a Tool.
-type ToolOption interface {
-	set(*ServerTool)
-}
-
-type toolSetter func(*ServerTool)
-
-func (s toolSetter) set(t *ServerTool) { s(t) }
-
-// Input applies the provided [SchemaOption] configuration to the tool's input
-// schema.
-func Input(opts ...SchemaOption) ToolOption {
-	return toolSetter(func(t *ServerTool) {
-		for _, opt := range opts {
-			opt.set(t.Tool.InputSchema)
-		}
-	})
-}
-
-// A SchemaOption configures a jsonschema.Schema.
-type SchemaOption interface {
-	set(s *jsonschema.Schema)
-}
-
-type schemaSetter func(*jsonschema.Schema)
-
-func (s schemaSetter) set(schema *jsonschema.Schema) { s(schema) }
-
-// Property configures the schema for the property of the given name.
-// If there is no such property in the schema, it is created.
-func Property(name string, opts ...SchemaOption) SchemaOption {
-	return schemaSetter(func(schema *jsonschema.Schema) {
-		propSchema, ok := schema.Properties[name]
-		if !ok {
-			propSchema = new(jsonschema.Schema)
-			schema.Properties[name] = propSchema
-		}
-		// Apply the options, with special handling for Required, as it needs to be
-		// set on the parent schema.
-		for _, opt := range opts {
-			if req, ok := opt.(required); ok {
-				if req {
-					if !slices.Contains(schema.Required, name) {
-						schema.Required = append(schema.Required, name)
-					}
-				} else {
-					schema.Required = slices.DeleteFunc(schema.Required, func(s string) bool {
-						return s == name
-					})
-				}
-			} else {
-				opt.set(propSchema)
-			}
-		}
-	})
-}
-
-// Required sets whether the associated property is required. It is only valid
-// when used in a [Property] option: using Required outside of Property panics.
-func Required(v bool) SchemaOption {
-	return required(v)
-}
-
-// required must be a distinguished type as it needs special handling to mutate
-// the parent schema, and to mutate prompt arguments.
-type required bool
-
-func (required) set(s *jsonschema.Schema) {
-	panic("use of required outside of Property")
-}
-
-// Enum sets the provided values as the "enum" value of the schema.
-func Enum(values ...any) SchemaOption {
-	return schemaSetter(func(s *jsonschema.Schema) {
-		s.Enum = values
-	})
-}
-
-// Description sets the provided schema description.
-func Description(desc string) SchemaOption {
-	return description(desc)
-}
-
-// description must be a distinguished type so that it can be handled by prompt
-// options.
-type description string
-
-func (d description) set(s *jsonschema.Schema) {
-	s.Description = string(d)
-}
-
-// Schema overrides the inferred schema with a shallow copy of the given
-// schema.
-func Schema(schema *jsonschema.Schema) SchemaOption {
-	return schemaSetter(func(s *jsonschema.Schema) {
-		*s = *schema
-	})
 }
 
 // schemaJSON returns the JSON value for s as a string, or a string indicating an error.


### PR DESCRIPTION
BREAKING CHANGE

Change the API for adding tools, prompts, resources and resource templates to a server.

The ServerXXX types are gone along with the plural Add methods (AddTools, AddPrompts etc.)
Instead there are single Add methods (AddTool, AddPrompt).
In addition, instead of NewServerTool, there is AddTool[In, Out].
