### PR TITLE
mcp: render blank text field in TextContent instead of omitempty

### DIFF
--- a/mcp/content.go
+++ b/mcp/content.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+// TODO(findleyr): update JSON marshalling of all content types to preserve required fields.
+// (See [TextContent.MarshalJSON], which handles this for text content).
+
 package mcp
 
 import (
@@ -25,12 +28,19 @@ type TextContent struct {
 }
 
 func (c *TextContent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&wireContent{
+	// Custom wire format to ensure the required "text" field is always included, even when empty.
+	wire := struct {
+		Type        string       `json:"type"`
+		Text        string       `json:"text"`
+		Meta        Meta         `json:"_meta,omitempty"`
+		Annotations *Annotations `json:"annotations,omitempty"`
+	}{
 		Type:        "text",
 		Text:        c.Text,
 		Meta:        c.Meta,
 		Annotations: c.Annotations,
-	})
+	}
+	return json.Marshal(wire)
 }
 
 func (c *TextContent) fromWire(wire *wireContent) {

--- a/mcp/content_test.go
+++ b/mcp/content_test.go
@@ -23,6 +23,14 @@ func TestContent(t *testing.T) {
 			`{"type":"text","text":"hello"}`,
 		},
 		{
+			&mcp.TextContent{Text: ""},
+			`{"type":"text","text":""}`,
+		},
+		{
+			&mcp.TextContent{},
+			`{"type":"text","text":""}`,
+		},
+		{
 			&mcp.TextContent{
 				Text:        "hello",
 				Meta:        mcp.Meta{"key": "value"},


### PR DESCRIPTION
The text field is required, but current implementation omits the text field when it is a blank string.

Some clients fail to parse the response if the text field is omitted. A blank text result is a valid MCP response.

Claude desktop error message:
```
ClaudeAiToolResultRequest.content.0.text.text: Field required
```

The solution is to return the field even when it is blank by removing `omitempty`.