### PR TITLE
mcp: advertise a capability if and only if added

### DIFF
--- a/mcp/features.go
+++ b/mcp/features.go
@@ -66,6 +66,9 @@ func (s *featureSet[T]) get(uid string) (T, bool) {
 	return t, ok
 }
 
+// len returns the number of features in the set.
+func (s *featureSet[T]) len() int { return len(s.features) }
+
 // all returns an iterator over of all the features in the set
 // sorted by unique ID.
 func (s *featureSet[T]) all() iter.Seq[T] {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -435,6 +435,11 @@ func fileResourceHandler(dir string) ResourceHandler {
 // Run runs the server over the given transport, which must be persistent.
 //
 // Run blocks until the client terminates the connection.
+//
+// If tools have been added to the server before this call, then the server will
+// advertise the capability for tools, including the ability to send list-changed notifications.
+// If no tools have been added, the server will not have the tool capability.
+// The same goes for other features like prompts and resources.
 func (s *Server) Run(ctx context.Context, t Transport) error {
 	ss, err := s.Connect(ctx, t)
 	if err != nil {
@@ -670,24 +675,31 @@ func (ss *ServerSession) initialize(ctx context.Context, params *InitializeParam
 		version = v
 	}
 
+	caps := &serverCapabilities{
+		Completions: &completionCapabilities{},
+		Logging:     &loggingCapabilities{},
+	}
+	ss.server.mu.Lock()
+	hasTools := ss.server.tools.len() > 0
+	hasPrompts := ss.server.prompts.len() > 0
+	hasResources := ss.server.resources.len() > 0
+	ss.server.mu.Unlock()
+	if hasTools {
+		caps.Tools = &toolCapabilities{ListChanged: true}
+	}
+	if hasPrompts {
+		caps.Prompts = &promptCapabilities{ListChanged: true}
+	}
+	if hasResources {
+		caps.Resources = &resourceCapabilities{ListChanged: true}
+	}
+
 	return &InitializeResult{
 		// TODO(rfindley): alter behavior when falling back to an older version:
 		// reject unsupported features.
 		ProtocolVersion: version,
-		Capabilities: &serverCapabilities{
-			Completions: &completionCapabilities{},
-			Prompts: &promptCapabilities{
-				ListChanged: true,
-			},
-			Tools: &toolCapabilities{
-				ListChanged: true,
-			},
-			Resources: &resourceCapabilities{
-				ListChanged: true,
-			},
-			Logging: &loggingCapabilities{},
-		},
-		Instructions: ss.server.opts.Instructions,
+		Capabilities:    caps,
+		Instructions:    ss.server.opts.Instructions,
 		ServerInfo: &implementation{
 			Name:    ss.server.name,
 			Version: ss.server.version,

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -151,8 +151,6 @@ func TestStreamableServerTransport(t *testing.T) {
 		Capabilities: &serverCapabilities{
 			Completions: &completionCapabilities{},
 			Logging:     &loggingCapabilities{},
-			Prompts:     &promptCapabilities{ListChanged: true},
-			Resources:   &resourceCapabilities{ListChanged: true},
 			Tools:       &toolCapabilities{ListChanged: true},
 		},
 		ProtocolVersion: "2025-03-26",


### PR DESCRIPTION
If tools are added to a Server when Run is called, it will send toolCapabilities to the client. Otherwise it won't. Ditto for prompts and resources.

For #56.
