### PR TITLE
mcp: ensure meta is not skipped on blob ResourceContents

### DIFF
--- a/mcp/content.go
+++ b/mcp/content.go
@@ -177,10 +177,12 @@ func (r ResourceContents) MarshalJSON() ([]byte, error) {
 		URI      string `json:"uri,omitempty"`
 		MIMEType string `json:"mimeType,omitempty"`
 		Blob     []byte `json:"blob"`
+		Meta     Meta   `json:"_meta,omitempty"`
 	}{
 		URI:      r.URI,
 		MIMEType: r.MIMEType,
 		Blob:     r.Blob,
+		Meta:     r.Meta,
 	}
 	return json.Marshal(br)
 }

--- a/mcp/content_test.go
+++ b/mcp/content_test.go
@@ -146,6 +146,10 @@ func TestEmbeddedResource(t *testing.T) {
 			&mcp.ResourceContents{URI: "u", Blob: []byte{1}},
 			`{"uri":"u","blob":"AQ=="}`,
 		},
+		{
+			&mcp.ResourceContents{URI: "u", MIMEType: "m", Blob: []byte{1}, Meta: mcp.Meta{"key": "value"}},
+			`{"uri":"u","mimeType":"m","blob":"AQ==","_meta":{"key":"value"}}`,
+		},
 	} {
 		data, err := json.Marshal(tt.rc)
 		if err != nil {


### PR DESCRIPTION
I noticed this while working on #95. Seems Meta was accidentally skipped in the custom wire format struct.