### PR TITLE
jsonrpc: package with JSON-RPC symbols

### DIFF
--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -1,0 +1,20 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// Package jsonrpc exposes part of a JSON-RPC v2 implementation
+// for use by mcp transport authors.
+package jsonrpc
+
+import "github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
+
+type (
+	// ID is a JSON-RPC request ID.
+	ID = jsonrpc2.ID
+	// Message is a JSON-RPC message.
+	Message = jsonrpc2.Message
+	// Request is a JSON-RPC request.
+	Request = jsonrpc2.Request
+	// Response is a JSON-RPC response.
+	Response = jsonrpc2.Response
+)

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
 // A Client is an MCP client, which may be connected to an MCP server
@@ -301,7 +302,7 @@ func (cs *ClientSession) receivingMethodInfos() map[string]methodInfo {
 	return clientMethodInfos
 }
 
-func (cs *ClientSession) handle(ctx context.Context, req *JSONRPCRequest) (any, error) {
+func (cs *ClientSession) handle(ctx context.Context, req *jsonrpc.Request) (any, error) {
 	return handleReceive(ctx, cs, req)
 }
 

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/internal/util"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
 const DefaultPageSize = 1000
@@ -610,7 +611,7 @@ func (ss *ServerSession) receivingMethodHandler() methodHandler {
 func (ss *ServerSession) getConn() *jsonrpc2.Connection { return ss.conn }
 
 // handle invokes the method described by the given JSON RPC request.
-func (ss *ServerSession) handle(ctx context.Context, req *JSONRPCRequest) (any, error) {
+func (ss *ServerSession) handle(ctx context.Context, req *jsonrpc.Request) (any, error) {
 	ss.mu.Lock()
 	initialized := ss.initialized
 	ss.mu.Unlock()

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
 // latestProtocolVersion is the latest protocol version that this version of the SDK supports.
@@ -121,7 +122,7 @@ func defaultReceivingMethodHandler[S Session](ctx context.Context, session S, me
 	return info.handleMethod.(MethodHandler[S])(ctx, session, method, params)
 }
 
-func handleReceive[S Session](ctx context.Context, session S, req *JSONRPCRequest) (Result, error) {
+func handleReceive[S Session](ctx context.Context, session S, req *jsonrpc.Request) (Result, error) {
 	info, ok := session.receivingMethodInfos()[req.Method]
 	if !ok {
 		return nil, jsonrpc2.ErrNotHandled

--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
 // This file implements support for SSE (HTTP with server-sent events)
@@ -111,7 +112,7 @@ func NewSSEHandler(getServer func(request *http.Request) *Server) *SSEHandler {
 //   - Close terminates the hanging GET.
 type SSEServerTransport struct {
 	endpoint string
-	incoming chan JSONRPCMessage // queue of incoming messages; never closed
+	incoming chan jsonrpc.Message // queue of incoming messages; never closed
 
 	// We must guard both pushes to the incoming queue and writes to the response
 	// writer, because incoming POST requests are arbitrarily concurrent and we
@@ -138,7 +139,7 @@ func NewSSEServerTransport(endpoint string, w http.ResponseWriter) *SSEServerTra
 	return &SSEServerTransport{
 		endpoint: endpoint,
 		w:        w,
-		incoming: make(chan JSONRPCMessage, 100),
+		incoming: make(chan jsonrpc.Message, 100),
 		done:     make(chan struct{}),
 	}
 }
@@ -267,7 +268,7 @@ type sseServerConn struct {
 func (s sseServerConn) SessionID() string { return "" }
 
 // Read implements jsonrpc2.Reader.
-func (s sseServerConn) Read(ctx context.Context) (JSONRPCMessage, error) {
+func (s sseServerConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -279,7 +280,7 @@ func (s sseServerConn) Read(ctx context.Context) (JSONRPCMessage, error) {
 }
 
 // Write implements jsonrpc2.Writer.
-func (s sseServerConn) Write(ctx context.Context, msg JSONRPCMessage) error {
+func (s sseServerConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -532,7 +533,7 @@ func (c *sseClientConn) isDone() bool {
 	return c.closed
 }
 
-func (c *sseClientConn) Read(ctx context.Context) (JSONRPCMessage, error) {
+func (c *sseClientConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -553,7 +554,7 @@ func (c *sseClientConn) Read(ctx context.Context) (JSONRPCMessage, error) {
 	}
 }
 
-func (c *sseClientConn) Write(ctx context.Context, msg JSONRPCMessage) error {
+func (c *sseClientConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	data, err := jsonrpc2.EncodeMessage(msg)
 	if err != nil {
 		return err

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
 func TestStreamableTransports(t *testing.T) {
@@ -126,16 +127,16 @@ func TestStreamableServerTransport(t *testing.T) {
 		// Redundant with OnRequest: all OnRequest steps are asynchronous.
 		Async bool
 
-		Method     string           // HTTP request method
-		Send       []JSONRPCMessage // messages to send
-		CloseAfter int              // if nonzero, close after receiving this many messages
-		StatusCode int              // expected status code
-		Recv       []JSONRPCMessage // expected messages to receive
+		Method     string            // HTTP request method
+		Send       []jsonrpc.Message // messages to send
+		CloseAfter int               // if nonzero, close after receiving this many messages
+		StatusCode int               // expected status code
+		Recv       []jsonrpc.Message // expected messages to receive
 	}
 
 	// JSON-RPC message constructors.
-	req := func(id int64, method string, params any) *JSONRPCRequest {
-		r := &JSONRPCRequest{
+	req := func(id int64, method string, params any) *jsonrpc.Request {
+		r := &jsonrpc.Request{
 			Method: method,
 			Params: mustMarshal(t, params),
 		}
@@ -144,8 +145,8 @@ func TestStreamableServerTransport(t *testing.T) {
 		}
 		return r
 	}
-	resp := func(id int64, result any, err error) *JSONRPCResponse {
-		return &JSONRPCResponse{
+	resp := func(id int64, result any, err error) *jsonrpc.Response {
+		return &jsonrpc.Response{
 			ID:     jsonrpc2.Int64ID(id),
 			Result: mustMarshal(t, result),
 			Error:  err,
@@ -168,13 +169,13 @@ func TestStreamableServerTransport(t *testing.T) {
 	initializedMsg := req(0, "initialized", &InitializedParams{})
 	initialize := step{
 		Method:     "POST",
-		Send:       []JSONRPCMessage{initReq},
+		Send:       []jsonrpc.Message{initReq},
 		StatusCode: http.StatusOK,
-		Recv:       []JSONRPCMessage{initResp},
+		Recv:       []jsonrpc.Message{initResp},
 	}
 	initialized := step{
 		Method:     "POST",
-		Send:       []JSONRPCMessage{initializedMsg},
+		Send:       []jsonrpc.Message{initializedMsg},
 		StatusCode: http.StatusAccepted,
 	}
 
@@ -190,9 +191,9 @@ func TestStreamableServerTransport(t *testing.T) {
 				initialized,
 				{
 					Method:     "POST",
-					Send:       []JSONRPCMessage{req(2, "tools/call", &CallToolParams{Name: "tool"})},
+					Send:       []jsonrpc.Message{req(2, "tools/call", &CallToolParams{Name: "tool"})},
 					StatusCode: http.StatusOK,
-					Recv:       []JSONRPCMessage{resp(2, &CallToolResult{}, nil)},
+					Recv:       []jsonrpc.Message{resp(2, &CallToolResult{}, nil)},
 				},
 			},
 		},
@@ -209,11 +210,11 @@ func TestStreamableServerTransport(t *testing.T) {
 				initialized,
 				{
 					Method: "POST",
-					Send: []JSONRPCMessage{
+					Send: []jsonrpc.Message{
 						req(2, "tools/call", &CallToolParams{Name: "tool"}),
 					},
 					StatusCode: http.StatusOK,
-					Recv: []JSONRPCMessage{
+					Recv: []jsonrpc.Message{
 						req(0, "notifications/progress", &ProgressNotificationParams{}),
 						resp(2, &CallToolResult{}, nil),
 					},
@@ -234,18 +235,18 @@ func TestStreamableServerTransport(t *testing.T) {
 				{
 					Method:    "POST",
 					OnRequest: 1,
-					Send: []JSONRPCMessage{
+					Send: []jsonrpc.Message{
 						resp(1, &ListRootsResult{}, nil),
 					},
 					StatusCode: http.StatusAccepted,
 				},
 				{
 					Method: "POST",
-					Send: []JSONRPCMessage{
+					Send: []jsonrpc.Message{
 						req(2, "tools/call", &CallToolParams{Name: "tool"}),
 					},
 					StatusCode: http.StatusOK,
-					Recv: []JSONRPCMessage{
+					Recv: []jsonrpc.Message{
 						req(1, "roots/list", &ListRootsParams{}),
 						resp(2, &CallToolResult{}, nil),
 					},
@@ -275,7 +276,7 @@ func TestStreamableServerTransport(t *testing.T) {
 				{
 					Method:    "POST",
 					OnRequest: 1,
-					Send: []JSONRPCMessage{
+					Send: []jsonrpc.Message{
 						resp(1, &ListRootsResult{}, nil),
 					},
 					StatusCode: http.StatusAccepted,
@@ -285,18 +286,18 @@ func TestStreamableServerTransport(t *testing.T) {
 					Async:      true,
 					StatusCode: http.StatusOK,
 					CloseAfter: 2,
-					Recv: []JSONRPCMessage{
+					Recv: []jsonrpc.Message{
 						req(0, "notifications/progress", &ProgressNotificationParams{}),
 						req(1, "roots/list", &ListRootsParams{}),
 					},
 				},
 				{
 					Method: "POST",
-					Send: []JSONRPCMessage{
+					Send: []jsonrpc.Message{
 						req(2, "tools/call", &CallToolParams{Name: "tool"}),
 					},
 					StatusCode: http.StatusOK,
-					Recv: []JSONRPCMessage{
+					Recv: []jsonrpc.Message{
 						resp(2, &CallToolResult{}, nil),
 					},
 				},
@@ -315,9 +316,9 @@ func TestStreamableServerTransport(t *testing.T) {
 				},
 				{
 					Method:     "POST",
-					Send:       []JSONRPCMessage{req(2, "tools/call", &CallToolParams{Name: "tool"})},
+					Send:       []jsonrpc.Message{req(2, "tools/call", &CallToolParams{Name: "tool"})},
 					StatusCode: http.StatusOK,
-					Recv: []JSONRPCMessage{resp(2, nil, &jsonrpc2.WireError{
+					Recv: []jsonrpc.Message{resp(2, nil, &jsonrpc2.WireError{
 						Message: `method "tools/call" is invalid during session initialization`,
 					})},
 				},
@@ -344,7 +345,7 @@ func TestStreamableServerTransport(t *testing.T) {
 			httpServer := httptest.NewServer(handler)
 			defer httpServer.Close()
 
-			// blocks records request blocks by JSONRPC ID.
+			// blocks records request blocks by jsonrpc. ID.
 			//
 			// When an OnRequest step is encountered, it waits on the corresponding
 			// block. When a request with that ID is received, the block is closed.
@@ -382,8 +383,8 @@ func TestStreamableServerTransport(t *testing.T) {
 
 				// Collect messages received during this request, unblock other steps
 				// when requests are received.
-				var got []JSONRPCMessage
-				out := make(chan JSONRPCMessage)
+				var got []jsonrpc.Message
+				out := make(chan jsonrpc.Message)
 				// Cancel the step if we encounter a request that isn't going to be
 				// handled.
 				ctx, cancel := context.WithCancel(context.Background())
@@ -394,7 +395,7 @@ func TestStreamableServerTransport(t *testing.T) {
 					defer wg.Done()
 
 					for m := range out {
-						if req, ok := m.(*JSONRPCRequest); ok && req.ID.IsValid() {
+						if req, ok := m.(*jsonrpc.Request); ok && req.ID.IsValid() {
 							// Encountered a server->client request. We should have a
 							// response queued. Otherwise, we may deadlock.
 							mu.Lock()
@@ -427,7 +428,7 @@ func TestStreamableServerTransport(t *testing.T) {
 				}
 				wg.Wait()
 
-				transform := cmpopts.AcyclicTransformer("jsonrpcid", func(id JSONRPCID) any { return id.Raw() })
+				transform := cmpopts.AcyclicTransformer("jsonrpcid", func(id jsonrpc.ID) any { return id.Raw() })
 				if diff := cmp.Diff(step.Recv, got, transform); diff != "" {
 					t.Errorf("received unexpected messages (-want +got):\n%s", diff)
 				}
@@ -469,7 +470,7 @@ func TestStreamableServerTransport(t *testing.T) {
 // Returns the sessionID and http status code from the response. If an error is
 // returned, sessionID and status code may still be set if the error occurs
 // after the response headers have been received.
-func streamingRequest(ctx context.Context, serverURL, sessionID, method string, in []JSONRPCMessage, out chan<- JSONRPCMessage) (string, int, error) {
+func streamingRequest(ctx context.Context, serverURL, sessionID, method string, in []jsonrpc.Message, out chan<- jsonrpc.Message) (string, int, error) {
 	defer close(out)
 
 	var body []byte

--- a/mcp/transport_test.go
+++ b/mcp/transport_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
 func TestBatchFraming(t *testing.T) {
@@ -22,10 +23,10 @@ func TestBatchFraming(t *testing.T) {
 
 	r, w := io.Pipe()
 	tport := newIOConn(rwc{r, w})
-	tport.outgoingBatch = make([]JSONRPCMessage, 0, 2)
+	tport.outgoingBatch = make([]jsonrpc.Message, 0, 2)
 
 	// Read the two messages into a channel, for easy testing later.
-	read := make(chan JSONRPCMessage)
+	read := make(chan jsonrpc.Message)
 	go func() {
 		for range 2 {
 			msg, _ := tport.Read(ctx)
@@ -34,7 +35,7 @@ func TestBatchFraming(t *testing.T) {
 	}()
 
 	// The first write should not yet be observed by the reader.
-	tport.Write(ctx, &JSONRPCRequest{ID: jsonrpc2.Int64ID(1), Method: "test"})
+	tport.Write(ctx, &jsonrpc.Request{ID: jsonrpc2.Int64ID(1), Method: "test"})
 	select {
 	case got := <-read:
 		t.Fatalf("after one write, got message %v", got)
@@ -42,10 +43,10 @@ func TestBatchFraming(t *testing.T) {
 	}
 
 	// ...but the second write causes both messages to be observed.
-	tport.Write(ctx, &JSONRPCRequest{ID: jsonrpc2.Int64ID(2), Method: "test"})
+	tport.Write(ctx, &jsonrpc.Request{ID: jsonrpc2.Int64ID(2), Method: "test"})
 	for _, want := range []int64{1, 2} {
 		got := <-read
-		if got := got.(*JSONRPCRequest).ID.Raw(); got != want {
+		if got := got.(*jsonrpc.Request).ID.Raw(); got != want {
 			t.Errorf("got message #%d, want #%d", got, want)
 		}
 	}


### PR DESCRIPTION
Move the aliases to the internal/jsonrpc2 package into their own package.

Fixes #115.
