### PR TITLE
jsonschema: improve doc

### DIFF
--- a/jsonschema/LICENSE
+++ b/jsonschema/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Go MCP SDK Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jsonschema/README.md
+++ b/jsonschema/README.md
@@ -1,0 +1,39 @@
+TODO: this file should live at the root of the jsonschema-go module,
+above the jsonschema package.
+
+# JSON Schema for GO
+
+This module implements the [JSON Schema](https://json-schema.org/) specification.
+The `jsonschema` package supports creating schemas, validating JSON values
+against a schema, and inferring a schema from a Go struct. See the package
+documentation for usage.
+
+## Contributing
+
+This module welcomes external contributions.
+It has no dependencies outside of the standard library, and can be built with
+the standard Go toolchain. Run `go test ./...` at the module root to run all
+the tests.
+
+## Issues
+
+This project uses the [GitHub issue
+tracker](https://github.com/TODO/jsonschema-go/issues) for bug reports, feature requests, and other issues. 
+
+Please [report
+bugs](https://github.com/TODO/jsonschema-go/issues/new). If the SDK is
+not working as you expected, it is likely due to a bug or inadequate
+documentation, and reporting an issue will help us address this shortcoming.
+
+When reporting a bug, make sure to answer these five questions:
+
+1. What did you do?
+2. What did you see?
+3. What did you expect to see?
+4. What version of the Go MCP SDK are you using?
+5. What version of Go are you using (`go version`)?
+
+## License
+
+This project is licensed under the MIT license. See the LICENSE file for details.
+

--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -34,12 +34,13 @@ import (
 // types, as they are incompatible with the JSON schema spec.
 //   - maps with key other than 'string'
 //   - function types
+//   - channel types
 //   - complex numbers
 //   - unsafe pointers
 //
 // It will return an error if there is a cycle in the types.
 //
-// For recognizes struct field tags named "jsonschema".
+// This function recognizes struct field tags named "jsonschema".
 // A jsonschema tag on a field is used as the description for the corresponding property.
 // For future compatibility, descriptions must not start with "WORD=", where WORD is a
 // sequence of non-whitespace characters.


### PR DESCRIPTION
Improve the package documentation.

Add a README and LICENSE, anticipating the relocation of this package to its own module elsewhere.