### PR TITLE
Fix jsonrpc path and url

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The SDK consists of three importable packages:
   package provides an implementation of [JSON
   Schema](https://json-schema.org/), used for MCP tool input and output schema.
 - The
-  [`github.com/modelcontextprotocol/jsonrpc`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/jsonschema) package is for users implementing
+  [`github.com/modelcontextprotocol/go-sdk/jsonrpc`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/jsonrpc) package is for users implementing
   their own transports.
    
 


### PR DESCRIPTION
jsonrpc's github path notation and pkg.go.dev link url are broken.

### PR Tips

Typically, PRs should consist of a single commit, and so should generally follow
the [rules for Go commit messages](https://go.dev/wiki/CommitMessage), with the following
changes and additions:

- Markdown is allowed.

- For a pervasive change, use "all" in the title instead of a package name.

- The PR description should provide context (why this change?) and describe the changes
  at a high level. Changes that are obvious from the diffs don't need to be mentioned.
