### PR TITLE
mcp: fix conformance tests

### DIFF
--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -39,6 +39,21 @@ func sayHi(ctx context.Context, ss *ServerSession, params *CallToolParamsFor[hiP
 	return &CallToolResultFor[any]{Content: []Content{&TextContent{Text: "hi " + params.Arguments.Name}}}, nil
 }
 
+var codeReviewPrompt = &Prompt{
+	Name:        "code_review",
+	Description: "do a code review",
+	Arguments:   []*PromptArgument{{Name: "Code", Required: true}},
+}
+
+func codReviewPromptHandler(_ context.Context, _ *ServerSession, params *GetPromptParams) (*GetPromptResult, error) {
+	return &GetPromptResult{
+		Description: "Code review prompt",
+		Messages: []*PromptMessage{
+			{Role: "user", Content: &TextContent{Text: "Please review the following code: " + params.Arguments["Code"]}},
+		},
+	}, nil
+}
+
 func TestEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	var ct, st Transport = NewInMemoryTransports()
@@ -73,18 +88,7 @@ func TestEndToEnd(t *testing.T) {
 		func(context.Context, *ServerSession, *CallToolParamsFor[map[string]any]) (*CallToolResult, error) {
 			return nil, errTestFailure
 		})
-	s.AddPrompt(&Prompt{
-		Name:        "code_review",
-		Description: "do a code review",
-		Arguments:   []*PromptArgument{{Name: "Code", Required: true}},
-	}, func(_ context.Context, _ *ServerSession, params *GetPromptParams) (*GetPromptResult, error) {
-		return &GetPromptResult{
-			Description: "Code review prompt",
-			Messages: []*PromptMessage{
-				{Role: "user", Content: &TextContent{Text: "Please review the following code: " + params.Arguments["Code"]}},
-			},
-		}, nil
-	})
+	s.AddPrompt(codeReviewPrompt, codReviewPromptHandler)
 	s.AddPrompt(&Prompt{Name: "fail"}, func(_ context.Context, _ *ServerSession, _ *GetPromptParams) (*GetPromptResult, error) {
 		return nil, errTestFailure
 	})

--- a/mcp/testdata/conformance/server/prompts.txtar
+++ b/mcp/testdata/conformance/server/prompts.txtar
@@ -29,12 +29,6 @@ code_review
 			"logging": {},
 			"prompts": {
 				"listChanged": true
-			},
-			"resources": {
-				"listChanged": true
-			},
-			"tools": {
-				"listChanged": true
 			}
 		},
 		"protocolVersion": "2024-11-05",

--- a/mcp/testdata/conformance/server/resources.txtar
+++ b/mcp/testdata/conformance/server/resources.txtar
@@ -47,13 +47,7 @@ info.txt
 		"capabilities": {
 			"completions": {},
 			"logging": {},
-			"prompts": {
-				"listChanged": true
-			},
 			"resources": {
-				"listChanged": true
-			},
-			"tools": {
 				"listChanged": true
 			}
 		},

--- a/mcp/testdata/conformance/server/tools.txtar
+++ b/mcp/testdata/conformance/server/tools.txtar
@@ -30,12 +30,6 @@ greet
 		"capabilities": {
 			"completions": {},
 			"logging": {},
-			"prompts": {
-				"listChanged": true
-			},
-			"resources": {
-				"listChanged": true
-			},
 			"tools": {
 				"listChanged": true
 			}

--- a/mcp/testdata/conformance/server/version-latest.txtar
+++ b/mcp/testdata/conformance/server/version-latest.txtar
@@ -19,18 +19,9 @@ response with its latest supported version.
 	"result": {
 		"capabilities": {
 			"completions": {},
-			"logging": {},
-			"prompts": {
-				"listChanged": true
-			},
-			"resources": {
-				"listChanged": true
-			},
-			"tools": {
-				"listChanged": true
-			}
+			"logging": {}
 		},
-		"protocolVersion": "2025-03-26",
+		"protocolVersion": "2025-06-18",
 		"serverInfo": {
 			"name": "testServer",
 			"version": "v1.0.0"

--- a/mcp/testdata/conformance/server/version-older.txtar
+++ b/mcp/testdata/conformance/server/version-older.txtar
@@ -19,16 +19,7 @@ support.
 	"result": {
 		"capabilities": {
 			"completions": {},
-			"logging": {},
-			"prompts": {
-				"listChanged": true
-			},
-			"resources": {
-				"listChanged": true
-			},
-			"tools": {
-				"listChanged": true
-			}
+			"logging": {}
 		},
 		"protocolVersion": "2024-11-05",
 		"serverInfo": {


### PR DESCRIPTION
- Use new AddXXX API.

- Update goldens to reflect new capability logic.

Fixes #131.