### PR TITLE
Checking extra tags in schema structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ func main() {
 	// Call a tool on the server.
 	params := &mcp.CallToolParams{
 		Name:      "greet",
-		Arguments: map[string]any{"name": "you"},
+		Arguments: map[string]any{"name": "you", "age": 24, "funkos": []string{"Batman", "Superman"}},
 	}
 	res, err := session.CallTool(ctx, params)
 	if err != nil {
@@ -108,13 +108,15 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-type HiParams struct {
-	Name string `json:"name" jsonschema:"the name of the person to greet"`
+type HiArgs struct {
+	Name   string   `json:"name" jsonschema:"the name to say hi to"`
+	Age    int      `json:"age" jsonschema:"the age of the person" minimum:"0" maximum:"120" default:"20"`
+	Funkos []string `json:"funkos" jsonschema:"the funkos the person has" minimum:"1" examples:"[\"Batman\", \"Superman\"]" default:"[\"Batman\"]"`
 }
 
 func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[HiParams]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + params.Arguments.Name}},
+		&mcp.TextContent{Text: fmt.Sprintf("Hi %s! You are %d years old and have %v funkos", params.Arguments.Name, params.Arguments.Age, params.Arguments.Funkos)},
 	}, nil
 }
 

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -19,13 +19,15 @@ import (
 var httpAddr = flag.String("http", "", "if set, use streamable HTTP at this address, instead of stdin/stdout")
 
 type HiArgs struct {
-	Name string `json:"name" jsonschema:"the name to say hi to"`
+	Name   string   `json:"name" jsonschema:"the name to say hi to"`
+	Age    int      `json:"age" jsonschema:"the age of the person" minimum:"0" maximum:"120" default:"20"`
+	Funkos []string `json:"funkos" jsonschema:"the funkos the person has" minimum:"1" examples:"[\"Batman\", \"Superman\"]" default:"[\"Batman\"]"`
 }
 
 func SayHi(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[HiArgs]) (*mcp.CallToolResultFor[struct{}], error) {
 	return &mcp.CallToolResultFor[struct{}]{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: "Hi " + params.Arguments.Name},
+			&mcp.TextContent{Text: fmt.Sprintf("Hi %s! You are %d years old and have %v funkos", params.Arguments.Name, params.Arguments.Age, params.Arguments.Funkos)},
 		},
 	}, nil
 }

--- a/jsonschema/infer.go
+++ b/jsonschema/infer.go
@@ -156,7 +156,8 @@ func forType(t reflect.Type, seen map[reflect.Type]bool) (*Schema, error) {
 			if !info.Settings["omitempty"] && !info.Settings["omitzero"] {
 				s.Required = append(s.Required, info.Name)
 			}
-			// Checks for extra tags.
+			// Set extra tags on the schema field, if they are present in the struct field.
+			// This allows for additional schema properties like "default", "minimum", etc.
 			if err := setExtraTags(fs, field); err != nil {
 				return nil, fmt.Errorf("failed to set extra tags for field %s.%s: %w", t, field.Name, err)
 			}
@@ -175,7 +176,7 @@ func forType(t reflect.Type, seen map[reflect.Type]bool) (*Schema, error) {
 // Disallow jsonschema tag values beginning "WORD=", for future expansion.
 var disallowedPrefixRegexp = regexp.MustCompile("^[^ \t\n]*=")
 
-// setTags sets the extra tags on the schema field, if they are present in the struct field.
+// setExtraTags sets the extra tags on the schema field, if they are present in the struct field.
 // It returns an error if any of the tags are invalid or if the tag values are empty.
 // Note: For the "examples" tag, values are appended to the Schema.Examples field, not overwritten.
 // TODO: Make the `extraTags` list configurable.
@@ -284,7 +285,7 @@ func handleFloatTag(value string, tag string) (float64, error) {
 	return max, nil
 }
 
-// handleBoolTag handles tags that expect a boolean value, like "exclusiveMaximum" or "exclusiveMinimum".
+// handleBoolTag handles tags that expect a boolean value, like "readOnly" or "writeOnly".
 func handleBoolTag(value string, tag string) (bool, error) {
 	selection, err := strconv.ParseBool(value)
 	if err != nil {

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -28,7 +28,7 @@ func TestFor(t *testing.T) {
 	type S struct {
 		B int       `jsonschema:"bdesc"`
 		C int       `jsonschema:"cdesc" default:"42"`
-		D int       `jsonschema:"ddesc" minimum:"1" maximum:"100"`
+		D int       `jsonschema:"ddesc" minimum:"1.0" maximum:"100"`
 		F []float64 `jsonschema:"fdesc" examples:"[1.5,2.0,3.0]"`
 		G []string  `jsonschema:"gdesc" examples:"[\"default\", \"value\"]" default:"[\"default\", \"value\"]"`
 		H string    `jsonschema:"hdesc" default:"default value"`

--- a/jsonschema/infer_test.go
+++ b/jsonschema/infer_test.go
@@ -5,6 +5,7 @@
 package jsonschema_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -25,8 +26,21 @@ func TestFor(t *testing.T) {
 	type schema = jsonschema.Schema
 
 	type S struct {
-		B int `jsonschema:"bdesc"`
+		B int       `jsonschema:"bdesc"`
+		C int       `jsonschema:"cdesc" default:"42"`
+		D int       `jsonschema:"ddesc" minimum:"1" maximum:"100"`
+		F []float64 `jsonschema:"fdesc" examples:"[1.5,2.0,3.0]"`
+		G []string  `jsonschema:"gdesc" examples:"[\"default\", \"value\"]" default:"[\"default\", \"value\"]"`
+		H string    `jsonschema:"hdesc" default:"default value"`
+		I []string  `jsonschema:"idesc" default:"[]"`
 	}
+
+	// These are the expected values for the schema.
+	var default42 = json.RawMessage("42")
+	var defaultStrArray = json.RawMessage(`["default", "value"]`)
+	var defaultStrValue = json.RawMessage(`"default value"`)
+	var oneMin float64 = 1.0
+	var hundredMax float64 = 100.0
 
 	tests := []struct {
 		name string
@@ -96,16 +110,28 @@ func TestFor(t *testing.T) {
 						Type: "object",
 						Properties: map[string]*schema{
 							"B": {Type: "integer", Description: "bdesc"},
+							"C": {Type: "integer", Description: "cdesc", Default: default42},
+							"D": {Type: "integer", Description: "ddesc", Minimum: &oneMin, Maximum: &hundredMax},
+							"F": {Type: "array", Description: "fdesc", Examples: []any{1.5, 2.0, 3.0}, Items: &schema{Type: "number"}},
+							"G": {Type: "array", Description: "gdesc", Examples: []any{"default", "value"}, Default: defaultStrArray, Items: &schema{Type: "string"}},
+							"H": {Type: "string", Description: "hdesc", Default: defaultStrValue},
+							"I": {Type: "array", Description: "idesc", Default: json.RawMessage("[]"), Items: &schema{Type: "string"}},
 						},
-						Required:             []string{"B"},
+						Required:             []string{"B", "C", "D", "F", "G", "H", "I"},
 						AdditionalProperties: falseSchema(),
 					},
 					"S": {
 						Type: "object",
 						Properties: map[string]*schema{
 							"B": {Type: "integer", Description: "bdesc"},
+							"C": {Type: "integer", Description: "cdesc", Default: default42},
+							"D": {Type: "integer", Description: "ddesc", Minimum: &oneMin, Maximum: &hundredMax},
+							"F": {Type: "array", Description: "fdesc", Examples: []any{1.5, 2.0, 3.0}, Items: &schema{Type: "number"}},
+							"G": {Type: "array", Description: "gdesc", Examples: []any{"default", "value"}, Default: defaultStrArray, Items: &schema{Type: "string"}},
+							"H": {Type: "string", Description: "hdesc", Default: defaultStrValue},
+							"I": {Type: "array", Description: "idesc", Default: json.RawMessage("[]"), Items: &schema{Type: "string"}},
 						},
-						Required:             []string{"B"},
+						Required:             []string{"B", "C", "D", "F", "G", "H", "I"},
 						AdditionalProperties: falseSchema(),
 					},
 				},


### PR DESCRIPTION
Currently, we only support adding the `jsonschema` tag that will be mapped to the description of the schema. Adding support for more tags that will improve validation of the expected data from the client.

- Adding an option to support extra tags in the structs
  - Current list supports the ones that could be needed the most: `["default", "minimum", "maximum", "examples", "readOnly", "deprecated", "writeOnly"]`

Reference:
[jsonschema-go](https://github.com/swaggest/jsonschema-go?tab=readme-ov-file)

Related to #28
