### PR TITLE
docs: Enhance README formatting and fix relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains an unreleased implementation of the official Go
 software development kit (SDK) for the Model Context Protocol (MCP).
 
 > [!WARNING]
-> **WARNING**: The SDK should be considered unreleased, and is currently unstable
+> The SDK should be considered unreleased, and is currently unstable
 > and subject to breaking changes. Please test it out and file bug reports or API
 > proposals, but don't use it in real projects. See the issue tracker for known
 > issues and missing features. We aim to release a stable version of the SDK in

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ https://github.com/modelcontextprotocol/go-sdk/releases/tag/v0.2.0) for details.
 This repository contains an unreleased implementation of the official Go
 software development kit (SDK) for the Model Context Protocol (MCP).
 
-**WARNING**: The SDK should be considered unreleased, and is currently unstable
-and subject to breaking changes. Please test it out and file bug reports or API
-proposals, but don't use it in real projects. See the issue tracker for known
-issues and missing features. We aim to release a stable version of the SDK in
-August, 2025.
+> [!WARNING]
+> **WARNING**: The SDK should be considered unreleased, and is currently unstable
+> and subject to breaking changes. Please test it out and file bug reports or API
+> proposals, but don't use it in real projects. See the issue tracker for known
+> issues and missing features. We aim to release a stable version of the SDK in
+> August, 2025.
 
 ## Design
 
@@ -28,7 +29,7 @@ Further design discussion should occur in
 [issues](https://github.com/modelcontextprotocol/go-sdk/issues) (for concrete
 proposals) or
 [discussions](https://github.com/modelcontextprotocol/go-sdk/discussions) for
-open-ended discussion. See CONTRIBUTING.md for details.
+open-ended discussion. See [CONTRIBUTING.md](/CONTRIBUTING.md) for details.
 
 ## Package documentation
 
@@ -130,7 +131,7 @@ func main() {
 }
 ```
 
-The `examples/` directory contains more example clients and servers.
+The [`examples/`](/examples/) directory contains more example clients and servers.
 
 ## Acknowledgements
 

--- a/internal/readme/README.src.md
+++ b/internal/readme/README.src.md
@@ -12,7 +12,7 @@ This repository contains an unreleased implementation of the official Go
 software development kit (SDK) for the Model Context Protocol (MCP).
 
 > [!WARNING]
-> **WARNING**: The SDK should be considered unreleased, and is currently unstable
+> The SDK should be considered unreleased, and is currently unstable
 > and subject to breaking changes. Please test it out and file bug reports or API
 > proposals, but don't use it in real projects. See the issue tracker for known
 > issues and missing features. We aim to release a stable version of the SDK in

--- a/internal/readme/README.src.md
+++ b/internal/readme/README.src.md
@@ -11,11 +11,12 @@ https://github.com/modelcontextprotocol/go-sdk/releases/tag/v0.2.0) for details.
 This repository contains an unreleased implementation of the official Go
 software development kit (SDK) for the Model Context Protocol (MCP).
 
-**WARNING**: The SDK should be considered unreleased, and is currently unstable
-and subject to breaking changes. Please test it out and file bug reports or API
-proposals, but don't use it in real projects. See the issue tracker for known
-issues and missing features. We aim to release a stable version of the SDK in
-August, 2025.
+> [!WARNING]
+> **WARNING**: The SDK should be considered unreleased, and is currently unstable
+> and subject to breaking changes. Please test it out and file bug reports or API
+> proposals, but don't use it in real projects. See the issue tracker for known
+> issues and missing features. We aim to release a stable version of the SDK in
+> August, 2025.
 
 ## Design
 
@@ -27,7 +28,7 @@ Further design discussion should occur in
 [issues](https://github.com/modelcontextprotocol/go-sdk/issues) (for concrete
 proposals) or
 [discussions](https://github.com/modelcontextprotocol/go-sdk/discussions) for
-open-ended discussion. See CONTRIBUTING.md for details.
+open-ended discussion. See [CONTRIBUTING.md](/CONTRIBUTING.md) for details.
 
 ## Package documentation
 
@@ -58,7 +59,7 @@ with its client over stdin/stdout:
 
 %include server/server.go -
 
-The `examples/` directory contains more example clients and servers.
+The [`examples/`](/examples/) directory contains more example clients and servers.
 
 ## Acknowledgements
 


### PR DESCRIPTION
This PR improves the formatting and internal link structure of both the main `README.md` and the source file at `internal/readme/README.src.md`. Changes include:

### 🛠 Changes Made

* Replaced plain-text warning with a GitHub-style admonition block (`> [!WARNING]`) for improved visibility and consistency with other docs.

Example:

> [!WARNING]
> The SDK should be considered unreleased, and is currently unstable
> and subject to breaking changes. Please test it out and file bug reports or API
> proposals, but don't use it in real projects. See the issue tracker for known
> issues and missing features. We aim to release a stable version of the SDK in
> August, 2025.

* Updated markdown links to use cleaner relative paths:
  * Changed `CONTRIBUTING.md` reference to `[CONTRIBUTING.md](/CONTRIBUTING.md)`
  * Updated `examples/` reference to `[examples/](/examples/)`
* Ensured that all updates were mirrored in both the generated and source README files.

### 📌 Why It Matters

These changes improve the readability and usability of the documentation, especially when viewed on GitHub. The updated formatting helps call attention to important warnings, and fixing relative paths ensures that links work reliably across platforms and contexts.