### PR TITLE
mcp/examples: Make example more usable.

### DIFF
--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -16,10 +16,8 @@ import (
 )
 
 var (
-	httpAddr = flag.String("http", "", "use SSE HTTP at this address (deprecated, use -host and -port instead)")
 	host     = flag.String("host", "localhost", "host to listen on")
 	port     = flag.String("port", "8080", "port to listen on")
-	showUsage = flag.Bool("usage", false, "show usage information")
 )
 
 type SayHiParams struct {
@@ -47,16 +45,7 @@ func main() {
 	}
 	flag.Parse()
 
-	if *showUsage {
-		flag.Usage()
-	}
-
-	var addr string
-	if *httpAddr != "" {
-		addr = *httpAddr
-	} else {
-		addr = fmt.Sprintf("%s:%s", *host, *port)
-	}
+	addr := fmt.Sprintf("%s:%s", *host, *port)
 
 	server1 := mcp.NewServer(&mcp.Implementation{Name: "greeter1"}, nil)
 	mcp.AddTool(server1, &mcp.Tool{Name: "greet1", Description: "say hi"}, SayHi)
@@ -78,7 +67,5 @@ func main() {
 		}
 	})
 	
-	if err := http.ListenAndServe(addr, handler); err != nil {
-		log.Fatalf("Failed to start server on %s: %v", addr, err)
-	}
+	log.Fatal(http.ListenAndServe(addr, handler))
 }

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -19,18 +19,8 @@ var (
 	httpAddr = flag.String("http", "", "use SSE HTTP at this address (deprecated, use -host and -port instead)")
 	host     = flag.String("host", "localhost", "host to listen on")
 	port     = flag.String("port", "8080", "port to listen on")
+	showUsage = flag.Bool("usage", false, "show usage information")
 )
-
-func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\n", os.Args[0])
-	fmt.Fprintf(os.Stderr, "This program runs MCP servers over SSE HTTP.\n\n")
-	fmt.Fprintf(os.Stderr, "Options:\n")
-	flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, "\nEndpoints:\n")
-	fmt.Fprintf(os.Stderr, "  /greeter1 - Greeter 1 service\n")
-	fmt.Fprintf(os.Stderr, "  /greeter2 - Greeter 2 service\n")
-	os.Exit(1)
-}
 
 type SayHiParams struct {
 	Name string `json:"name"`
@@ -45,7 +35,21 @@ func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParam
 }
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "This program runs MCP servers over SSE HTTP.\n\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nEndpoints:\n")
+		fmt.Fprintf(os.Stderr, "  /greeter1 - Greeter 1 service\n")
+		fmt.Fprintf(os.Stderr, "  /greeter2 - Greeter 2 service\n")
+		os.Exit(1)
+	}
 	flag.Parse()
+
+	if *showUsage {
+		flag.Usage()
+	}
 
 	var addr string
 	if *httpAddr != "" {

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	host     = flag.String("host", "localhost", "host to listen on")
-	port     = flag.String("port", "8080", "port to listen on")
+	host = flag.String("host", "localhost", "host to listen on")
+	port = flag.String("port", "8080", "port to listen on")
 )
 
 type SayHiParams struct {

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -7,13 +7,30 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-var httpAddr = flag.String("http", "", "use SSE HTTP at this address")
+var (
+	httpAddr = flag.String("http", "", "use SSE HTTP at this address (deprecated, use -host and -port instead)")
+	host     = flag.String("host", "localhost", "host to listen on")
+	port     = flag.String("port", "8080", "port to listen on")
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\n", os.Args[0])
+	fmt.Fprintf(os.Stderr, "This program runs MCP servers over SSE HTTP.\n\n")
+	fmt.Fprintf(os.Stderr, "Options:\n")
+	flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, "\nEndpoints:\n")
+	fmt.Fprintf(os.Stderr, "  /greeter1 - Greeter 1 service\n")
+	fmt.Fprintf(os.Stderr, "  /greeter2 - Greeter 2 service\n")
+	os.Exit(1)
+}
 
 type SayHiParams struct {
 	Name string `json:"name"`
@@ -30,8 +47,11 @@ func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParam
 func main() {
 	flag.Parse()
 
-	if httpAddr == nil || *httpAddr == "" {
-		log.Fatal("http address not set")
+	var addr string
+	if *httpAddr != "" {
+		addr = *httpAddr
+	} else {
+		addr = fmt.Sprintf("%s:%s", *host, *port)
 	}
 
 	server1 := mcp.NewServer(&mcp.Implementation{Name: "greeter1"}, nil)
@@ -40,7 +60,7 @@ func main() {
 	server2 := mcp.NewServer(&mcp.Implementation{Name: "greeter2"}, nil)
 	mcp.AddTool(server2, &mcp.Tool{Name: "greet2", Description: "say hello"}, SayHi)
 
-	log.Printf("MCP servers serving at %s", *httpAddr)
+	log.Printf("MCP servers serving at %s", addr)
 	handler := mcp.NewSSEHandler(func(request *http.Request) *mcp.Server {
 		url := request.URL.Path
 		log.Printf("Handling request for URL %s\n", url)
@@ -53,5 +73,8 @@ func main() {
 			return nil
 		}
 	})
-	http.ListenAndServe(*httpAddr, handler)
+	
+	if err := http.ListenAndServe(addr, handler); err != nil {
+		log.Fatalf("Failed to start server on %s: %v", addr, err)
+	}
 }


### PR DESCRIPTION
I'm making this example more useful for debugging:
- `-port` is supported
- `-host` is supported
- error handling is there.