### PR TITLE
mcp: gracefully handle a nil server in handlers

### DIFF
--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -53,5 +53,5 @@ func main() {
 			return nil
 		}
 	})
-	http.ListenAndServe(*httpAddr, handler)
+	log.Fatal(http.ListenAndServe(*httpAddr, handler))
 }


### PR DESCRIPTION
If the getServer function passed to NewSSEHandler or NewStreamableHTTPHandler returns nil, serve a 400 instead of panicking.

Fixes #161.