### PR TITLE
mcp: don't panic on bad JSON RPC input

### DIFF
--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"os"
 	"sync"
@@ -120,6 +121,7 @@ func connect[H handler](ctx context.Context, t Transport, b binder[H]) (H, error
 		OnDone: func() {
 			b.disconnect(h)
 		},
+		OnInternalError: func(err error) { log.Printf("jsonrpc2 error: %v", err) },
 	})
 	assert(preempter.conn != nil, "unbound preempter")
 	h.setConn(conn)


### PR DESCRIPTION
Log internal errors from the jsonprc2 package, instead of panicking.

Fixes #175.
