### PR TITLE
mcp/server: add initial capability server option

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -46,14 +46,6 @@ type Server struct {
 	resourceSubscriptions   map[string]map[*ServerSession]bool // uri -> session -> bool
 }
 
-// InitialCapabilities allows a server to advertise support for capabilities
-// during initialization, even if no resources for that capability have been added yet.
-type InitialCapabilities struct {
-	Prompts   bool
-	Tools     bool
-	Resources bool
-}
-
 // ServerOptions is used to configure behavior of the server.
 type ServerOptions struct {
 	// Optional instructions for connected clients.
@@ -77,10 +69,15 @@ type ServerOptions struct {
 	SubscribeHandler func(context.Context, *SubscribeParams) error
 	// Function called when a client session unsubscribes from a resource.
 	UnsubscribeHandler func(context.Context, *UnsubscribeParams) error
-	// InitialCapabilities allows a server to advertise support for capabilities
-	// at initialization, even if no specific items (like tools or prompts)
-	// have been added yet.
-	InitialCapabilities InitialCapabilities
+	// If true, advertises the prompts capability during initialization,
+	// even if no prompts have been registered.
+	HasPrompts bool
+	// If true, advertises the resources capability during initialization,
+	// even if no resources have been registered.
+	HasResources bool
+	// If true, advertises the tools capability during initialization,
+	// even if no tools have been registered.
+	HasTools bool
 }
 
 // NewServer creates a new MCP server. The resulting server has no features:
@@ -246,13 +243,13 @@ func (s *Server) capabilities() *serverCapabilities {
 		Completions: &completionCapabilities{},
 		Logging:     &loggingCapabilities{},
 	}
-	if s.tools.len() > 0 || s.opts.InitialCapabilities.Tools {
+	if s.opts.HasTools || s.tools.len() > 0 {
 		caps.Tools = &toolCapabilities{ListChanged: true}
 	}
-	if s.prompts.len() > 0 || s.opts.InitialCapabilities.Prompts {
+	if s.opts.HasPrompts || s.prompts.len() > 0 {
 		caps.Prompts = &promptCapabilities{ListChanged: true}
 	}
-	if s.resources.len() > 0 || s.resourceTemplates.len() > 0 || s.opts.InitialCapabilities.Resources {
+	if s.opts.HasResources || s.resources.len() > 0 || s.resourceTemplates.len() > 0 {
 		caps.Resources = &resourceCapabilities{ListChanged: true}
 		if s.opts.SubscribeHandler != nil {
 			caps.Resources.Subscribe = true

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -337,11 +337,9 @@ func TestServerCapabilities(t *testing.T) {
 			name:            "With initial capabilities",
 			configureServer: func(s *Server) {},
 			serverOpts: ServerOptions{
-				InitialCapabilities: InitialCapabilities{
-					Prompts:   true,
-					Tools:     true,
-					Resources: true,
-				},
+				HasPrompts:   true,
+				HasResources: true,
+				HasTools:     true,
 			},
 			wantCapabilities: &serverCapabilities{
 				Completions: &completionCapabilities{},

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -333,6 +333,24 @@ func TestServerCapabilities(t *testing.T) {
 				Tools:       &toolCapabilities{ListChanged: true},
 			},
 		},
+		{
+			name:            "With initial capabilities",
+			configureServer: func(s *Server) {},
+			serverOpts: ServerOptions{
+				InitialCapabilities: InitialCapabilities{
+					Prompts:   true,
+					Tools:     true,
+					Resources: true,
+				},
+			},
+			wantCapabilities: &serverCapabilities{
+				Completions: &completionCapabilities{},
+				Logging:     &loggingCapabilities{},
+				Prompts:     &promptCapabilities{ListChanged: true},
+				Resources:   &resourceCapabilities{ListChanged: true},
+				Tools:       &toolCapabilities{ListChanged: true},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This CL adds an option for servers to advertise support for features that have not been added yet. This includes Prompts, Tools, and Resources as these could be dynamically added after initialization.

Fixes: #135