### PR TITLE
internal/jsonrpc2,mcp: fix typos

### DIFF
--- a/internal/jsonrpc2/conn.go
+++ b/internal/jsonrpc2/conn.go
@@ -125,7 +125,7 @@ func (c *Connection) updateInFlight(f func(*inFlightState)) {
 		// that and avoided making any updates that would cause the state to be
 		// non-idle.)
 		if !s.idle() {
-			panic("jsonrpc2_v2: updateInFlight transitioned to non-idle when already done")
+			panic("jsonrpc2: updateInFlight transitioned to non-idle when already done")
 		}
 		return
 	default:
@@ -718,7 +718,7 @@ func (c *Connection) processResult(from any, req *incomingRequest, result any, e
 	req.cancel()
 	c.updateInFlight(func(s *inFlightState) {
 		if s.incoming == 0 {
-			panic("jsonrpc2_v2: processResult called when incoming count is already zero")
+			panic("jsonrpc2: processResult called when incoming count is already zero")
 		}
 		s.incoming--
 	})

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -29,7 +29,7 @@ const DefaultPageSize = 1000
 // A Server is an instance of an MCP server.
 //
 // Servers expose server-side MCP features, which can serve one or more MCP
-// sessions by using [Server.Start] or [Server.Run].
+// sessions by using [Server.Run].
 type Server struct {
 	// fixed at creation
 	impl *Implementation
@@ -74,8 +74,7 @@ type ServerOptions struct {
 // NewServer creates a new MCP server. The resulting server has no features:
 // add features using the various Server.AddXXX methods, and the [AddTool] function.
 //
-// The server can be connected to one or more MCP clients using [Server.Start]
-// or [Server.Run].
+// The server can be connected to one or more MCP clients using [Server.Run].
 //
 // The first argument must not be nil.
 //
@@ -733,7 +732,7 @@ func (ss *ServerSession) handle(ctx context.Context, req *jsonrpc.Request) (any,
 	}
 	// For the streamable transport, we need the request ID to correlate
 	// server->client calls and notifications to the incoming request from which
-	// they originated. See [idContext] for details.
+	// they originated. See [idContextKey] for details.
 	ctx = context.WithValue(ctx, idContextKey{}, req.ID)
 	return handleReceive(ctx, ss, req)
 }

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -44,7 +44,7 @@ type MethodHandler[S Session] func(ctx context.Context, _ S, method string, para
 // the compiler would complain.
 type methodHandler any // MethodHandler[*ClientSession] | MethodHandler[*ServerSession]
 
-// A Session is either a ClientSession or a ServerSession.
+// A Session is either a [ClientSession] or a [ServerSession].
 type Session interface {
 	*ClientSession | *ServerSession
 	// ID returns the session ID, or the empty string if there is none.
@@ -57,7 +57,7 @@ type Session interface {
 	getConn() *jsonrpc2.Connection
 }
 
-// Middleware is a function from MethodHandlers to MethodHandlers.
+// Middleware is a function from [MethodHandler] to [MethodHandler].
 type Middleware[S Session] func(MethodHandler[S]) MethodHandler[S]
 
 // addMiddleware wraps the handler in the middleware functions.

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -134,7 +134,7 @@ type canceller struct {
 	conn *jsonrpc2.Connection
 }
 
-// Preempt implements jsonrpc2.Preempter.
+// Preempt implements [jsonrpc2.Preempter].
 func (c *canceller) Preempt(ctx context.Context, req *jsonrpc.Request) (result any, err error) {
 	if req.Method == "notifications/cancelled" {
 		var params CancelledParams
@@ -203,7 +203,7 @@ type loggingConn struct {
 
 func (c *loggingConn) SessionID() string { return c.delegate.SessionID() }
 
-// loggingReader is a stream middleware that logs incoming messages.
+// Read is a stream middleware that logs incoming messages.
 func (s *loggingConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 	msg, err := s.delegate.Read(ctx)
 	if err != nil {
@@ -218,7 +218,7 @@ func (s *loggingConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 	return msg, err
 }
 
-// loggingWriter is a stream middleware that logs outgoing messages.
+// Write is a stream middleware that logs outgoing messages.
 func (s *loggingConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	err := s.delegate.Write(ctx, msg)
 	if err != nil {


### PR DESCRIPTION
This pull request includes various documentation updates and minor code adjustments to improve clarity and consistency across the codebase. The changes focus on refining comments, fixing references, and correcting naming conventions.

### Documentation Updates:

* [`mcp/server.go`](diffhunk://#diff-11ef4b86b57e1edc1d90d4618fbb4a188a8ae2e0c9dd2ff0300f40c0074ae8caL32-R32): Updated comments to remove references to `[Server.Start]` and use `[Server.Run]` consistently, ensuring alignment with the current implementation. [[1]](diffhunk://#diff-11ef4b86b57e1edc1d90d4618fbb4a188a8ae2e0c9dd2ff0300f40c0074ae8caL32-R32) [[2]](diffhunk://#diff-11ef4b86b57e1edc1d90d4618fbb4a188a8ae2e0c9dd2ff0300f40c0074ae8caL77-R77)
* [`mcp/server.go`](diffhunk://#diff-11ef4b86b57e1edc1d90d4618fbb4a188a8ae2e0c9dd2ff0300f40c0074ae8caL736-R735): Changed the reference from `[idContext]` to `[idContextKey]` for better clarity in comments about request ID handling.
* [`mcp/shared.go`](diffhunk://#diff-f105fc7cdde2d23ea58d3bfbf5c12a7e62317064f5180b2489d0647717ef4934L47-R47): Improved comments to use square brackets around type names (`[ClientSession]`, `[ServerSession]`, `[MethodHandler]`) for consistency with documentation conventions. [[1]](diffhunk://#diff-f105fc7cdde2d23ea58d3bfbf5c12a7e62317064f5180b2489d0647717ef4934L47-R47) [[2]](diffhunk://#diff-f105fc7cdde2d23ea58d3bfbf5c12a7e62317064f5180b2489d0647717ef4934L60-R60)
* [`mcp/transport.go`](diffhunk://#diff-103fedbd8f38add8caaa755fcab1f825e7cd68e76dfefa00340402951c603444L137-R137): Updated comments to clarify implementation details, such as changing `Preempt implements jsonrpc2.Preempter` to `Preempt implements [jsonrpc2.Preempter]`.

### Code Adjustments:

* [`internal/jsonrpc2/conn.go`](diffhunk://#diff-3d7fcdfe297a71df957d8eb25626dcd937ddb14b7783f7d22237b8d293eed94dL128-R128): Fixed panic message strings to remove `_v2` suffix for consistency with the current naming conventions. [[1]](diffhunk://#diff-3d7fcdfe297a71df957d8eb25626dcd937ddb14b7783f7d22237b8d293eed94dL128-R128) [[2]](diffhunk://#diff-3d7fcdfe297a71df957d8eb25626dcd937ddb14b7783f7d22237b8d293eed94dL721-R721)
* [`mcp/transport.go`](diffhunk://#diff-103fedbd8f38add8caaa755fcab1f825e7cd68e76dfefa00340402951c603444L206-R206): Renamed middleware function descriptions in comments (`loggingReader` → `Read`, `loggingWriter` → `Write`) to match method names directly. [[1]](diffhunk://#diff-103fedbd8f38add8caaa755fcab1f825e7cd68e76dfefa00340402951c603444L206-R206) [[2]](diffhunk://#diff-103fedbd8f38add8caaa755fcab1f825e7cd68e76dfefa00340402951c603444L221-R221)