### PR TITLE
CONTRIBUTING.md: timeout policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,12 @@ The CI system will automatically check that the README is up-to-date by running
 `make` and verifying no changes result. If you see a CI failure about the
 README being out of sync, follow the steps above to regenerate it.
 
+## Timeouts
+
+If a contributor hasn't responded to issue questions or PR comments in two weeks,
+the issue or PR may be closed. It can be reopened when the contributor can resume
+work.
+
 ## Code of conduct
 
 This project follows the [Go Community Code of Conduct](https://go.dev/conduct).


### PR DESCRIPTION
Explain that we'll close issues or PRs after a period of inactivity.

This will reduce clutter on the issue and PR pages.