### PR TITLE
mcp: reject requests with bad IDs

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -287,16 +287,16 @@ func (c *Client) AddReceivingMiddleware(middleware ...Middleware[*ClientSession]
 
 // clientMethodInfos maps from the RPC method name to serverMethodInfos.
 var clientMethodInfos = map[string]methodInfo{
-	methodComplete:                  newMethodInfo(sessionMethod((*ClientSession).Complete)),
-	methodPing:                      newMethodInfo(sessionMethod((*ClientSession).ping)),
-	methodListRoots:                 newMethodInfo(clientMethod((*Client).listRoots)),
-	methodCreateMessage:             newMethodInfo(clientMethod((*Client).createMessage)),
-	notificationToolListChanged:     newMethodInfo(clientMethod((*Client).callToolChangedHandler)),
-	notificationPromptListChanged:   newMethodInfo(clientMethod((*Client).callPromptChangedHandler)),
-	notificationResourceListChanged: newMethodInfo(clientMethod((*Client).callResourceChangedHandler)),
-	notificationResourceUpdated:     newMethodInfo(clientMethod((*Client).callResourceUpdatedHandler)),
-	notificationLoggingMessage:      newMethodInfo(clientMethod((*Client).callLoggingHandler)),
-	notificationProgress:            newMethodInfo(sessionMethod((*ClientSession).callProgressNotificationHandler)),
+	methodComplete:                  newMethodInfo(sessionMethod((*ClientSession).Complete), true),
+	methodPing:                      newMethodInfo(sessionMethod((*ClientSession).ping), true),
+	methodListRoots:                 newMethodInfo(clientMethod((*Client).listRoots), true),
+	methodCreateMessage:             newMethodInfo(clientMethod((*Client).createMessage), true),
+	notificationToolListChanged:     newMethodInfo(clientMethod((*Client).callToolChangedHandler), false),
+	notificationPromptListChanged:   newMethodInfo(clientMethod((*Client).callPromptChangedHandler), false),
+	notificationResourceListChanged: newMethodInfo(clientMethod((*Client).callResourceChangedHandler), false),
+	notificationResourceUpdated:     newMethodInfo(clientMethod((*Client).callResourceUpdatedHandler), false),
+	notificationLoggingMessage:      newMethodInfo(clientMethod((*Client).callLoggingHandler), false),
+	notificationProgress:            newMethodInfo(sessionMethod((*ClientSession).callProgressNotificationHandler), false),
 }
 
 func (cs *ClientSession) sendingMethodInfos() map[string]methodInfo {
@@ -323,7 +323,7 @@ func (cs *ClientSession) receivingMethodHandler() methodHandler {
 	return cs.client.receivingMethodHandler_
 }
 
-// getConn implements [session.getConn].
+// getConn implements [Session.getConn].
 func (cs *ClientSession) getConn() *jsonrpc2.Connection { return cs.conn }
 
 func (*ClientSession) ping(context.Context, *PingParams) (*emptyResult, error) {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -688,22 +688,22 @@ func (s *Server) AddReceivingMiddleware(middleware ...Middleware[*ServerSession]
 
 // serverMethodInfos maps from the RPC method name to serverMethodInfos.
 var serverMethodInfos = map[string]methodInfo{
-	methodComplete:               newMethodInfo(serverMethod((*Server).complete)),
-	methodInitialize:             newMethodInfo(sessionMethod((*ServerSession).initialize)),
-	methodPing:                   newMethodInfo(sessionMethod((*ServerSession).ping)),
-	methodListPrompts:            newMethodInfo(serverMethod((*Server).listPrompts)),
-	methodGetPrompt:              newMethodInfo(serverMethod((*Server).getPrompt)),
-	methodListTools:              newMethodInfo(serverMethod((*Server).listTools)),
-	methodCallTool:               newMethodInfo(serverMethod((*Server).callTool)),
-	methodListResources:          newMethodInfo(serverMethod((*Server).listResources)),
-	methodListResourceTemplates:  newMethodInfo(serverMethod((*Server).listResourceTemplates)),
-	methodReadResource:           newMethodInfo(serverMethod((*Server).readResource)),
-	methodSetLevel:               newMethodInfo(sessionMethod((*ServerSession).setLevel)),
-	methodSubscribe:              newMethodInfo(serverMethod((*Server).subscribe)),
-	methodUnsubscribe:            newMethodInfo(serverMethod((*Server).unsubscribe)),
-	notificationInitialized:      newMethodInfo(serverMethod((*Server).callInitializedHandler)),
-	notificationRootsListChanged: newMethodInfo(serverMethod((*Server).callRootsListChangedHandler)),
-	notificationProgress:         newMethodInfo(sessionMethod((*ServerSession).callProgressNotificationHandler)),
+	methodComplete:               newMethodInfo(serverMethod((*Server).complete), true),
+	methodInitialize:             newMethodInfo(sessionMethod((*ServerSession).initialize), true),
+	methodPing:                   newMethodInfo(sessionMethod((*ServerSession).ping), true),
+	methodListPrompts:            newMethodInfo(serverMethod((*Server).listPrompts), true),
+	methodGetPrompt:              newMethodInfo(serverMethod((*Server).getPrompt), true),
+	methodListTools:              newMethodInfo(serverMethod((*Server).listTools), true),
+	methodCallTool:               newMethodInfo(serverMethod((*Server).callTool), true),
+	methodListResources:          newMethodInfo(serverMethod((*Server).listResources), true),
+	methodListResourceTemplates:  newMethodInfo(serverMethod((*Server).listResourceTemplates), true),
+	methodReadResource:           newMethodInfo(serverMethod((*Server).readResource), true),
+	methodSetLevel:               newMethodInfo(sessionMethod((*ServerSession).setLevel), true),
+	methodSubscribe:              newMethodInfo(serverMethod((*Server).subscribe), true),
+	methodUnsubscribe:            newMethodInfo(serverMethod((*Server).unsubscribe), true),
+	notificationInitialized:      newMethodInfo(serverMethod((*Server).callInitializedHandler), false),
+	notificationRootsListChanged: newMethodInfo(serverMethod((*Server).callRootsListChangedHandler), false),
+	notificationProgress:         newMethodInfo(sessionMethod((*ServerSession).callProgressNotificationHandler), false),
 }
 
 func (ss *ServerSession) sendingMethodInfos() map[string]methodInfo { return clientMethodInfos }

--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -129,6 +129,12 @@ func (t *SSEServerTransport) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		http.Error(w, "failed to parse body", http.StatusBadRequest)
 		return
 	}
+	if req, ok := msg.(*jsonrpc.Request); ok {
+		if _, err := checkRequest(req, serverMethodInfos); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
 	select {
 	case t.incoming <- msg:
 		w.WriteHeader(http.StatusAccepted)

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -280,7 +280,7 @@ func TestStreamableServerTransport(t *testing.T) {
 	}
 
 	// Predefined steps, to avoid repetition below.
-	initReq := req(1, "initialize", &InitializeParams{})
+	initReq := req(1, methodInitialize, &InitializeParams{})
 	initResp := resp(1, &InitializeResult{
 		Capabilities: &serverCapabilities{
 			Completions: &completionCapabilities{},
@@ -290,7 +290,7 @@ func TestStreamableServerTransport(t *testing.T) {
 		ProtocolVersion: latestProtocolVersion,
 		ServerInfo:      &Implementation{Name: "testServer", Version: "v1.0.0"},
 	}, nil)
-	initializedMsg := req(0, "initialized", &InitializedParams{})
+	initializedMsg := req(0, notificationInitialized, &InitializedParams{})
 	initialize := step{
 		Method:     "POST",
 		Send:       []jsonrpc.Message{initReq},
@@ -437,6 +437,16 @@ func TestStreamableServerTransport(t *testing.T) {
 				{
 					Method:     "DELETE",
 					StatusCode: http.StatusBadRequest,
+				},
+				{
+					Method:     "POST",
+					Send:       []jsonrpc.Message{req(1, "notamethod", nil)},
+					StatusCode: http.StatusBadRequest, // notamethod is an invalid method
+				},
+				{
+					Method:     "POST",
+					Send:       []jsonrpc.Message{req(0, "tools/call", &CallToolParams{Name: "tool"})},
+					StatusCode: http.StatusBadRequest, // tools/call must have an ID
 				},
 				{
 					Method:     "POST",

--- a/mcp/testdata/conformance/server/missing_fields.txtar
+++ b/mcp/testdata/conformance/server/missing_fields.txtar
@@ -1,0 +1,54 @@
+Check robustness to missing fields: servers should reject and otherwise ignore
+bad requests.
+
+Fixed bugs:
+- No id in 'initialize' should not panic (#197).
+- No id in 'ping' should not panic (#194).
+
+TODO:
+- No params in 'initialize' should not panic (#195).
+
+-- prompts --
+code_review
+
+-- client --
+{
+  "jsonrpc": "2.0",
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": { "name": "ExampleClient", "version": "1.0.0" }
+  }
+}
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": { "name": "ExampleClient", "version": "1.0.0" }
+  }
+}
+{"jsonrpc":"2.0", "method":"ping"}
+
+-- server --
+{
+	"jsonrpc": "2.0",
+	"id": 2,
+	"result": {
+		"capabilities": {
+			"completions": {},
+			"logging": {},
+			"prompts": {
+				"listChanged": true
+			}
+		},
+		"protocolVersion": "2024-11-05",
+		"serverInfo": {
+			"name": "testServer",
+			"version": "v1.0.0"
+		}
+	}
+}


### PR DESCRIPTION
Add an isRequest field to methodInfo, used it to reject non-notification requests that lack a valid ID. Furthermore, lift this validation to the transport layer for HTTP server transports, so that we can preemptively reject bad HTTP requests.

Fixes #194
Fixes #197