### PR TITLE
mcp: reject notifications with unexpected ID field

### DIFF
--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -155,7 +155,10 @@ func checkRequest(req *jsonrpc.Request, infos map[string]methodInfo) (methodInfo
 		return methodInfo{}, fmt.Errorf("%w: %q unsupported", jsonrpc2.ErrNotHandled, req.Method)
 	}
 	if info.isRequest && !req.ID.IsValid() {
-		return methodInfo{}, fmt.Errorf("%w: %q missing ID", jsonrpc2.ErrInvalidRequest, req.Method)
+		return methodInfo{}, fmt.Errorf("%w: missing ID, %q", jsonrpc2.ErrInvalidRequest, req.Method)
+	}
+	if !info.isRequest && req.ID.IsValid() {
+		return methodInfo{}, fmt.Errorf("%w: unexpected id for %q", jsonrpc2.ErrInvalidRequest, req.Method)
 	}
 	return info, nil
 }

--- a/mcp/testdata/conformance/server/bad_requests.txtar
+++ b/mcp/testdata/conformance/server/bad_requests.txtar
@@ -4,6 +4,7 @@ bad requests.
 Fixed bugs:
 - No id in 'initialize' should not panic (#197).
 - No id in 'ping' should not panic (#194).
+- Notifications with IDs should not be treated like requests.
 
 TODO:
 - No params in 'initialize' should not panic (#195).
@@ -31,6 +32,7 @@ code_review
     "clientInfo": { "name": "ExampleClient", "version": "1.0.0" }
   }
 }
+{"jsonrpc":"2.0", "id": 3, "method":"notifications/initialized"}
 {"jsonrpc":"2.0", "method":"ping"}
 
 -- server --
@@ -50,5 +52,13 @@ code_review
 			"name": "testServer",
 			"version": "v1.0.0"
 		}
+	}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 3,
+	"error": {
+		"code": -32600,
+		"message": "JSON RPC invalid request: unexpected id for \"notifications/initialized\""
 	}
 }


### PR DESCRIPTION
Use the new 'isRequest' field on methodInfo to also reject notifications with an unexpected ID field.

For #196