### PR TITLE
mcp: remove unused functions (cleanup)

### DIFF
--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -520,17 +520,6 @@ func handleEmbeddedResource(_ context.Context, _ *ServerSession, params *ReadRes
 	}, nil
 }
 
-// Add calls the given function to add the named features.
-func add[T any](m map[string]T, add func(...T), names ...string) {
-	for _, name := range names {
-		feat, ok := m[name]
-		if !ok {
-			panic("missing feature " + name)
-		}
-		add(feat)
-	}
-}
-
 // errorCode returns the code associated with err.
 // If err is nil, it returns 0.
 // If there is no code, it returns -1.
@@ -836,9 +825,6 @@ func traceCalls[S Session](w io.Writer, prefix string) Middleware[S] {
 		}
 	}
 }
-
-// A function, because schemas must form a tree (they have hidden state).
-func falseSchema() *jsonschema.Schema { return &jsonschema.Schema{Not: &jsonschema.Schema{}} }
 
 func nopHandler(context.Context, *ServerSession, *CallToolParamsFor[map[string]any]) (*CallToolResult, error) {
 	return nil, nil

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -423,10 +423,6 @@ func (s *Server) lookupResourceHandler(uri string) (ResourceHandler, string, boo
 // Lexical path traversal attacks, where the path has ".." elements that escape dir,
 // are always caught. Go 1.24 and above also protects against symlink-based attacks,
 // where symlinks under dir lead out of the tree.
-func (s *Server) fileResourceHandler(dir string) ResourceHandler {
-	return fileResourceHandler(dir)
-}
-
 func fileResourceHandler(dir string) ResourceHandler {
 	// Convert dir to an absolute path.
 	dirFilepath, err := filepath.Abs(dir)


### PR DESCRIPTION
Remove a few functions that were flagged by gopls as unused. We can always add them back if necessary.