### PR TITLE
mcp/server: advertise completions only if installed

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -238,9 +238,7 @@ func (s *Server) capabilities() *serverCapabilities {
 	defer s.mu.Unlock()
 
 	caps := &serverCapabilities{
-		// TODO(samthanawalla): check for completionHandler before advertising capability.
-		Completions: &completionCapabilities{},
-		Logging:     &loggingCapabilities{},
+		Logging: &loggingCapabilities{},
 	}
 	if s.opts.HasTools || s.tools.len() > 0 {
 		caps.Tools = &toolCapabilities{ListChanged: true}
@@ -253,6 +251,9 @@ func (s *Server) capabilities() *serverCapabilities {
 		if s.opts.SubscribeHandler != nil {
 			caps.Resources.Subscribe = true
 		}
+	}
+	if s.opts.CompletionHandler != nil {
+		caps.Completions = &completionCapabilities{}
 	}
 	return caps
 }

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -242,8 +242,7 @@ func TestServerCapabilities(t *testing.T) {
 			name:            "No capabilities",
 			configureServer: func(s *Server) {},
 			wantCapabilities: &serverCapabilities{
-				Completions: &completionCapabilities{},
-				Logging:     &loggingCapabilities{},
+				Logging: &loggingCapabilities{},
 			},
 		},
 		{
@@ -252,9 +251,8 @@ func TestServerCapabilities(t *testing.T) {
 				s.AddPrompt(&Prompt{Name: "p"}, nil)
 			},
 			wantCapabilities: &serverCapabilities{
-				Completions: &completionCapabilities{},
-				Logging:     &loggingCapabilities{},
-				Prompts:     &promptCapabilities{ListChanged: true},
+				Logging: &loggingCapabilities{},
+				Prompts: &promptCapabilities{ListChanged: true},
 			},
 		},
 		{
@@ -263,9 +261,8 @@ func TestServerCapabilities(t *testing.T) {
 				s.AddResource(&Resource{URI: "file:///r"}, nil)
 			},
 			wantCapabilities: &serverCapabilities{
-				Completions: &completionCapabilities{},
-				Logging:     &loggingCapabilities{},
-				Resources:   &resourceCapabilities{ListChanged: true},
+				Logging:   &loggingCapabilities{},
+				Resources: &resourceCapabilities{ListChanged: true},
 			},
 		},
 		{
@@ -274,9 +271,8 @@ func TestServerCapabilities(t *testing.T) {
 				s.AddResourceTemplate(&ResourceTemplate{URITemplate: "file:///rt"}, nil)
 			},
 			wantCapabilities: &serverCapabilities{
-				Completions: &completionCapabilities{},
-				Logging:     &loggingCapabilities{},
-				Resources:   &resourceCapabilities{ListChanged: true},
+				Logging:   &loggingCapabilities{},
+				Resources: &resourceCapabilities{ListChanged: true},
 			},
 		},
 		{
@@ -293,9 +289,8 @@ func TestServerCapabilities(t *testing.T) {
 				},
 			},
 			wantCapabilities: &serverCapabilities{
-				Completions: &completionCapabilities{},
-				Logging:     &loggingCapabilities{},
-				Resources:   &resourceCapabilities{ListChanged: true, Subscribe: true},
+				Logging:   &loggingCapabilities{},
+				Resources: &resourceCapabilities{ListChanged: true, Subscribe: true},
 			},
 		},
 		{
@@ -304,9 +299,21 @@ func TestServerCapabilities(t *testing.T) {
 				s.AddTool(tool, nil)
 			},
 			wantCapabilities: &serverCapabilities{
-				Completions: &completionCapabilities{},
+				Logging: &loggingCapabilities{},
+				Tools:   &toolCapabilities{ListChanged: true},
+			},
+		},
+		{
+			name:            "With completions",
+			configureServer: func(s *Server) {},
+			serverOpts: ServerOptions{
+				CompletionHandler: func(ctx context.Context, ss *ServerSession, params *CompleteParams) (*CompleteResult, error) {
+					return nil, nil
+				},
+			},
+			wantCapabilities: &serverCapabilities{
 				Logging:     &loggingCapabilities{},
-				Tools:       &toolCapabilities{ListChanged: true},
+				Completions: &completionCapabilities{},
 			},
 		},
 		{
@@ -323,6 +330,9 @@ func TestServerCapabilities(t *testing.T) {
 				},
 				UnsubscribeHandler: func(ctx context.Context, up *UnsubscribeParams) error {
 					return nil
+				},
+				CompletionHandler: func(ctx context.Context, ss *ServerSession, params *CompleteParams) (*CompleteResult, error) {
+					return nil, nil
 				},
 			},
 			wantCapabilities: &serverCapabilities{
@@ -342,11 +352,10 @@ func TestServerCapabilities(t *testing.T) {
 				HasTools:     true,
 			},
 			wantCapabilities: &serverCapabilities{
-				Completions: &completionCapabilities{},
-				Logging:     &loggingCapabilities{},
-				Prompts:     &promptCapabilities{ListChanged: true},
-				Resources:   &resourceCapabilities{ListChanged: true},
-				Tools:       &toolCapabilities{ListChanged: true},
+				Logging:   &loggingCapabilities{},
+				Prompts:   &promptCapabilities{ListChanged: true},
+				Resources: &resourceCapabilities{ListChanged: true},
+				Tools:     &toolCapabilities{ListChanged: true},
 			},
 		},
 	}

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -314,9 +314,8 @@ func TestStreamableServerTransport(t *testing.T) {
 	initReq := req(1, methodInitialize, &InitializeParams{})
 	initResp := resp(1, &InitializeResult{
 		Capabilities: &serverCapabilities{
-			Completions: &completionCapabilities{},
-			Logging:     &loggingCapabilities{},
-			Tools:       &toolCapabilities{ListChanged: true},
+			Logging: &loggingCapabilities{},
+			Tools:   &toolCapabilities{ListChanged: true},
 		},
 		ProtocolVersion: latestProtocolVersion,
 		ServerInfo:      &Implementation{Name: "testServer", Version: "v1.0.0"},
@@ -732,9 +731,8 @@ func TestStreamableClientTransportApplicationJSON(t *testing.T) {
 	}
 	initResult := &InitializeResult{
 		Capabilities: &serverCapabilities{
-			Completions: &completionCapabilities{},
-			Logging:     &loggingCapabilities{},
-			Tools:       &toolCapabilities{ListChanged: true},
+			Logging: &loggingCapabilities{},
+			Tools:   &toolCapabilities{ListChanged: true},
 		},
 		ProtocolVersion: latestProtocolVersion,
 		ServerInfo:      &Implementation{Name: "testServer", Version: "v1.0.0"},

--- a/mcp/testdata/conformance/server/bad_requests.txtar
+++ b/mcp/testdata/conformance/server/bad_requests.txtar
@@ -41,7 +41,6 @@ code_review
 	"id": 2,
 	"result": {
 		"capabilities": {
-			"completions": {},
 			"logging": {},
 			"prompts": {
 				"listChanged": true

--- a/mcp/testdata/conformance/server/prompts.txtar
+++ b/mcp/testdata/conformance/server/prompts.txtar
@@ -25,7 +25,6 @@ code_review
 	"id": 1,
 	"result": {
 		"capabilities": {
-			"completions": {},
 			"logging": {},
 			"prompts": {
 				"listChanged": true

--- a/mcp/testdata/conformance/server/resources.txtar
+++ b/mcp/testdata/conformance/server/resources.txtar
@@ -45,7 +45,6 @@ info.txt
 	"id": 1,
 	"result": {
 		"capabilities": {
-			"completions": {},
 			"logging": {},
 			"resources": {
 				"listChanged": true

--- a/mcp/testdata/conformance/server/tools.txtar
+++ b/mcp/testdata/conformance/server/tools.txtar
@@ -28,7 +28,6 @@ greet
 	"id": 1,
 	"result": {
 		"capabilities": {
-			"completions": {},
 			"logging": {},
 			"tools": {
 				"listChanged": true

--- a/mcp/testdata/conformance/server/version-latest.txtar
+++ b/mcp/testdata/conformance/server/version-latest.txtar
@@ -18,7 +18,6 @@ response with its latest supported version.
 	"id": 1,
 	"result": {
 		"capabilities": {
-			"completions": {},
 			"logging": {}
 		},
 		"protocolVersion": "2025-06-18",

--- a/mcp/testdata/conformance/server/version-older.txtar
+++ b/mcp/testdata/conformance/server/version-older.txtar
@@ -18,7 +18,6 @@ support.
 	"id": 1,
 	"result": {
 		"capabilities": {
-			"completions": {},
 			"logging": {}
 		},
 		"protocolVersion": "2024-11-05",


### PR DESCRIPTION
Previously, completions would always be advertised as a capability even if the CompletionHandler was not installed by the server. This CL fixes that.
