### PR TITLE
add and implement SessionStorage interface

### DIFF
--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -65,6 +65,6 @@ func main() {
 		default:
 			return nil
 		}
-	})
+	}, nil)
 	log.Fatal(http.ListenAndServe(addr, handler))
 }

--- a/mcp/session_store.go
+++ b/mcp/session_store.go
@@ -1,0 +1,73 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"iter"
+	"sync"
+)
+
+// ServerSessionStore is a store of [Transport] sessions.
+//
+// The store must be thread-safe.
+type ServerSessionStore[T Transport] interface {
+	Get(id string) (T, error)
+	Set(id string, session T) error
+	Delete(id string) error
+	Reset() error
+	All() (iter.Seq[T], error)
+}
+
+// MemoryServerSessionStore is a simple in-memory implementation of
+// [ServerSessionStore].
+type MemoryServerSessionStore[T Transport] struct {
+	mu       sync.Mutex
+	sessions map[string]T
+}
+
+func NewMemoryServerSessionStore[T Transport]() *MemoryServerSessionStore[T] {
+	return &MemoryServerSessionStore[T]{
+		sessions: make(map[string]T),
+	}
+}
+
+func (s *MemoryServerSessionStore[T]) Get(id string) (T, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sessions[id], nil
+}
+
+func (s *MemoryServerSessionStore[T]) Set(id string, session T) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[id] = session
+	return nil
+}
+
+func (s *MemoryServerSessionStore[T]) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, id)
+	return nil
+}
+
+func (s *MemoryServerSessionStore[T]) All() (iter.Seq[T], error) {
+	return func(yield func(T) bool) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		for _, session := range s.sessions {
+			if !yield(session) {
+				return
+			}
+		}
+	}, nil
+}
+
+func (s *MemoryServerSessionStore[T]) Reset() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions = make(map[string]T)
+	return nil
+}

--- a/mcp/session_store_test.go
+++ b/mcp/session_store_test.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMemorySessionStorePersistence(t *testing.T) {
+	store := NewMemoryServerSessionStore[*SSEServerTransport]()
+
+	sessionID := "session-1"
+	rr := httptest.NewRecorder()
+	expectedSession := NewSSEServerTransport("endpoint-1", rr)
+	store.Set(sessionID, expectedSession)
+
+	actualSession, err := store.Get(sessionID)
+	if err != nil {
+		t.Error("unexpected session Get error", err)
+	}
+	if actualSession != expectedSession {
+		t.Errorf("wanted %s to be %v but got %v", sessionID, expectedSession, actualSession)
+	}
+
+	err = store.Delete(sessionID)
+	if err != nil {
+		t.Error("unexpected session Delete error", err)
+	}
+
+	actualSession, err = store.Get(sessionID)
+	if err != nil {
+		t.Error("unexpected session Get error", err)
+	}
+	if actualSession != nil {
+		t.Errorf("wanted %s to be nil but got %v", sessionID, actualSession)
+	}
+}

--- a/mcp/sse_example_test.go
+++ b/mcp/sse_example_test.go
@@ -30,7 +30,7 @@ func ExampleSSEHandler() {
 	server := mcp.NewServer(&mcp.Implementation{Name: "adder", Version: "v0.0.1"}, nil)
 	mcp.AddTool(server, &mcp.Tool{Name: "add", Description: "add two numbers"}, Add)
 
-	handler := mcp.NewSSEHandler(func(*http.Request) *mcp.Server { return server })
+	handler := mcp.NewSSEHandler(func(*http.Request) *mcp.Server { return server }, nil)
 	httpServer := httptest.NewServer(handler)
 	defer httpServer.Close()
 

--- a/mcp/sse_test.go
+++ b/mcp/sse_test.go
@@ -22,7 +22,7 @@ func TestSSEServer(t *testing.T) {
 			server := NewServer(testImpl, nil)
 			AddTool(server, &Tool{Name: "greet"}, sayHi)
 
-			sseHandler := NewSSEHandler(func(*http.Request) *Server { return server })
+			sseHandler := NewSSEHandler(func(*http.Request) *Server { return server }, nil)
 
 			conns := make(chan *ServerSession, 1)
 			sseHandler.onConnection = func(cc *ServerSession) {


### PR DESCRIPTION
This is a step toward enabling distributed MCP servers. It's a new interface that would allow additional types of session stores like:
- Database backed sessions
- Stateless sessions

This interface supports streamable HTTP, SSE, and custom Transports.

MemorySessionStore is the only current implementation. Other implementations are left to users for now.

This doesn't totally solve distributed MCP servers - routing messages between server instances still needs to be solved.

Related: #148, #212
