### PR TITLE
support http://json-schema.org/draft-07/schema#

### DIFF
--- a/jsonschema/doc.go
+++ b/jsonschema/doc.go
@@ -6,8 +6,8 @@
 Package jsonschema is an implementation of the [JSON Schema specification],
 a JSON-based format for describing the structure of JSON data.
 The package can be used to read schemas for code generation, and to validate
-data using the draft 2020-12 specification. Validation with other drafts
-or custom meta-schemas is not supported.
+data using the draft 2020-12 and draft-07 specifications. Validation with
+other drafts or custom meta-schemas is not supported.
 
 Construct a [Schema] as you would any Go struct (for example, by writing
 a struct literal), or unmarshal a JSON schema into a [Schema] in the usual


### PR DESCRIPTION
We can not connect to some MCP servers, such as mongodb and playwright, because we cannot validate against this draft.

```
panic: adding tool "switch-connection": cannot validate version http://json-schema.org/draft-07/schema#, 
only https://json-schema.org/draft/2020-12/schema
```

I heard from @jba that we will be moving this module out of the schema, but in the short term, the number of MCP servers that we can be limited.