### PR TITLE
server: support distributed sessions

### DIFF
--- a/mcp/logging.go
+++ b/mcp/logging.go
@@ -117,7 +117,7 @@ func (h *LoggingHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	// This is also checked in ServerSession.LoggingMessage, so checking it here
 	// is just an optimization that skips building the JSON.
 	h.ss.mu.Lock()
-	mcpLevel := h.ss.logLevel
+	mcpLevel := h.ss.state.LogLevel
 	h.ss.mu.Unlock()
 	return level >= mcpLevelToSlog(mcpLevel)
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -535,7 +535,7 @@ func (s *Server) Run(ctx context.Context, t Transport) error {
 // bind implements the binder[*ServerSession] interface, so that Servers can
 // be connected using [connect].
 func (s *Server) bind(conn *jsonrpc2.Connection) *ServerSession {
-	ss := &ServerSession{conn: conn, server: s}
+	ss := &ServerSession{conn: conn, server: s, state: &SessionState{}}
 	s.mu.Lock()
 	s.sessions = append(s.sessions, ss)
 	s.mu.Unlock()
@@ -596,25 +596,32 @@ func (ss *ServerSession) NotifyProgress(ctx context.Context, params *ProgressNot
 // Call [ServerSession.Close] to close the connection, or await client
 // termination with [ServerSession.Wait].
 type ServerSession struct {
-	server           *Server
-	conn             *jsonrpc2.Connection
-	mcpConn          Connection
-	mu               sync.Mutex
-	logLevel         LoggingLevel
-	initializeParams *InitializeParams
-	initialized      bool
-	keepaliveCancel  context.CancelFunc
+	server          *Server
+	conn            *jsonrpc2.Connection
+	mu              sync.Mutex
+	initialized     bool
+	keepaliveCancel context.CancelFunc
+
+	sessionID string
+	state     *SessionState
+	store     SessionStore
 }
 
 func (ss *ServerSession) setConn(c Connection) {
-	ss.mcpConn = c
 }
 
-func (ss *ServerSession) ID() string {
-	if ss.mcpConn == nil {
-		return ""
-	}
-	return ss.mcpConn.SessionID()
+func (ss *ServerSession) ID() string { return ss.sessionID }
+
+// InitSession initializes the session with a session ID, state, and store.
+// If called, it must be called immediately after the session is connected.
+// If never called, the session will begin with a zero SessionState and no session
+// ID or store.
+func (ss *ServerSession) InitSession(sessionID string, state *SessionState, store SessionStore) {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	ss.sessionID = sessionID
+	ss.state = state
+	ss.store = store
 }
 
 // Ping pings the client.
@@ -638,7 +645,7 @@ func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessag
 // is below that of the last SetLevel.
 func (ss *ServerSession) Log(ctx context.Context, params *LoggingMessageParams) error {
 	ss.mu.Lock()
-	logLevel := ss.logLevel
+	logLevel := ss.state.LogLevel
 	ss.mu.Unlock()
 	if logLevel == "" {
 		// The spec is unclear, but seems to imply that no log messages are sent until the client
@@ -752,8 +759,13 @@ func (ss *ServerSession) initialize(ctx context.Context, params *InitializeParam
 		return nil, fmt.Errorf("%w: \"params\" must be be provided", jsonrpc2.ErrInvalidParams)
 	}
 	ss.mu.Lock()
-	ss.initializeParams = params
+	ss.state.InitializeParams = params
 	ss.mu.Unlock()
+	if ss.store != nil {
+		if err := ss.store.Store(ctx, ss.sessionID, ss.state); err != nil {
+			return nil, fmt.Errorf("storing session state: %w", err)
+		}
+	}
 
 	// Mark the connection as initialized when this method exits.
 	// TODO: Technically, the server should not be considered initialized until it has
@@ -787,10 +799,15 @@ func (ss *ServerSession) ping(context.Context, *PingParams) (*emptyResult, error
 	return &emptyResult{}, nil
 }
 
-func (ss *ServerSession) setLevel(_ context.Context, params *SetLevelParams) (*emptyResult, error) {
+func (ss *ServerSession) setLevel(ctx context.Context, params *SetLevelParams) (*emptyResult, error) {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
-	ss.logLevel = params.Level
+	ss.state.LogLevel = params.Level
+	if ss.store != nil {
+		if err := ss.store.Store(ctx, ss.sessionID, ss.state); err != nil {
+			return nil, err
+		}
+	}
 	return &emptyResult{}, nil
 }
 

--- a/mcp/session.go
+++ b/mcp/session.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"io/fs"
+	"sync"
+)
+
+// SessionState is the state of a session.
+type SessionState struct {
+	// InitializeParams are the parameters from the initialize request.
+	InitializeParams *InitializeParams `json:"initializeParams"`
+
+	// LogLevel is the logging level for the session.
+	LogLevel LoggingLevel `json:"logLevel"`
+
+	// TODO: resource subscriptions
+}
+
+// SessionStore is an interface for storing and retrieving session state.
+type SessionStore interface {
+	// Load retrieves the session state for the given session ID.
+	// If there is none, it returns nil, fs.ErrNotExist.
+	Load(ctx context.Context, sessionID string) (*SessionState, error)
+	// Store saves the session state for the given session ID.
+	Store(ctx context.Context, sessionID string, state *SessionState) error
+	// Delete removes the session state for the given session ID.
+	Delete(ctx context.Context, sessionID string) error
+}
+
+// MemorySessionStore is an in-memory implementation of SessionStore.
+// It is safe for concurrent use.
+type MemorySessionStore struct {
+	mu    sync.Mutex
+	store map[string]*SessionState
+}
+
+// NewMemorySessionStore creates a new MemorySessionStore.
+func NewMemorySessionStore() *MemorySessionStore {
+	return &MemorySessionStore{
+		store: make(map[string]*SessionState),
+	}
+}
+
+// Load retrieves the session state for the given session ID.
+func (s *MemorySessionStore) Load(ctx context.Context, sessionID string) (*SessionState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.store[sessionID]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return state, nil
+}
+
+// Store saves the session state for the given session ID.
+func (s *MemorySessionStore) Store(ctx context.Context, sessionID string, state *SessionState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.store[sessionID] = state
+	return nil
+}
+
+// Delete removes the session state for the given session ID.
+func (s *MemorySessionStore) Delete(ctx context.Context, sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.store, sessionID)
+	return nil
+}

--- a/mcp/session_test.go
+++ b/mcp/session_test.go
@@ -1,0 +1,48 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+)
+
+func TestMemorySessionStore(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemorySessionStore()
+
+	sessionID := "test-session"
+	state := &SessionState{LogLevel: "debug"}
+
+	// Test Store and Load
+	if err := store.Store(ctx, sessionID, state); err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+
+	loadedState, err := store.Load(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loadedState == nil {
+		t.Fatal("Load() returned nil state")
+	}
+	if loadedState.LogLevel != state.LogLevel {
+		t.Errorf("Load() LogLevel = %v, want %v", loadedState.LogLevel, state.LogLevel)
+	}
+
+	// Test Delete
+	if err := store.Delete(ctx, sessionID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	deletedState, err := store.Load(ctx, sessionID)
+	if err != fs.ErrNotExist {
+		t.Fatalf("Load() after Delete(): got %v, want fs.ErrNotExist", err)
+	}
+	if deletedState != nil {
+		t.Error("Load() after Delete() returned non-nil state")
+	}
+}


### PR DESCRIPTION
- SessionState holds the state of a ServerSession.

- SessionStore allows arbitrary storage for SessionState.

- ServerSession.InitSession provides a session ID, store and state to a ServerSession.
