### PR TITLE
jsonschema: marshal to bools

### DIFF
--- a/jsonschema/schema_test.go
+++ b/jsonschema/schema_test.go
@@ -54,9 +54,9 @@ func TestJSONRoundTrip(t *testing.T) {
 	for _, tt := range []struct {
 		in, want string
 	}{
-		{`true`, `{}`}, // boolean schemas become object schemas
-		{`false`, `{"not":{}}`},
-		{`{"type":"", "enum":null}`, `{}`}, // empty fields are omitted
+		{`true`, `true`},
+		{`false`, `false`},
+		{`{"type":"", "enum":null}`, `true`}, // empty fields are omitted
 		{`{"minimum":1}`, `{"minimum":1}`},
 		{`{"minimum":1.0}`, `{"minimum":1}`},     // floating-point integers lose their fractional part
 		{`{"minLength":1.0}`, `{"minLength":1}`}, // some floats are unmarshaled into ints, but you can't tell

--- a/mcp/testdata/conformance/server/tools.txtar
+++ b/mcp/testdata/conformance/server/tools.txtar
@@ -59,9 +59,7 @@ greet
 							"type": "string"
 						}
 					},
-					"additionalProperties": {
-						"not": {}
-					}
+					"additionalProperties": false
 				},
 				"name": "greet"
 			}


### PR DESCRIPTION
Marshal the empty schema to true, and its negation to false.

This is technically a breaking behavior change, but a properly written consumer of JSON Schema will not notice.

For #244.

Fixes #230.
