### PR TITLE
jsonschema: copy wrapf into jsonschema/util.go

### DIFF
--- a/jsonschema/json_pointer.go
+++ b/jsonschema/json_pointer.go
@@ -26,8 +26,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-
-	"github.com/modelcontextprotocol/go-sdk/internal/util"
 )
 
 var (
@@ -71,7 +69,7 @@ func parseJSONPointer(ptr string) (segments []string, err error) {
 // This implementation suffices for JSON Schema: pointers are applied only to Schemas,
 // and refer only to Schemas.
 func dereferenceJSONPointer(s *Schema, sptr string) (_ *Schema, err error) {
-	defer util.Wrapf(&err, "JSON Pointer %q", sptr)
+	defer wrapf(&err, "JSON Pointer %q", sptr)
 
 	segments, err := parseJSONPointer(sptr)
 	if err != nil {

--- a/jsonschema/util.go
+++ b/jsonschema/util.go
@@ -454,3 +454,10 @@ func fieldJSONInfo(f reflect.StructField) jsonInfo {
 	}
 	return info
 }
+
+// wrapf wraps *errp with the given formatted message if *errp is not nil.
+func wrapf(errp *error, format string, args ...any) {
+	if *errp != nil {
+		*errp = fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), *errp)
+	}
+}

--- a/jsonschema/validate.go
+++ b/jsonschema/validate.go
@@ -16,8 +16,6 @@ import (
 	"strings"
 	"sync"
 	"unicode/utf8"
-
-	"github.com/modelcontextprotocol/go-sdk/internal/util"
 )
 
 // The value of the "$schema" keyword for the version that we can validate.
@@ -74,7 +72,7 @@ type state struct {
 
 // validate validates the reflected value of the instance.
 func (st *state) validate(instance reflect.Value, schema *Schema, callerAnns *annotations) (err error) {
-	defer util.Wrapf(&err, "validating %s", st.rs.schemaString(schema))
+	defer wrapf(&err, "validating %s", st.rs.schemaString(schema))
 
 	// Maintain a stack for dynamic schema resolution.
 	st.stack = append(st.stack, schema) // push
@@ -613,7 +611,7 @@ func (rs *Resolved) ApplyDefaults(instancep any) error {
 // Leave this as a potentially recursive helper function, because we'll surely want
 // to apply defaults on sub-schemas someday.
 func (st *state) applyDefaults(instancep reflect.Value, schema *Schema) (err error) {
-	defer util.Wrapf(&err, "applyDefaults: schema %s, instance %v", st.rs.schemaString(schema), instancep)
+	defer wrapf(&err, "applyDefaults: schema %s, instance %v", st.rs.schemaString(schema), instancep)
 
 	schemaInfo := st.rs.resolvedInfos[schema]
 	instance := instancep.Elem()


### PR DESCRIPTION
jsonschema depends on wrapf in mcp/util.go, copy this into jsonschema for the code move.