### PR TITLE
mcp: refactor streamable serving and support JSON responses

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -134,8 +134,8 @@ func (c *Client) Connect(ctx context.Context, t Transport) (cs *ClientSession, e
 		return nil, unsupportedProtocolVersionError{res.ProtocolVersion}
 	}
 	cs.initializeResult = res
-	if hc, ok := cs.mcpConn.(httpConnection); ok {
-		hc.setProtocolVersion(res.ProtocolVersion)
+	if hc, ok := cs.mcpConn.(clientConnection); ok {
+		hc.initialized(res)
 	}
 	if err := handleNotify(ctx, cs, notificationInitialized, &InitializedParams{}); err != nil {
 		_ = cs.Close()

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -250,7 +250,7 @@ func (c *Client) listRoots(_ context.Context, _ *ClientSession, _ *ListRootsPara
 func (c *Client) createMessage(ctx context.Context, cs *ClientSession, params *CreateMessageParams) (*CreateMessageResult, error) {
 	if c.opts.CreateMessageHandler == nil {
 		// TODO: wrap or annotate this error? Pick a standard code?
-		return nil, &jsonrpc2.WireError{Code: CodeUnsupportedMethod, Message: "client does not support CreateMessage"}
+		return nil, jsonrpc2.NewError(CodeUnsupportedMethod, "client does not support CreateMessage")
 	}
 	return c.opts.CreateMessageHandler(ctx, cs, params)
 }

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -275,6 +275,8 @@ func sessionMethod[S Session, P Params, R Result](f func(S, context.Context, P) 
 
 // Error codes
 const (
+	// TODO: should these be unexported?
+
 	CodeResourceNotFound = -32002
 	// The error code if the method exists and was called properly, but the peer does not support it.
 	CodeUnsupportedMethod = -31001

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -79,7 +79,7 @@ func TestStreamableTransports(t *testing.T) {
 	if sid == "" {
 		t.Error("empty session ID")
 	}
-	if g, w := session.mcpConn.(*streamableClientConn).protocolVersion, latestProtocolVersion; g != w {
+	if g, w := session.mcpConn.(*streamableClientConn).initializedResult.ProtocolVersion, latestProtocolVersion; g != w {
 		t.Fatalf("got protocol version %q, want %q", g, w)
 	}
 	// 4. The client calls the "greet" tool.

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -60,10 +60,11 @@ type Connection interface {
 	SessionID() string
 }
 
-// An httpConnection is a [Connection] that runs over HTTP.
-type httpConnection interface {
+// A clientConnection is a [Connection] that is specific to the MCP client, and
+// so may receive information about the client session.
+type clientConnection interface {
 	Connection
-	setProtocolVersion(string)
+	initialized(*InitializeResult)
 }
 
 // A StdioTransport is a [Transport] that communicates over stdin/stdout using


### PR DESCRIPTION
Add support for JSON responses in the streamable HTTP server, and simplify the streamable client. See commit messages for details.

Fixes https://github.com/modelcontextprotocol/go-sdk/issues/211