### PR TITLE
mcp: simplify ServerSession.initialize

### DIFF
--- a/mcp/testdata/conformance/server/bad_requests.txtar
+++ b/mcp/testdata/conformance/server/bad_requests.txtar
@@ -38,11 +38,12 @@ code_review
     "clientInfo": { "name": "ExampleClient", "version": "1.0.0" }
   }
 }
-{"jsonrpc":"2.0", "id": 3, "method": "notifications/initialized"}
-{"jsonrpc":"2.0", "method":"ping"}
-{"jsonrpc":"2.0", "id": 4, "method": "logging/setLevel"}
-{"jsonrpc":"2.0", "id": 5, "method": "completion/complete"}
-{"jsonrpc":"2.0", "id": 4, "method": "logging/setLevel", "params": null}
+{ "jsonrpc":"2.0", "id": 3, "method": "notifications/initialized" }
+{ "jsonrpc":"2.0", "method": "notifications/initialized" }
+{ "jsonrpc":"2.0", "method":"ping" }
+{ "jsonrpc":"2.0", "id": 4, "method": "logging/setLevel" }
+{ "jsonrpc":"2.0", "id": 5, "method": "completion/complete" }
+{ "jsonrpc":"2.0", "id": 4, "method": "logging/setLevel", "params": null }
 
 -- server --
 {

--- a/mcp/testdata/conformance/server/lifecycle.txtar
+++ b/mcp/testdata/conformance/server/lifecycle.txtar
@@ -1,0 +1,57 @@
+This test checks that the server obeys the rules for initialization lifecycle,
+and rejects non-ping requests until 'initialized' is received.
+
+See also modelcontextprotocol/go-sdk#225.
+
+-- client --
+{ "jsonrpc":"2.0", "method": "notifications/initialized" }
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": { "name": "ExampleClient", "version": "1.0.0" }
+  }
+}
+{ "jsonrpc":"2.0", "id": 1, "method":"ping" }
+{ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }
+{ "jsonrpc":"2.0", "method": "notifications/initialized" }
+{ "jsonrpc": "2.0", "id": 3, "method": "tools/list" }
+
+-- server --
+{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"result": {
+		"capabilities": {
+			"logging": {}
+		},
+		"protocolVersion": "2024-11-05",
+		"serverInfo": {
+			"name": "testServer",
+			"version": "v1.0.0"
+		}
+	}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"result": {}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 2,
+	"error": {
+		"code": 0,
+		"message": "method \"tools/list\" is invalid during session initialization"
+	}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 3,
+	"result": {
+		"tools": []
+	}
+}

--- a/mcp/testdata/conformance/server/prompts.txtar
+++ b/mcp/testdata/conformance/server/prompts.txtar
@@ -18,9 +18,11 @@ code_review
     "clientInfo": { "name": "ExampleClient", "version": "1.0.0" }
   }
 }
+{ "jsonrpc":"2.0", "method": "notifications/initialized" }
 { "jsonrpc": "2.0", "id": 2, "method": "tools/list" }
 { "jsonrpc": "2.0", "id": 4, "method": "prompts/list" }
 { "jsonrpc": "2.0", "id": 5, "method": "prompts/get" }
+
 -- server --
 {
 	"jsonrpc": "2.0",

--- a/mcp/testdata/conformance/server/resources.txtar
+++ b/mcp/testdata/conformance/server/resources.txtar
@@ -21,6 +21,7 @@ info.txt
     "clientInfo": { "name": "ExampleClient", "version": "1.0.0" }
   }
 }
+{ "jsonrpc":"2.0", "method": "notifications/initialized" }
 { "jsonrpc": "2.0", "id": 2, "method": "resources/list" }
 {
   "jsonrpc": "2.0", "id": 3,

--- a/mcp/testdata/conformance/server/tools.txtar
+++ b/mcp/testdata/conformance/server/tools.txtar
@@ -20,6 +20,7 @@ greet
     "clientInfo": { "name": "ExampleClient", "version": "1.0.0" }
   }
 }
+{"jsonrpc":"2.0", "method": "notifications/initialized"}
 { "jsonrpc": "2.0", "id": 2, "method": "tools/list" }
 { "jsonrpc": "2.0", "id": 3, "method": "resources/list" }
 { "jsonrpc": "2.0", "id": 4, "method": "prompts/list" }


### PR DESCRIPTION
First, make the simplifications described in #222. I don't know why we originally had such fine granularity of locking: perhaps we were going to execute 'oninitialized' callbacks.

Then actually fix the 'initialized' condition, by not setting the session as initialized until 'notifications/initialized' is actually received

Fixes #222
Fixes #225