### PR TITLE
mcp: rename mcp{Params,Result} to is{Params,Result}

### DIFF
--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -78,7 +78,7 @@ type CallToolResultFor[Out any] struct {
 	IsError bool `json:"isError,omitempty"`
 }
 
-func (*CallToolResultFor[Out]) mcpResult() {}
+func (*CallToolResultFor[Out]) isResult() {}
 
 // UnmarshalJSON handles the unmarshalling of content into the Content
 // interface.
@@ -99,7 +99,7 @@ func (x *CallToolResultFor[Out]) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (x *CallToolParamsFor[Out]) mcpParams()             {}
+func (x *CallToolParamsFor[Out]) isParams()              {}
 func (x *CallToolParamsFor[Out]) GetProgressToken() any  { return getProgressToken(x) }
 func (x *CallToolParamsFor[Out]) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -117,7 +117,7 @@ type CancelledParams struct {
 	RequestID any `json:"requestId"`
 }
 
-func (x *CancelledParams) mcpParams()             {}
+func (x *CancelledParams) isParams()              {}
 func (x *CancelledParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *CancelledParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -211,7 +211,7 @@ type CompleteParams struct {
 	Ref      *CompleteReference     `json:"ref"`
 }
 
-func (*CompleteParams) mcpParams() {}
+func (*CompleteParams) isParams() {}
 
 type CompletionResultDetails struct {
 	HasMore bool     `json:"hasMore,omitempty"`
@@ -227,7 +227,7 @@ type CompleteResult struct {
 	Completion CompletionResultDetails `json:"completion"`
 }
 
-func (*CompleteResult) mcpResult() {}
+func (*CompleteResult) isResult() {}
 
 type CreateMessageParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
@@ -253,7 +253,7 @@ type CreateMessageParams struct {
 	Temperature  float64 `json:"temperature,omitempty"`
 }
 
-func (x *CreateMessageParams) mcpParams()             {}
+func (x *CreateMessageParams) isParams()              {}
 func (x *CreateMessageParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *CreateMessageParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -273,7 +273,7 @@ type CreateMessageResult struct {
 	StopReason string `json:"stopReason,omitempty"`
 }
 
-func (*CreateMessageResult) mcpResult() {}
+func (*CreateMessageResult) isResult() {}
 func (r *CreateMessageResult) UnmarshalJSON(data []byte) error {
 	type result CreateMessageResult // avoid recursion
 	var wire struct {
@@ -301,7 +301,7 @@ type GetPromptParams struct {
 	Name string `json:"name"`
 }
 
-func (x *GetPromptParams) mcpParams()             {}
+func (x *GetPromptParams) isParams()              {}
 func (x *GetPromptParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *GetPromptParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -315,7 +315,7 @@ type GetPromptResult struct {
 	Messages    []*PromptMessage `json:"messages"`
 }
 
-func (*GetPromptResult) mcpResult() {}
+func (*GetPromptResult) isResult() {}
 
 type InitializeParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
@@ -328,7 +328,7 @@ type InitializeParams struct {
 	ProtocolVersion string `json:"protocolVersion"`
 }
 
-func (x *InitializeParams) mcpParams()             {}
+func (x *InitializeParams) isParams()              {}
 func (x *InitializeParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *InitializeParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -352,7 +352,7 @@ type InitializeResult struct {
 	ServerInfo      *Implementation `json:"serverInfo"`
 }
 
-func (*InitializeResult) mcpResult() {}
+func (*InitializeResult) isResult() {}
 
 type InitializedParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
@@ -360,7 +360,7 @@ type InitializedParams struct {
 	Meta `json:"_meta,omitempty"`
 }
 
-func (x *InitializedParams) mcpParams()             {}
+func (x *InitializedParams) isParams()              {}
 func (x *InitializedParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *InitializedParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -373,7 +373,7 @@ type ListPromptsParams struct {
 	Cursor string `json:"cursor,omitempty"`
 }
 
-func (x *ListPromptsParams) mcpParams()             {}
+func (x *ListPromptsParams) isParams()              {}
 func (x *ListPromptsParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *ListPromptsParams) SetProgressToken(t any) { setProgressToken(x, t) }
 func (x *ListPromptsParams) cursorPtr() *string     { return &x.Cursor }
@@ -389,7 +389,7 @@ type ListPromptsResult struct {
 	Prompts    []*Prompt `json:"prompts"`
 }
 
-func (x *ListPromptsResult) mcpResult()             {}
+func (x *ListPromptsResult) isResult()              {}
 func (x *ListPromptsResult) nextCursorPtr() *string { return &x.NextCursor }
 
 type ListResourceTemplatesParams struct {
@@ -401,7 +401,7 @@ type ListResourceTemplatesParams struct {
 	Cursor string `json:"cursor,omitempty"`
 }
 
-func (x *ListResourceTemplatesParams) mcpParams()             {}
+func (x *ListResourceTemplatesParams) isParams()              {}
 func (x *ListResourceTemplatesParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *ListResourceTemplatesParams) SetProgressToken(t any) { setProgressToken(x, t) }
 func (x *ListResourceTemplatesParams) cursorPtr() *string     { return &x.Cursor }
@@ -417,7 +417,7 @@ type ListResourceTemplatesResult struct {
 	ResourceTemplates []*ResourceTemplate `json:"resourceTemplates"`
 }
 
-func (x *ListResourceTemplatesResult) mcpResult()             {}
+func (x *ListResourceTemplatesResult) isResult()              {}
 func (x *ListResourceTemplatesResult) nextCursorPtr() *string { return &x.NextCursor }
 
 type ListResourcesParams struct {
@@ -429,7 +429,7 @@ type ListResourcesParams struct {
 	Cursor string `json:"cursor,omitempty"`
 }
 
-func (x *ListResourcesParams) mcpParams()             {}
+func (x *ListResourcesParams) isParams()              {}
 func (x *ListResourcesParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *ListResourcesParams) SetProgressToken(t any) { setProgressToken(x, t) }
 func (x *ListResourcesParams) cursorPtr() *string     { return &x.Cursor }
@@ -445,7 +445,7 @@ type ListResourcesResult struct {
 	Resources  []*Resource `json:"resources"`
 }
 
-func (x *ListResourcesResult) mcpResult()             {}
+func (x *ListResourcesResult) isResult()              {}
 func (x *ListResourcesResult) nextCursorPtr() *string { return &x.NextCursor }
 
 type ListRootsParams struct {
@@ -454,7 +454,7 @@ type ListRootsParams struct {
 	Meta `json:"_meta,omitempty"`
 }
 
-func (x *ListRootsParams) mcpParams()             {}
+func (x *ListRootsParams) isParams()              {}
 func (x *ListRootsParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *ListRootsParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -468,7 +468,7 @@ type ListRootsResult struct {
 	Roots []*Root `json:"roots"`
 }
 
-func (*ListRootsResult) mcpResult() {}
+func (*ListRootsResult) isResult() {}
 
 type ListToolsParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
@@ -479,7 +479,7 @@ type ListToolsParams struct {
 	Cursor string `json:"cursor,omitempty"`
 }
 
-func (x *ListToolsParams) mcpParams()             {}
+func (x *ListToolsParams) isParams()              {}
 func (x *ListToolsParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *ListToolsParams) SetProgressToken(t any) { setProgressToken(x, t) }
 func (x *ListToolsParams) cursorPtr() *string     { return &x.Cursor }
@@ -495,7 +495,7 @@ type ListToolsResult struct {
 	Tools      []*Tool `json:"tools"`
 }
 
-func (x *ListToolsResult) mcpResult()             {}
+func (x *ListToolsResult) isResult()              {}
 func (x *ListToolsResult) nextCursorPtr() *string { return &x.NextCursor }
 
 // The severity of a log message.
@@ -517,7 +517,7 @@ type LoggingMessageParams struct {
 	Logger string `json:"logger,omitempty"`
 }
 
-func (x *LoggingMessageParams) mcpParams()             {}
+func (x *LoggingMessageParams) isParams()              {}
 func (x *LoggingMessageParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *LoggingMessageParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -579,7 +579,7 @@ type PingParams struct {
 	Meta `json:"_meta,omitempty"`
 }
 
-func (x *PingParams) mcpParams()             {}
+func (x *PingParams) isParams()              {}
 func (x *PingParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *PingParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -599,7 +599,7 @@ type ProgressNotificationParams struct {
 	Total float64 `json:"total,omitempty"`
 }
 
-func (*ProgressNotificationParams) mcpParams() {}
+func (*ProgressNotificationParams) isParams() {}
 
 // A prompt or prompt template that the server offers.
 type Prompt struct {
@@ -638,7 +638,7 @@ type PromptListChangedParams struct {
 	Meta `json:"_meta,omitempty"`
 }
 
-func (x *PromptListChangedParams) mcpParams()             {}
+func (x *PromptListChangedParams) isParams()              {}
 func (x *PromptListChangedParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *PromptListChangedParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -679,7 +679,7 @@ type ReadResourceParams struct {
 	URI string `json:"uri"`
 }
 
-func (x *ReadResourceParams) mcpParams()             {}
+func (x *ReadResourceParams) isParams()              {}
 func (x *ReadResourceParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *ReadResourceParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -691,7 +691,7 @@ type ReadResourceResult struct {
 	Contents []*ResourceContents `json:"contents"`
 }
 
-func (*ReadResourceResult) mcpResult() {}
+func (*ReadResourceResult) isResult() {}
 
 // A known resource that the server is capable of reading.
 type Resource struct {
@@ -733,7 +733,7 @@ type ResourceListChangedParams struct {
 	Meta `json:"_meta,omitempty"`
 }
 
-func (x *ResourceListChangedParams) mcpParams()             {}
+func (x *ResourceListChangedParams) isParams()              {}
 func (x *ResourceListChangedParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *ResourceListChangedParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -791,7 +791,7 @@ type RootsListChangedParams struct {
 	Meta `json:"_meta,omitempty"`
 }
 
-func (x *RootsListChangedParams) mcpParams()             {}
+func (x *RootsListChangedParams) isParams()              {}
 func (x *RootsListChangedParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *RootsListChangedParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -836,7 +836,7 @@ type SetLevelParams struct {
 	Level LoggingLevel `json:"level"`
 }
 
-func (x *SetLevelParams) mcpParams()             {}
+func (x *SetLevelParams) isParams()              {}
 func (x *SetLevelParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *SetLevelParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -912,7 +912,7 @@ type ToolListChangedParams struct {
 	Meta `json:"_meta,omitempty"`
 }
 
-func (x *ToolListChangedParams) mcpParams()             {}
+func (x *ToolListChangedParams) isParams()              {}
 func (x *ToolListChangedParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *ToolListChangedParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
@@ -926,7 +926,7 @@ type SubscribeParams struct {
 	URI string `json:"uri"`
 }
 
-func (*SubscribeParams) mcpParams() {}
+func (*SubscribeParams) isParams() {}
 
 // Sent from the client to request cancellation of resources/updated
 // notifications from the server. This should follow a previous
@@ -939,7 +939,7 @@ type UnsubscribeParams struct {
 	URI string `json:"uri"`
 }
 
-func (*UnsubscribeParams) mcpParams() {}
+func (*UnsubscribeParams) isParams() {}
 
 // A notification from the server to the client, informing it that a resource
 // has changed and may need to be read again. This should only be sent if the
@@ -952,7 +952,7 @@ type ResourceUpdatedNotificationParams struct {
 	URI string `json:"uri"`
 }
 
-func (*ResourceUpdatedNotificationParams) mcpParams() {}
+func (*ResourceUpdatedNotificationParams) isParams() {}
 
 // TODO(jba): add CompleteRequest and related types.
 

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -337,8 +337,8 @@ func setProgressToken(p Params, pt any) {
 
 // Params is a parameter (input) type for an MCP call or notification.
 type Params interface {
-	// mcpParams discourages implementation of Params outside of this package.
-	mcpParams()
+	// isParams discourages implementation of Params outside of this package.
+	isParams()
 
 	// GetMeta returns metadata from a value.
 	GetMeta() map[string]any
@@ -361,8 +361,8 @@ type RequestParams interface {
 
 // Result is a result of an MCP call.
 type Result interface {
-	// mcpResult discourages implementation of Result outside of this package.
-	mcpResult()
+	// isResult discourages implementation of Result outside of this package.
+	isResult()
 
 	// GetMeta returns metadata from a value.
 	GetMeta() map[string]any
@@ -374,7 +374,7 @@ type Result interface {
 // Those methods cannot return nil, because jsonrpc2 cannot handle nils.
 type emptyResult struct{}
 
-func (*emptyResult) mcpResult()              {}
+func (*emptyResult) isResult()               {}
 func (*emptyResult) GetMeta() map[string]any { panic("should never be called") }
 func (*emptyResult) SetMeta(map[string]any)  { panic("should never be called") }
 


### PR DESCRIPTION
For some reason, when making these marker methods, the standard naming convention escaped me.
