### PR TITLE
.github: update go 1.25 builds to rc3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.23', '1.24', '1.25.0-rc.2' ]
+        go: [ '1.23', '1.24', '1.25.0-rc.3' ]
     steps:
     - name: Check out code
       uses: actions/checkout@v4


### PR DESCRIPTION
Now that rc3 is out, update our 1.25 builds to use it.