### PR TITLE
jsonrpc: paper over race in jsonrpc2 test

### DIFF
--- a/internal/jsonrpc2/jsonrpc2_test.go
+++ b/internal/jsonrpc2/jsonrpc2_test.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 )
@@ -143,6 +144,8 @@ func testConnection(t *testing.T, framer jsonrpc2.Framer) {
 		t.Run(test.Name(), func(t *testing.T) {
 			client, err := jsonrpc2.Dial(ctx,
 				listener.Dialer(), binder{framer, func(h *handler) {
+					// Sleep a little to a void a race with setting conn.writer in jsonrpc2.bindConnection.
+					time.Sleep(50 * time.Millisecond)
 					defer h.conn.Close()
 					test.Invoke(t, ctx, h)
 					if call, ok := test.(*call); ok {


### PR DESCRIPTION
In jsonprc2_test.go, binder.Bind starts a goroutine. That goroutine begins to run during jsonrpc2.bindConnection, and can race with the setting of conn.write in bindConnection.

This PR adds a sleep, which is a poor way to deal with the race, but the least invasive change. Better ones include running the test function after Dial returns, or adding a Connection.Ready method to detect when initialization is complete.