### PR TITLE
Add .gitignore for Go, VSCode, JetBrains and dev tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,38 @@
-# Binaries
+# Builds
 *.exe
 *.exe~
+dist/
+build/
+bin/
+*.tmp
 
 # IDE files
 .vscode/
 *.code-workspace
+.idea/
+*~
 
-# Profiling files
+# Go Specific
 *.prof
 *.pprof
+*.out
+*.coverage
+coverage.txt
+coverage.html
+
+# OS generated files
+# macOS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Windows
+Desktop.ini
+$RECYCLE.BIN/
+
+# Linux
+.nfs*


### PR DESCRIPTION
Adds comprehensive `.gitignore` to exclude Go build artifacts, test files, IDE configurations, and OS-specific files from Git