### PR TITLE
mcp: pass TokenInfo to server handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ type HiParams struct {
 	Name string `json:"name" jsonschema:"the name of the person to greet"`
 }
 
-func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[HiParams]) (*mcp.CallToolResultFor[any], error) {
+func SayHi(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[HiParams]]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + params.Arguments.Name}},
+		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + req.Params.Arguments.Name}},
 	}, nil
 }
 

--- a/design/design.md
+++ b/design/design.md
@@ -431,12 +431,9 @@ We provide a mechanism to add MCP-level middleware on the both the client and se
 
 ```go
 // A MethodHandler handles MCP messages.
-// The params argument is an XXXParams struct pointer, such as *GetPromptParams.
-// For methods, a MethodHandler must return either an XXResult struct pointer and a nil error, or
-// nil with a non-nil error.
-// For notifications, a MethodHandler must return nil, nil.
-type MethodHandler[S Session] func(
-	ctx context.Context, _ *S, method string, params Params) (result Result, err error)
+// For methods, exactly one of the return values must be nil.
+// For notifications, both must be nil.
+type MethodHandler[S Session] func(ctx context.Context, method string, req *Request[S]) (result Result, err error)
 
 // Middleware is a function from MethodHandlers to MethodHandlers.
 type Middleware[S Session] func(MethodHandler[S]) MethodHandler[S]
@@ -620,8 +617,9 @@ type Tool struct {
 	Name string                    `json:"name"`
 }
 
-type ToolHandlerFor[In, Out any] func(context.Context, *ServerSession, *CallToolParamsFor[In]) (*CallToolResultFor[Out], error)
-type ToolHandler = ToolHandlerFor[map[string]any, any]
+// A ToolHandlerFor handles a call to tools/call with typed arguments and results.
+type ToolHandlerFor[In, Out any] func(context.Context, *ServerRequest[*CallToolParamsFor[In]]) (*CallToolResultFor[Out], error)
+
 ```
 
 Add tools to a server with the `AddTool` method or function. The function is generic and infers schemas from the handler
@@ -671,8 +669,8 @@ type AddParams struct {
     Y int `json:"y"`
 }
 
-func addHandler(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[AddParams]) (*mcp.CallToolResultFor[int], error) {
-    return &mcp.CallToolResultFor[int]{StructuredContent: params.Arguments.X + params.Arguments.Y}, nil
+func addHandler(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[AddParams]]) (*mcp.CallToolResultFor[int], error) {
+    return &mcp.CallToolResultFor[int]{StructuredContent: req.Params.Arguments.X + req.Params.Arguments.Y}, nil
 }
 ```
 
@@ -688,8 +686,6 @@ Client sessions can call the spec method `ListTools` or an iterator method `Tool
 
 ```go
 func (cs *ClientSession) CallTool(context.Context, *CallToolParams[json.RawMessage]) (*CallToolResult, error)
-
-func CallTool[TArgs any](context.Context, *ClientSession, *CallToolParams[TArgs]) (*CallToolResult, error)
 ```
 
 **Differences from mcp-go**: We provide a full JSON Schema implementation for validating tool input schemas against incoming arguments. The `jsonschema.Schema` type provides exported features for all keywords in the JSON Schema draft2020-12 spec. Tool definers can use it to construct any schema they want. The `jsonschema.For[T]` function can infer a schema from a Go struct. These combined features eliminate the need for variadic arguments to construct tool schemas.
@@ -775,10 +771,10 @@ If a server author wants to support resource subscriptions, they must provide ha
 ```go
 type ServerOptions struct {
   ...
-  // Function called when a client session subscribes to a resource.
-  SubscribeHandler func(context.Context, ss *ServerSession, *SubscribeParams) error
-  // Function called when a client session unsubscribes from a resource.
-  UnsubscribeHandler func(context.Context, ss *ServerSession, *UnsubscribeParams) error
+	// Function called when a client session subscribes to a resource.
+	SubscribeHandler func(context.Context, *ServerRequest[*SubscribeParams]) error
+	// Function called when a client session unsubscribes from a resource.
+	UnsubscribeHandler func(context.Context, *ServerRequest[*UnsubscribeParams]) error
 }
 ```
 
@@ -797,10 +793,10 @@ When a list of tools, prompts or resources changes as the result of an AddXXX or
 ```go
 type ClientOptions struct {
   ...
-  ToolListChangedHandler func(context.Context, *ClientSession, *ToolListChangedParams)
-  PromptListChangedHandler func(context.Context, *ClientSession, *PromptListChangedParams)
+	ToolListChangedHandler      func(context.Context, *ClientRequest[*ToolListChangedParams])
+	PromptListChangedHandler    func(context.Context, *ClientRequest[*PromptListChangedParams])
   // For both resources and resource templates.
-  ResourceListChangedHandler func(context.Context, *ClientSession, *ResourceListChangedParams)
+	ResourceListChangedHandler  func(context.Context, *ClientRequest[*ResourceListChangedParams])
 }
 ```
 
@@ -811,13 +807,10 @@ type ClientOptions struct {
 Clients call the spec method `Complete` to request completions. If a server installs a `CompletionHandler`, it will be called when the client sends a completion request.
 
 ```go
-// A CompletionHandler handles a call to completion/complete.
-type CompletionHandler func(context.Context, *ServerSession, *CompleteParams) (*CompleteResult, error)
-
 type ServerOptions struct {
   ...
   // If non-nil, called when a client sends a completion request.
-  CompletionHandler CompletionHandler
+	CompletionHandler func(context.Context, *ServerRequest[*CompleteParams]) (*CompleteResult, error)
 }
 ```
 

--- a/design/design.md
+++ b/design/design.md
@@ -433,10 +433,10 @@ We provide a mechanism to add MCP-level middleware on the both the client and se
 // A MethodHandler handles MCP messages.
 // For methods, exactly one of the return values must be nil.
 // For notifications, both must be nil.
-type MethodHandler[S Session] func(ctx context.Context, method string, req *Request[S]) (result Result, err error)
+type MethodHandler func(ctx context.Context, method string, req Request) (result Result, err error)
 
 // Middleware is a function from MethodHandlers to MethodHandlers.
-type Middleware[S Session] func(MethodHandler[S]) MethodHandler[S]
+type Middleware func(MethodHandler) MethodHandler
 
 // AddMiddleware wraps the client/server's current method handler using the provided
 // middleware. Middleware is applied from right to left, so that the first one
@@ -444,17 +444,17 @@ type Middleware[S Session] func(MethodHandler[S]) MethodHandler[S]
 //
 // For example, AddMiddleware(m1, m2, m3) augments the server method handler as
 // m1(m2(m3(handler))).
-func (c *Client) AddSendingMiddleware(middleware ...Middleware[*ClientSession])
-func (c *Client) AddReceivingMiddleware(middleware ...Middleware[*ClientSession])
-func (s *Server) AddSendingMiddleware(middleware ...Middleware[*ServerSession])
-func (s *Server) AddReceivingMiddleware(middleware ...Middleware[*ServerSession])
+func (c *Client) AddSendingMiddleware(middleware ...Middleware)
+func (c *Client) AddReceivingMiddleware(middleware ...Middleware)
+func (s *Server) AddSendingMiddleware(middleware ...Middleware)
+func (s *Server) AddReceivingMiddleware(middleware ...Middleware)
 ```
 
 As an example, this code adds server-side logging:
 
 ```go
-func withLogging(h mcp.MethodHandler[*mcp.ServerSession]) mcp.MethodHandler[*mcp.ServerSession]{
-    return func(ctx context.Context, s *mcp.ServerSession, method string, params mcp.Params) (res mcp.Result, err error) {
+func withLogging(h mcp.MethodHandler) mcp.MethodHandler{
+    return func(ctx context.Context, method string, req mcp.Request) (res mcp.Result, err error) {
         log.Printf("request: %s %v", method, params)
         defer func() { log.Printf("response: %v, %v", res, err) }()
         return h(ctx, s , method, params)

--- a/examples/server/completion/main.go
+++ b/examples/server/completion/main.go
@@ -16,17 +16,17 @@ import (
 // a CompletionHandler to an MCP Server's options.
 func main() {
 	// Define your custom CompletionHandler logic.
-	myCompletionHandler := func(_ context.Context, _ *mcp.ServerSession, params *mcp.CompleteParams) (*mcp.CompleteResult, error) {
+	myCompletionHandler := func(_ context.Context, req *mcp.ServerRequest[*mcp.CompleteParams]) (*mcp.CompleteResult, error) {
 		// In a real application, you'd implement actual completion logic here.
 		// For this example, we return a fixed set of suggestions.
 		var suggestions []string
-		switch params.Ref.Type {
+		switch req.Params.Ref.Type {
 		case "ref/prompt":
 			suggestions = []string{"suggestion1", "suggestion2", "suggestion3"}
 		case "ref/resource":
 			suggestions = []string{"suggestion4", "suggestion5", "suggestion6"}
 		default:
-			return nil, fmt.Errorf("unrecognized content type %s", params.Ref.Type)
+			return nil, fmt.Errorf("unrecognized content type %s", req.Params.Ref.Type)
 		}
 
 		return &mcp.CompleteResult{

--- a/examples/server/custom-transport/main.go
+++ b/examples/server/custom-transport/main.go
@@ -85,10 +85,10 @@ type HiArgs struct {
 }
 
 // SayHi is a tool handler that responds with a greeting.
-func SayHi(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[HiArgs]) (*mcp.CallToolResultFor[struct{}], error) {
+func SayHi(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[HiArgs]]) (*mcp.CallToolResultFor[struct{}], error) {
 	return &mcp.CallToolResultFor[struct{}]{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: "Hi " + params.Arguments.Name},
+			&mcp.TextContent{Text: "Hi " + req.Params.Arguments.Name},
 		},
 	}, nil
 }

--- a/examples/server/hello/main.go
+++ b/examples/server/hello/main.go
@@ -22,10 +22,10 @@ type HiArgs struct {
 	Name string `json:"name" jsonschema:"the name to say hi to"`
 }
 
-func SayHi(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[HiArgs]) (*mcp.CallToolResultFor[struct{}], error) {
+func SayHi(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[HiArgs]]) (*mcp.CallToolResultFor[struct{}], error) {
 	return &mcp.CallToolResultFor[struct{}]{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: "Hi " + params.Arguments.Name},
+			&mcp.TextContent{Text: "Hi " + req.Params.Arguments.Name},
 		},
 	}, nil
 }
@@ -69,8 +69,8 @@ var embeddedResources = map[string]string{
 	"info": "This is the hello example server.",
 }
 
-func handleEmbeddedResource(_ context.Context, _ *mcp.ServerSession, params *mcp.ReadResourceParams) (*mcp.ReadResourceResult, error) {
-	u, err := url.Parse(params.URI)
+func handleEmbeddedResource(_ context.Context, req *mcp.ServerRequest[*mcp.ReadResourceParams]) (*mcp.ReadResourceResult, error) {
+	u, err := url.Parse(req.Params.URI)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func handleEmbeddedResource(_ context.Context, _ *mcp.ServerSession, params *mcp
 	}
 	return &mcp.ReadResourceResult{
 		Contents: []*mcp.ResourceContents{
-			{URI: params.URI, MIMEType: "text/plain", Text: text},
+			{URI: req.Params.URI, MIMEType: "text/plain", Text: text},
 		},
 	}, nil
 }

--- a/examples/server/memory/kb.go
+++ b/examples/server/memory/kb.go
@@ -84,7 +84,7 @@ func (fs *fileStore) Read() ([]byte, error) {
 
 // Write saves data to file with 0600 permissions.
 func (fs *fileStore) Write(data []byte) error {
-	if err := os.WriteFile(fs.path, data, 0600); err != nil {
+	if err := os.WriteFile(fs.path, data, 0o600); err != nil {
 		return fmt.Errorf("failed to write file %s: %w", fs.path, err)
 	}
 	return nil
@@ -431,10 +431,10 @@ func (k knowledgeBase) openNodes(names []string) (KnowledgeGraph, error) {
 	}, nil
 }
 
-func (k knowledgeBase) CreateEntities(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[CreateEntitiesArgs]) (*mcp.CallToolResultFor[CreateEntitiesResult], error) {
+func (k knowledgeBase) CreateEntities(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[CreateEntitiesArgs]]) (*mcp.CallToolResultFor[CreateEntitiesResult], error) {
 	var res mcp.CallToolResultFor[CreateEntitiesResult]
 
-	entities, err := k.createEntities(params.Arguments.Entities)
+	entities, err := k.createEntities(req.Params.Arguments.Entities)
 	if err != nil {
 		return nil, err
 	}
@@ -450,10 +450,10 @@ func (k knowledgeBase) CreateEntities(ctx context.Context, ss *mcp.ServerSession
 	return &res, nil
 }
 
-func (k knowledgeBase) CreateRelations(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[CreateRelationsArgs]) (*mcp.CallToolResultFor[CreateRelationsResult], error) {
+func (k knowledgeBase) CreateRelations(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[CreateRelationsArgs]]) (*mcp.CallToolResultFor[CreateRelationsResult], error) {
 	var res mcp.CallToolResultFor[CreateRelationsResult]
 
-	relations, err := k.createRelations(params.Arguments.Relations)
+	relations, err := k.createRelations(req.Params.Arguments.Relations)
 	if err != nil {
 		return nil, err
 	}
@@ -469,10 +469,10 @@ func (k knowledgeBase) CreateRelations(ctx context.Context, ss *mcp.ServerSessio
 	return &res, nil
 }
 
-func (k knowledgeBase) AddObservations(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[AddObservationsArgs]) (*mcp.CallToolResultFor[AddObservationsResult], error) {
+func (k knowledgeBase) AddObservations(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[AddObservationsArgs]]) (*mcp.CallToolResultFor[AddObservationsResult], error) {
 	var res mcp.CallToolResultFor[AddObservationsResult]
 
-	observations, err := k.addObservations(params.Arguments.Observations)
+	observations, err := k.addObservations(req.Params.Arguments.Observations)
 	if err != nil {
 		return nil, err
 	}
@@ -488,10 +488,10 @@ func (k knowledgeBase) AddObservations(ctx context.Context, ss *mcp.ServerSessio
 	return &res, nil
 }
 
-func (k knowledgeBase) DeleteEntities(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[DeleteEntitiesArgs]) (*mcp.CallToolResultFor[struct{}], error) {
+func (k knowledgeBase) DeleteEntities(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[DeleteEntitiesArgs]]) (*mcp.CallToolResultFor[struct{}], error) {
 	var res mcp.CallToolResultFor[struct{}]
 
-	err := k.deleteEntities(params.Arguments.EntityNames)
+	err := k.deleteEntities(req.Params.Arguments.EntityNames)
 	if err != nil {
 		return nil, err
 	}
@@ -503,10 +503,10 @@ func (k knowledgeBase) DeleteEntities(ctx context.Context, ss *mcp.ServerSession
 	return &res, nil
 }
 
-func (k knowledgeBase) DeleteObservations(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[DeleteObservationsArgs]) (*mcp.CallToolResultFor[struct{}], error) {
+func (k knowledgeBase) DeleteObservations(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[DeleteObservationsArgs]]) (*mcp.CallToolResultFor[struct{}], error) {
 	var res mcp.CallToolResultFor[struct{}]
 
-	err := k.deleteObservations(params.Arguments.Deletions)
+	err := k.deleteObservations(req.Params.Arguments.Deletions)
 	if err != nil {
 		return nil, err
 	}
@@ -518,10 +518,10 @@ func (k knowledgeBase) DeleteObservations(ctx context.Context, ss *mcp.ServerSes
 	return &res, nil
 }
 
-func (k knowledgeBase) DeleteRelations(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[DeleteRelationsArgs]) (*mcp.CallToolResultFor[struct{}], error) {
+func (k knowledgeBase) DeleteRelations(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[DeleteRelationsArgs]]) (*mcp.CallToolResultFor[struct{}], error) {
 	var res mcp.CallToolResultFor[struct{}]
 
-	err := k.deleteRelations(params.Arguments.Relations)
+	err := k.deleteRelations(req.Params.Arguments.Relations)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +533,7 @@ func (k knowledgeBase) DeleteRelations(ctx context.Context, ss *mcp.ServerSessio
 	return &res, nil
 }
 
-func (k knowledgeBase) ReadGraph(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[struct{}]) (*mcp.CallToolResultFor[KnowledgeGraph], error) {
+func (k knowledgeBase) ReadGraph(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[struct{}]]) (*mcp.CallToolResultFor[KnowledgeGraph], error) {
 	var res mcp.CallToolResultFor[KnowledgeGraph]
 
 	graph, err := k.loadGraph()
@@ -549,10 +549,10 @@ func (k knowledgeBase) ReadGraph(ctx context.Context, ss *mcp.ServerSession, par
 	return &res, nil
 }
 
-func (k knowledgeBase) SearchNodes(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[SearchNodesArgs]) (*mcp.CallToolResultFor[KnowledgeGraph], error) {
+func (k knowledgeBase) SearchNodes(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[SearchNodesArgs]]) (*mcp.CallToolResultFor[KnowledgeGraph], error) {
 	var res mcp.CallToolResultFor[KnowledgeGraph]
 
-	graph, err := k.searchNodes(params.Arguments.Query)
+	graph, err := k.searchNodes(req.Params.Arguments.Query)
 	if err != nil {
 		return nil, err
 	}
@@ -565,10 +565,10 @@ func (k knowledgeBase) SearchNodes(ctx context.Context, ss *mcp.ServerSession, p
 	return &res, nil
 }
 
-func (k knowledgeBase) OpenNodes(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[OpenNodesArgs]) (*mcp.CallToolResultFor[KnowledgeGraph], error) {
+func (k knowledgeBase) OpenNodes(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[OpenNodesArgs]]) (*mcp.CallToolResultFor[KnowledgeGraph], error) {
 	var res mcp.CallToolResultFor[KnowledgeGraph]
 
-	graph, err := k.openNodes(params.Arguments.Names)
+	graph, err := k.openNodes(req.Params.Arguments.Names)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/server/memory/kb_test.go
+++ b/examples/server/memory/kb_test.go
@@ -230,7 +230,7 @@ func TestSaveAndLoadGraph(t *testing.T) {
 
 			// Test malformed data handling
 			if fs, ok := s.(*fileStore); ok {
-				err := os.WriteFile(fs.path, []byte("invalid json"), 0600)
+				err := os.WriteFile(fs.path, []byte("invalid json"), 0o600)
 				if err != nil {
 					t.Fatalf("failed to write invalid json: %v", err)
 				}
@@ -450,7 +450,7 @@ func TestMCPServerIntegration(t *testing.T) {
 				},
 			}
 
-			createResult, err := kb.CreateEntities(ctx, serverSession, createEntitiesParams)
+			createResult, err := kb.CreateEntities(ctx, requestFor(serverSession, createEntitiesParams))
 			if err != nil {
 				t.Fatalf("MCP CreateEntities failed: %v", err)
 			}
@@ -463,7 +463,7 @@ func TestMCPServerIntegration(t *testing.T) {
 
 			// Test ReadGraph through MCP
 			readParams := &mcp.CallToolParamsFor[struct{}]{}
-			readResult, err := kb.ReadGraph(ctx, serverSession, readParams)
+			readResult, err := kb.ReadGraph(ctx, requestFor(serverSession, readParams))
 			if err != nil {
 				t.Fatalf("MCP ReadGraph failed: %v", err)
 			}
@@ -487,7 +487,7 @@ func TestMCPServerIntegration(t *testing.T) {
 				},
 			}
 
-			relationsResult, err := kb.CreateRelations(ctx, serverSession, createRelationsParams)
+			relationsResult, err := kb.CreateRelations(ctx, requestFor(serverSession, createRelationsParams))
 			if err != nil {
 				t.Fatalf("MCP CreateRelations failed: %v", err)
 			}
@@ -510,7 +510,7 @@ func TestMCPServerIntegration(t *testing.T) {
 				},
 			}
 
-			obsResult, err := kb.AddObservations(ctx, serverSession, addObsParams)
+			obsResult, err := kb.AddObservations(ctx, requestFor(serverSession, addObsParams))
 			if err != nil {
 				t.Fatalf("MCP AddObservations failed: %v", err)
 			}
@@ -528,7 +528,7 @@ func TestMCPServerIntegration(t *testing.T) {
 				},
 			}
 
-			searchResult, err := kb.SearchNodes(ctx, serverSession, searchParams)
+			searchResult, err := kb.SearchNodes(ctx, requestFor(serverSession, searchParams))
 			if err != nil {
 				t.Fatalf("MCP SearchNodes failed: %v", err)
 			}
@@ -546,7 +546,7 @@ func TestMCPServerIntegration(t *testing.T) {
 				},
 			}
 
-			openResult, err := kb.OpenNodes(ctx, serverSession, openParams)
+			openResult, err := kb.OpenNodes(ctx, requestFor(serverSession, openParams))
 			if err != nil {
 				t.Fatalf("MCP OpenNodes failed: %v", err)
 			}
@@ -569,7 +569,7 @@ func TestMCPServerIntegration(t *testing.T) {
 				},
 			}
 
-			deleteObsResult, err := kb.DeleteObservations(ctx, serverSession, deleteObsParams)
+			deleteObsResult, err := kb.DeleteObservations(ctx, requestFor(serverSession, deleteObsParams))
 			if err != nil {
 				t.Fatalf("MCP DeleteObservations failed: %v", err)
 			}
@@ -590,7 +590,7 @@ func TestMCPServerIntegration(t *testing.T) {
 				},
 			}
 
-			deleteRelResult, err := kb.DeleteRelations(ctx, serverSession, deleteRelParams)
+			deleteRelResult, err := kb.DeleteRelations(ctx, requestFor(serverSession, deleteRelParams))
 			if err != nil {
 				t.Fatalf("MCP DeleteRelations failed: %v", err)
 			}
@@ -605,7 +605,7 @@ func TestMCPServerIntegration(t *testing.T) {
 				},
 			}
 
-			deleteEntResult, err := kb.DeleteEntities(ctx, serverSession, deleteEntParams)
+			deleteEntResult, err := kb.DeleteEntities(ctx, requestFor(serverSession, deleteEntParams))
 			if err != nil {
 				t.Fatalf("MCP DeleteEntities failed: %v", err)
 			}
@@ -614,7 +614,7 @@ func TestMCPServerIntegration(t *testing.T) {
 			}
 
 			// Verify final state
-			finalRead, err := kb.ReadGraph(ctx, serverSession, readParams)
+			finalRead, err := kb.ReadGraph(ctx, requestFor(serverSession, readParams))
 			if err != nil {
 				t.Fatalf("Final MCP ReadGraph failed: %v", err)
 			}
@@ -647,7 +647,7 @@ func TestMCPErrorHandling(t *testing.T) {
 				},
 			}
 
-			_, err := kb.AddObservations(ctx, serverSession, addObsParams)
+			_, err := kb.AddObservations(ctx, requestFor(serverSession, addObsParams))
 			if err == nil {
 				t.Errorf("expected MCP AddObservations to return error for non-existent entity")
 			} else {
@@ -678,7 +678,7 @@ func TestMCPResponseFormat(t *testing.T) {
 		},
 	}
 
-	result, err := kb.CreateEntities(ctx, serverSession, createParams)
+	result, err := kb.CreateEntities(ctx, requestFor(serverSession, createParams))
 	if err != nil {
 		t.Fatalf("CreateEntities failed: %v", err)
 	}
@@ -700,4 +700,8 @@ func TestMCPResponseFormat(t *testing.T) {
 	} else {
 		t.Errorf("expected Content[0] to be TextContent")
 	}
+}
+
+func requestFor[P mcp.Params](ss *mcp.ServerSession, p P) *mcp.ServerRequest[P] {
+	return &mcp.ServerRequest[P]{Session: ss, Params: p}
 }

--- a/examples/server/sequentialthinking/main.go
+++ b/examples/server/sequentialthinking/main.go
@@ -231,8 +231,8 @@ func deepCopyThoughts(thoughts []*Thought) []*Thought {
 }
 
 // StartThinking begins a new sequential thinking session for a complex problem.
-func StartThinking(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[StartThinkingArgs]) (*mcp.CallToolResultFor[any], error) {
-	args := params.Arguments
+func StartThinking(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[StartThinkingArgs]]) (*mcp.CallToolResultFor[any], error) {
+	args := req.Params.Arguments
 
 	sessionID := args.SessionID
 	if sessionID == "" {
@@ -266,8 +266,8 @@ func StartThinking(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallT
 }
 
 // ContinueThinking adds the next thought step, revises a previous step, or creates a branch in the thinking process.
-func ContinueThinking(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[ContinueThinkingArgs]) (*mcp.CallToolResultFor[any], error) {
-	args := params.Arguments
+func ContinueThinking(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[ContinueThinkingArgs]]) (*mcp.CallToolResultFor[any], error) {
+	args := req.Params.Arguments
 
 	// Handle revision of existing thought
 	if args.ReviseStep != nil {
@@ -395,8 +395,8 @@ func ContinueThinking(ctx context.Context, ss *mcp.ServerSession, params *mcp.Ca
 }
 
 // ReviewThinking provides a complete review of the thinking process for a session.
-func ReviewThinking(ctx context.Context, ss *mcp.ServerSession, params *mcp.CallToolParamsFor[ReviewThinkingArgs]) (*mcp.CallToolResultFor[any], error) {
-	args := params.Arguments
+func ReviewThinking(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[ReviewThinkingArgs]]) (*mcp.CallToolResultFor[any], error) {
+	args := req.Params.Arguments
 
 	// Get a snapshot of the session to avoid race conditions
 	sessionSnapshot, exists := store.SessionSnapshot(args.SessionID)
@@ -434,11 +434,11 @@ func ReviewThinking(ctx context.Context, ss *mcp.ServerSession, params *mcp.Call
 }
 
 // ThinkingHistory handles resource requests for thinking session data and history.
-func ThinkingHistory(ctx context.Context, ss *mcp.ServerSession, params *mcp.ReadResourceParams) (*mcp.ReadResourceResult, error) {
+func ThinkingHistory(ctx context.Context, req *mcp.ServerRequest[*mcp.ReadResourceParams]) (*mcp.ReadResourceResult, error) {
 	// Extract session ID from URI (e.g., "thinking://session_123")
-	u, err := url.Parse(params.URI)
+	u, err := url.Parse(req.Params.URI)
 	if err != nil {
-		return nil, fmt.Errorf("invalid thinking resource URI: %s", params.URI)
+		return nil, fmt.Errorf("invalid thinking resource URI: %s", req.Params.URI)
 	}
 	if u.Scheme != "thinking" {
 		return nil, fmt.Errorf("invalid thinking resource URI scheme: %s", u.Scheme)
@@ -456,7 +456,7 @@ func ThinkingHistory(ctx context.Context, ss *mcp.ServerSession, params *mcp.Rea
 		return &mcp.ReadResourceResult{
 			Contents: []*mcp.ResourceContents{
 				{
-					URI:      params.URI,
+					URI:      req.Params.URI,
 					MIMEType: "application/json",
 					Text:     string(data),
 				},
@@ -478,7 +478,7 @@ func ThinkingHistory(ctx context.Context, ss *mcp.ServerSession, params *mcp.Rea
 	return &mcp.ReadResourceResult{
 		Contents: []*mcp.ResourceContents{
 			{
-				URI:      params.URI,
+				URI:      req.Params.URI,
 				MIMEType: "application/json",
 				Text:     string(data),
 			},

--- a/examples/server/sequentialthinking/main_test.go
+++ b/examples/server/sequentialthinking/main_test.go
@@ -31,7 +31,7 @@ func TestStartThinking(t *testing.T) {
 		Arguments: args,
 	}
 
-	result, err := StartThinking(ctx, nil, params)
+	result, err := StartThinking(ctx, requestFor(params))
 	if err != nil {
 		t.Fatalf("StartThinking() error = %v", err)
 	}
@@ -89,7 +89,7 @@ func TestContinueThinking(t *testing.T) {
 		Arguments: startArgs,
 	}
 
-	_, err := StartThinking(ctx, nil, startParams)
+	_, err := StartThinking(ctx, requestFor(startParams))
 	if err != nil {
 		t.Fatalf("StartThinking() error = %v", err)
 	}
@@ -105,7 +105,7 @@ func TestContinueThinking(t *testing.T) {
 		Arguments: continueArgs,
 	}
 
-	result, err := ContinueThinking(ctx, nil, continueParams)
+	result, err := ContinueThinking(ctx, requestFor(continueParams))
 	if err != nil {
 		t.Fatalf("ContinueThinking() error = %v", err)
 	}
@@ -158,7 +158,7 @@ func TestContinueThinkingWithCompletion(t *testing.T) {
 		Arguments: startArgs,
 	}
 
-	_, err := StartThinking(ctx, nil, startParams)
+	_, err := StartThinking(ctx, requestFor(startParams))
 	if err != nil {
 		t.Fatalf("StartThinking() error = %v", err)
 	}
@@ -176,7 +176,7 @@ func TestContinueThinkingWithCompletion(t *testing.T) {
 		Arguments: continueArgs,
 	}
 
-	result, err := ContinueThinking(ctx, nil, continueParams)
+	result, err := ContinueThinking(ctx, requestFor(continueParams))
 	if err != nil {
 		t.Fatalf("ContinueThinking() error = %v", err)
 	}
@@ -233,7 +233,7 @@ func TestContinueThinkingRevision(t *testing.T) {
 		Arguments: continueArgs,
 	}
 
-	result, err := ContinueThinking(ctx, nil, continueParams)
+	result, err := ContinueThinking(ctx, requestFor(continueParams))
 	if err != nil {
 		t.Fatalf("ContinueThinking() error = %v", err)
 	}
@@ -289,7 +289,7 @@ func TestContinueThinkingBranching(t *testing.T) {
 		Arguments: continueArgs,
 	}
 
-	result, err := ContinueThinking(ctx, nil, continueParams)
+	result, err := ContinueThinking(ctx, requestFor(continueParams))
 	if err != nil {
 		t.Fatalf("ContinueThinking() error = %v", err)
 	}
@@ -356,7 +356,7 @@ func TestReviewThinking(t *testing.T) {
 		Arguments: reviewArgs,
 	}
 
-	result, err := ReviewThinking(ctx, nil, reviewParams)
+	result, err := ReviewThinking(ctx, requestFor(reviewParams))
 	if err != nil {
 		t.Fatalf("ReviewThinking() error = %v", err)
 	}
@@ -431,7 +431,7 @@ func TestThinkingHistory(t *testing.T) {
 		URI: "thinking://sessions",
 	}
 
-	result, err := ThinkingHistory(ctx, nil, listParams)
+	result, err := ThinkingHistory(ctx, requestFor(listParams))
 	if err != nil {
 		t.Fatalf("ThinkingHistory() error = %v", err)
 	}
@@ -461,7 +461,7 @@ func TestThinkingHistory(t *testing.T) {
 		URI: "thinking://session1",
 	}
 
-	result, err = ThinkingHistory(ctx, nil, sessionParams)
+	result, err = ThinkingHistory(ctx, requestFor(sessionParams))
 	if err != nil {
 		t.Fatalf("ThinkingHistory() error = %v", err)
 	}
@@ -496,7 +496,7 @@ func TestInvalidOperations(t *testing.T) {
 		Arguments: continueArgs,
 	}
 
-	_, err := ContinueThinking(ctx, nil, continueParams)
+	_, err := ContinueThinking(ctx, requestFor(continueParams))
 	if err == nil {
 		t.Error("Expected error for non-existent session")
 	}
@@ -511,7 +511,7 @@ func TestInvalidOperations(t *testing.T) {
 		Arguments: reviewArgs,
 	}
 
-	_, err = ReviewThinking(ctx, nil, reviewParams)
+	_, err = ReviewThinking(ctx, requestFor(reviewParams))
 	if err == nil {
 		t.Error("Expected error for non-existent session in review")
 	}
@@ -541,8 +541,12 @@ func TestInvalidOperations(t *testing.T) {
 		Arguments: invalidReviseArgs,
 	}
 
-	_, err = ContinueThinking(ctx, nil, invalidReviseParams)
+	_, err = ContinueThinking(ctx, requestFor(invalidReviseParams))
 	if err == nil {
 		t.Error("Expected error for invalid revision step")
 	}
+}
+
+func requestFor[P mcp.Params](p P) *mcp.ServerRequest[P] {
+	return &mcp.ServerRequest[P]{Params: p}
 }

--- a/examples/server/sse/main.go
+++ b/examples/server/sse/main.go
@@ -24,10 +24,10 @@ type SayHiParams struct {
 	Name string `json:"name"`
 }
 
-func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[SayHiParams]) (*mcp.CallToolResultFor[any], error) {
+func SayHi(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[SayHiParams]]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: "Hi " + params.Arguments.Name},
+			&mcp.TextContent{Text: "Hi " + req.Params.Arguments.Name},
 		},
 	}, nil
 }

--- a/internal/jsonrpc2/messages.go
+++ b/internal/jsonrpc2/messages.go
@@ -56,6 +56,9 @@ type Request struct {
 	Method string
 	// Params is either a struct or an array with the parameters of the method.
 	Params json.RawMessage
+	// Meta is additional information that does not appear on the wire. It can be
+	// used to pass information from the application to the underlying transport.
+	Meta any
 }
 
 // Response is a Message used as a reply to a call Request.
@@ -67,6 +70,9 @@ type Response struct {
 	Error error
 	// id of the request this is a response to.
 	ID ID
+	// Meta is additional information that does not appear on the wire. It can be
+	// used to pass information from the underlying transport to the application.
+	Meta any
 }
 
 // StringID creates a new string request identifier.

--- a/internal/readme/server/server.go
+++ b/internal/readme/server/server.go
@@ -16,9 +16,9 @@ type HiParams struct {
 	Name string `json:"name" jsonschema:"the name of the person to greet"`
 }
 
-func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[HiParams]) (*mcp.CallToolResultFor[any], error) {
+func SayHi(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[HiParams]]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
-		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + params.Arguments.Name}},
+		Content: []mcp.Content{&mcp.TextContent{Text: "Hi " + req.Params.Arguments.Name}},
 	}, nil
 }
 

--- a/mcp/example_progress_test.go
+++ b/mcp/example_progress_test.go
@@ -21,11 +21,11 @@ func Example_progressMiddleware() {
 	_ = c
 }
 
-func addProgressToken[S mcp.Session](h mcp.MethodHandler[S]) mcp.MethodHandler[S] {
-	return func(ctx context.Context, s S, method string, params mcp.Params) (result mcp.Result, err error) {
-		if rp, ok := params.(mcp.RequestParams); ok {
+func addProgressToken[S mcp.Session](h mcp.MethodHandler) mcp.MethodHandler {
+	return func(ctx context.Context, method string, req mcp.Request) (result mcp.Result, err error) {
+		if rp, ok := req.GetParams().(mcp.RequestParams); ok {
 			rp.SetProgressToken(nextProgressToken.Add(1))
 		}
-		return h(ctx, s, method, params)
+		return h(ctx, method, req)
 	}
 }

--- a/mcp/resource.go
+++ b/mcp/resource.go
@@ -35,7 +35,7 @@ type serverResourceTemplate struct {
 // A ResourceHandler is a function that reads a resource.
 // It will be called when the client calls [ClientSession.ReadResource].
 // If it cannot find the resource, it should return the result of calling [ResourceNotFoundError].
-type ResourceHandler func(context.Context, *ServerSession, *ReadResourceParams) (*ReadResourceResult, error)
+type ResourceHandler func(context.Context, *ServerRequest[*ReadResourceParams]) (*ReadResourceResult, error)
 
 // ResourceNotFoundError returns an error indicating that a resource being read could
 // not be found.

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -41,8 +41,8 @@ type Server struct {
 	resources               *featureSet[*serverResource]
 	resourceTemplates       *featureSet[*serverResourceTemplate]
 	sessions                []*ServerSession
-	sendingMethodHandler_   MethodHandler[*ServerSession]
-	receivingMethodHandler_ MethodHandler[*ServerSession]
+	sendingMethodHandler_   MethodHandler
+	receivingMethodHandler_ MethodHandler
 	resourceSubscriptions   map[string]map[*ServerSession]bool // uri -> session -> bool
 }
 
@@ -51,24 +51,24 @@ type ServerOptions struct {
 	// Optional instructions for connected clients.
 	Instructions string
 	// If non-nil, called when "notifications/initialized" is received.
-	InitializedHandler func(context.Context, *ServerSession, *InitializedParams)
+	InitializedHandler func(context.Context, *ServerRequest[*InitializedParams])
 	// PageSize is the maximum number of items to return in a single page for
 	// list methods (e.g. ListTools).
 	PageSize int
 	// If non-nil, called when "notifications/roots/list_changed" is received.
-	RootsListChangedHandler func(context.Context, *ServerSession, *RootsListChangedParams)
+	RootsListChangedHandler func(context.Context, *ServerRequest[*RootsListChangedParams])
 	// If non-nil, called when "notifications/progress" is received.
-	ProgressNotificationHandler func(context.Context, *ServerSession, *ProgressNotificationParams)
+	ProgressNotificationHandler func(context.Context, *ServerRequest[*ProgressNotificationParams])
 	// If non-nil, called when "completion/complete" is received.
-	CompletionHandler func(context.Context, *ServerSession, *CompleteParams) (*CompleteResult, error)
+	CompletionHandler func(context.Context, *ServerRequest[*CompleteParams]) (*CompleteResult, error)
 	// If non-zero, defines an interval for regular "ping" requests.
 	// If the peer fails to respond to pings originating from the keepalive check,
 	// the session is automatically closed.
 	KeepAlive time.Duration
 	// Function called when a client session subscribes to a resource.
-	SubscribeHandler func(context.Context, *ServerSession, *SubscribeParams) error
+	SubscribeHandler func(context.Context, *ServerRequest[*SubscribeParams]) error
 	// Function called when a client session unsubscribes from a resource.
-	UnsubscribeHandler func(context.Context, *ServerSession, *UnsubscribeParams) error
+	UnsubscribeHandler func(context.Context, *ServerRequest[*UnsubscribeParams]) error
 	// If true, advertises the prompts capability during initialization,
 	// even if no prompts have been registered.
 	HasPrompts bool
@@ -258,11 +258,11 @@ func (s *Server) capabilities() *serverCapabilities {
 	return caps
 }
 
-func (s *Server) complete(ctx context.Context, ss *ServerSession, params *CompleteParams) (Result, error) {
+func (s *Server) complete(ctx context.Context, req *ServerRequest[*CompleteParams]) (Result, error) {
 	if s.opts.CompletionHandler == nil {
 		return nil, jsonrpc2.ErrMethodNotFound
 	}
-	return s.opts.CompletionHandler(ctx, ss, params)
+	return s.opts.CompletionHandler(ctx, req)
 }
 
 // changeAndNotify is called when a feature is added or removed.
@@ -287,13 +287,13 @@ func (s *Server) Sessions() iter.Seq[*ServerSession] {
 	return slices.Values(clients)
 }
 
-func (s *Server) listPrompts(_ context.Context, _ *ServerSession, params *ListPromptsParams) (*ListPromptsResult, error) {
+func (s *Server) listPrompts(_ context.Context, req *ServerRequest[*ListPromptsParams]) (*ListPromptsResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if params == nil {
-		params = &ListPromptsParams{}
+	if req.Params == nil {
+		req.Params = &ListPromptsParams{}
 	}
-	return paginateList(s.prompts, s.opts.PageSize, params, &ListPromptsResult{}, func(res *ListPromptsResult, prompts []*serverPrompt) {
+	return paginateList(s.prompts, s.opts.PageSize, req.Params, &ListPromptsResult{}, func(res *ListPromptsResult, prompts []*serverPrompt) {
 		res.Prompts = []*Prompt{} // avoid JSON null
 		for _, p := range prompts {
 			res.Prompts = append(res.Prompts, p.prompt)
@@ -301,24 +301,24 @@ func (s *Server) listPrompts(_ context.Context, _ *ServerSession, params *ListPr
 	})
 }
 
-func (s *Server) getPrompt(ctx context.Context, ss *ServerSession, params *GetPromptParams) (*GetPromptResult, error) {
+func (s *Server) getPrompt(ctx context.Context, req *ServerRequest[*GetPromptParams]) (*GetPromptResult, error) {
 	s.mu.Lock()
-	prompt, ok := s.prompts.get(params.Name)
+	prompt, ok := s.prompts.get(req.Params.Name)
 	s.mu.Unlock()
 	if !ok {
 		// TODO: surface the error code over the wire, instead of flattening it into the string.
-		return nil, fmt.Errorf("%s: unknown prompt %q", jsonrpc2.ErrInvalidParams, params.Name)
+		return nil, fmt.Errorf("%s: unknown prompt %q", jsonrpc2.ErrInvalidParams, req.Params.Name)
 	}
-	return prompt.handler(ctx, ss, params)
+	return prompt.handler(ctx, req.Session, req.Params)
 }
 
-func (s *Server) listTools(_ context.Context, _ *ServerSession, params *ListToolsParams) (*ListToolsResult, error) {
+func (s *Server) listTools(_ context.Context, req *ServerRequest[*ListToolsParams]) (*ListToolsResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if params == nil {
-		params = &ListToolsParams{}
+	if req.Params == nil {
+		req.Params = &ListToolsParams{}
 	}
-	return paginateList(s.tools, s.opts.PageSize, params, &ListToolsResult{}, func(res *ListToolsResult, tools []*serverTool) {
+	return paginateList(s.tools, s.opts.PageSize, req.Params, &ListToolsResult{}, func(res *ListToolsResult, tools []*serverTool) {
 		res.Tools = []*Tool{} // avoid JSON null
 		for _, t := range tools {
 			res.Tools = append(res.Tools, t.tool)
@@ -326,23 +326,23 @@ func (s *Server) listTools(_ context.Context, _ *ServerSession, params *ListTool
 	})
 }
 
-func (s *Server) callTool(ctx context.Context, cc *ServerSession, params *CallToolParamsFor[json.RawMessage]) (*CallToolResult, error) {
+func (s *Server) callTool(ctx context.Context, req *ServerRequest[*CallToolParamsFor[json.RawMessage]]) (*CallToolResult, error) {
 	s.mu.Lock()
-	st, ok := s.tools.get(params.Name)
+	st, ok := s.tools.get(req.Params.Name)
 	s.mu.Unlock()
 	if !ok {
-		return nil, fmt.Errorf("%s: unknown tool %q", jsonrpc2.ErrInvalidParams, params.Name)
+		return nil, fmt.Errorf("%s: unknown tool %q", jsonrpc2.ErrInvalidParams, req.Params.Name)
 	}
-	return st.handler(ctx, cc, params)
+	return st.handler(ctx, req)
 }
 
-func (s *Server) listResources(_ context.Context, _ *ServerSession, params *ListResourcesParams) (*ListResourcesResult, error) {
+func (s *Server) listResources(_ context.Context, req *ServerRequest[*ListResourcesParams]) (*ListResourcesResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if params == nil {
-		params = &ListResourcesParams{}
+	if req.Params == nil {
+		req.Params = &ListResourcesParams{}
 	}
-	return paginateList(s.resources, s.opts.PageSize, params, &ListResourcesResult{}, func(res *ListResourcesResult, resources []*serverResource) {
+	return paginateList(s.resources, s.opts.PageSize, req.Params, &ListResourcesResult{}, func(res *ListResourcesResult, resources []*serverResource) {
 		res.Resources = []*Resource{} // avoid JSON null
 		for _, r := range resources {
 			res.Resources = append(res.Resources, r.resource)
@@ -350,13 +350,13 @@ func (s *Server) listResources(_ context.Context, _ *ServerSession, params *List
 	})
 }
 
-func (s *Server) listResourceTemplates(_ context.Context, _ *ServerSession, params *ListResourceTemplatesParams) (*ListResourceTemplatesResult, error) {
+func (s *Server) listResourceTemplates(_ context.Context, req *ServerRequest[*ListResourceTemplatesParams]) (*ListResourceTemplatesResult, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if params == nil {
-		params = &ListResourceTemplatesParams{}
+	if req.Params == nil {
+		req.Params = &ListResourceTemplatesParams{}
 	}
-	return paginateList(s.resourceTemplates, s.opts.PageSize, params, &ListResourceTemplatesResult{},
+	return paginateList(s.resourceTemplates, s.opts.PageSize, req.Params, &ListResourceTemplatesResult{},
 		func(res *ListResourceTemplatesResult, rts []*serverResourceTemplate) {
 			res.ResourceTemplates = []*ResourceTemplate{} // avoid JSON null
 			for _, rt := range rts {
@@ -365,8 +365,8 @@ func (s *Server) listResourceTemplates(_ context.Context, _ *ServerSession, para
 		})
 }
 
-func (s *Server) readResource(ctx context.Context, ss *ServerSession, params *ReadResourceParams) (*ReadResourceResult, error) {
-	uri := params.URI
+func (s *Server) readResource(ctx context.Context, req *ServerRequest[*ReadResourceParams]) (*ReadResourceResult, error) {
+	uri := req.Params.URI
 	// Look up the resource URI in the lists of resources and resource templates.
 	// This is a security check as well as an information lookup.
 	handler, mimeType, ok := s.lookupResourceHandler(uri)
@@ -375,7 +375,7 @@ func (s *Server) readResource(ctx context.Context, ss *ServerSession, params *Re
 		// Treat an unregistered resource the same as a registered one that couldn't be found.
 		return nil, ResourceNotFoundError(uri)
 	}
-	res, err := handler(ctx, ss, params)
+	res, err := handler(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -430,11 +430,11 @@ func fileResourceHandler(dir string) ResourceHandler {
 	if err != nil {
 		panic(err)
 	}
-	return func(ctx context.Context, ss *ServerSession, params *ReadResourceParams) (_ *ReadResourceResult, err error) {
-		defer util.Wrapf(&err, "reading resource %s", params.URI)
+	return func(ctx context.Context, req *ServerRequest[*ReadResourceParams]) (_ *ReadResourceResult, err error) {
+		defer util.Wrapf(&err, "reading resource %s", req.Params.URI)
 
 		// TODO: use a memoizing API here.
-		rootRes, err := ss.ListRoots(ctx, nil)
+		rootRes, err := req.Session.ListRoots(ctx, nil)
 		if err != nil {
 			return nil, fmt.Errorf("listing roots: %w", err)
 		}
@@ -442,13 +442,13 @@ func fileResourceHandler(dir string) ResourceHandler {
 		if err != nil {
 			return nil, err
 		}
-		data, err := readFileResource(params.URI, dirFilepath, roots)
+		data, err := readFileResource(req.Params.URI, dirFilepath, roots)
 		if err != nil {
 			return nil, err
 		}
 		// TODO(jba): figure out mime type. Omit for now: Server.readResource will fill it in.
 		return &ReadResourceResult{Contents: []*ResourceContents{
-			{URI: params.URI, Blob: data},
+			{URI: req.Params.URI, Blob: data},
 		}}, nil
 	}
 }
@@ -465,39 +465,39 @@ func (s *Server) ResourceUpdated(ctx context.Context, params *ResourceUpdatedNot
 	return nil
 }
 
-func (s *Server) subscribe(ctx context.Context, ss *ServerSession, params *SubscribeParams) (*emptyResult, error) {
+func (s *Server) subscribe(ctx context.Context, req *ServerRequest[*SubscribeParams]) (*emptyResult, error) {
 	if s.opts.SubscribeHandler == nil {
 		return nil, fmt.Errorf("%w: server does not support resource subscriptions", jsonrpc2.ErrMethodNotFound)
 	}
-	if err := s.opts.SubscribeHandler(ctx, ss, params); err != nil {
+	if err := s.opts.SubscribeHandler(ctx, req); err != nil {
 		return nil, err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.resourceSubscriptions[params.URI] == nil {
-		s.resourceSubscriptions[params.URI] = make(map[*ServerSession]bool)
+	if s.resourceSubscriptions[req.Params.URI] == nil {
+		s.resourceSubscriptions[req.Params.URI] = make(map[*ServerSession]bool)
 	}
-	s.resourceSubscriptions[params.URI][ss] = true
+	s.resourceSubscriptions[req.Params.URI][req.Session] = true
 
 	return &emptyResult{}, nil
 }
 
-func (s *Server) unsubscribe(ctx context.Context, ss *ServerSession, params *UnsubscribeParams) (*emptyResult, error) {
+func (s *Server) unsubscribe(ctx context.Context, req *ServerRequest[*UnsubscribeParams]) (*emptyResult, error) {
 	if s.opts.UnsubscribeHandler == nil {
 		return nil, jsonrpc2.ErrMethodNotFound
 	}
 
-	if err := s.opts.UnsubscribeHandler(ctx, ss, params); err != nil {
+	if err := s.opts.UnsubscribeHandler(ctx, req); err != nil {
 		return nil, err
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if subscribedSessions, ok := s.resourceSubscriptions[params.URI]; ok {
-		delete(subscribedSessions, ss)
+	if subscribedSessions, ok := s.resourceSubscriptions[req.Params.URI]; ok {
+		delete(subscribedSessions, req.Session)
 		if len(subscribedSessions) == 0 {
-			delete(s.resourceSubscriptions, params.URI)
+			delete(s.resourceSubscriptions, req.Params.URI)
 		}
 	}
 
@@ -611,15 +611,24 @@ func (ss *ServerSession) initialized(ctx context.Context, params *InitializedPar
 	if wasInitd {
 		return nil, fmt.Errorf("duplicate %q received", notificationInitialized)
 	}
-	return callNotificationHandler(ctx, ss.server.opts.InitializedHandler, ss, params)
+	if h := ss.server.opts.InitializedHandler; h != nil {
+		h(ctx, serverRequestFor(ss, params))
+	}
+	return nil, nil
 }
 
-func (s *Server) callRootsListChangedHandler(ctx context.Context, ss *ServerSession, params *RootsListChangedParams) (Result, error) {
-	return callNotificationHandler(ctx, s.opts.RootsListChangedHandler, ss, params)
+func (s *Server) callRootsListChangedHandler(ctx context.Context, req *ServerRequest[*RootsListChangedParams]) (Result, error) {
+	if h := s.opts.RootsListChangedHandler; h != nil {
+		h(ctx, req)
+	}
+	return nil, nil
 }
 
-func (ss *ServerSession) callProgressNotificationHandler(ctx context.Context, params *ProgressNotificationParams) (Result, error) {
-	return callNotificationHandler(ctx, ss.server.opts.ProgressNotificationHandler, ss, params)
+func (ss *ServerSession) callProgressNotificationHandler(ctx context.Context, p *ProgressNotificationParams) (Result, error) {
+	if h := ss.server.opts.ProgressNotificationHandler; h != nil {
+		h(ctx, serverRequestFor(ss, p))
+	}
+	return nil, nil
 }
 
 // NotifyProgress sends a progress notification from the server to the client
@@ -627,7 +636,11 @@ func (ss *ServerSession) callProgressNotificationHandler(ctx context.Context, pa
 // This is typically used to report on the status of a long-running request
 // that was initiated by the client.
 func (ss *ServerSession) NotifyProgress(ctx context.Context, params *ProgressNotificationParams) error {
-	return handleNotify(ctx, ss, notificationProgress, params)
+	return handleNotify(ctx, notificationProgress, newServerRequest(ss, orZero[Params](params)))
+}
+
+func newServerRequest[P Params](ss *ServerSession, params P) *ServerRequest[P] {
+	return &ServerRequest[P]{Session: ss, Params: params}
 }
 
 // A ServerSession is a logical connection from a single MCP client. Its
@@ -665,18 +678,18 @@ func (ss *ServerSession) ID() string {
 
 // Ping pings the client.
 func (ss *ServerSession) Ping(ctx context.Context, params *PingParams) error {
-	_, err := handleSend[*emptyResult](ctx, ss, methodPing, orZero[Params](params))
+	_, err := handleSend[*emptyResult](ctx, methodPing, newServerRequest(ss, orZero[Params](params)))
 	return err
 }
 
 // ListRoots lists the client roots.
 func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams) (*ListRootsResult, error) {
-	return handleSend[*ListRootsResult](ctx, ss, methodListRoots, orZero[Params](params))
+	return handleSend[*ListRootsResult](ctx, methodListRoots, newServerRequest(ss, orZero[Params](params)))
 }
 
 // CreateMessage sends a sampling request to the client.
 func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessageParams) (*CreateMessageResult, error) {
-	return handleSend[*CreateMessageResult](ctx, ss, methodCreateMessage, orZero[Params](params))
+	return handleSend[*CreateMessageResult](ctx, methodCreateMessage, newServerRequest(ss, orZero[Params](params)))
 }
 
 // Log sends a log message to the client.
@@ -695,7 +708,7 @@ func (ss *ServerSession) Log(ctx context.Context, params *LoggingMessageParams) 
 	if compareLevels(params.Level, logLevel) < 0 {
 		return nil
 	}
-	return handleNotify(ctx, ss, notificationLoggingMessage, params)
+	return handleNotify(ctx, notificationLoggingMessage, newServerRequest(ss, orZero[Params](params)))
 }
 
 // AddSendingMiddleware wraps the current sending method handler using the provided
@@ -707,7 +720,7 @@ func (ss *ServerSession) Log(ctx context.Context, params *LoggingMessageParams) 
 //
 // Sending middleware is called when a request is sent. It is useful for tasks
 // such as tracing, metrics, and adding progress tokens.
-func (s *Server) AddSendingMiddleware(middleware ...Middleware[*ServerSession]) {
+func (s *Server) AddSendingMiddleware(middleware ...Middleware) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	addMiddleware(&s.sendingMethodHandler_, middleware)
@@ -722,7 +735,7 @@ func (s *Server) AddSendingMiddleware(middleware ...Middleware[*ServerSession]) 
 //
 // Receiving middleware is called when a request is received. It is useful for tasks
 // such as authentication, request logging and metrics.
-func (s *Server) AddReceivingMiddleware(middleware ...Middleware[*ServerSession]) {
+func (s *Server) AddReceivingMiddleware(middleware ...Middleware) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	addMiddleware(&s.receivingMethodHandler_, middleware)
@@ -734,22 +747,22 @@ func (s *Server) AddReceivingMiddleware(middleware ...Middleware[*ServerSession]
 // TODO(rfindley): actually load and validate the protocol schema, rather than
 // curating these method flags.
 var serverMethodInfos = map[string]methodInfo{
-	methodComplete:               newMethodInfo(serverMethod((*Server).complete), 0),
-	methodInitialize:             newMethodInfo(sessionMethod((*ServerSession).initialize), 0),
-	methodPing:                   newMethodInfo(sessionMethod((*ServerSession).ping), missingParamsOK),
-	methodListPrompts:            newMethodInfo(serverMethod((*Server).listPrompts), missingParamsOK),
-	methodGetPrompt:              newMethodInfo(serverMethod((*Server).getPrompt), 0),
-	methodListTools:              newMethodInfo(serverMethod((*Server).listTools), missingParamsOK),
-	methodCallTool:               newMethodInfo(serverMethod((*Server).callTool), 0),
-	methodListResources:          newMethodInfo(serverMethod((*Server).listResources), missingParamsOK),
-	methodListResourceTemplates:  newMethodInfo(serverMethod((*Server).listResourceTemplates), missingParamsOK),
-	methodReadResource:           newMethodInfo(serverMethod((*Server).readResource), 0),
-	methodSetLevel:               newMethodInfo(sessionMethod((*ServerSession).setLevel), 0),
-	methodSubscribe:              newMethodInfo(serverMethod((*Server).subscribe), 0),
-	methodUnsubscribe:            newMethodInfo(serverMethod((*Server).unsubscribe), 0),
-	notificationInitialized:      newMethodInfo(sessionMethod((*ServerSession).initialized), notification|missingParamsOK),
-	notificationRootsListChanged: newMethodInfo(serverMethod((*Server).callRootsListChangedHandler), notification|missingParamsOK),
-	notificationProgress:         newMethodInfo(sessionMethod((*ServerSession).callProgressNotificationHandler), notification),
+	methodComplete:               newServerMethodInfo(serverMethod((*Server).complete), 0),
+	methodInitialize:             newServerMethodInfo(serverSessionMethod((*ServerSession).initialize), 0),
+	methodPing:                   newServerMethodInfo(serverSessionMethod((*ServerSession).ping), missingParamsOK),
+	methodListPrompts:            newServerMethodInfo(serverMethod((*Server).listPrompts), missingParamsOK),
+	methodGetPrompt:              newServerMethodInfo(serverMethod((*Server).getPrompt), 0),
+	methodListTools:              newServerMethodInfo(serverMethod((*Server).listTools), missingParamsOK),
+	methodCallTool:               newServerMethodInfo(serverMethod((*Server).callTool), 0),
+	methodListResources:          newServerMethodInfo(serverMethod((*Server).listResources), missingParamsOK),
+	methodListResourceTemplates:  newServerMethodInfo(serverMethod((*Server).listResourceTemplates), missingParamsOK),
+	methodReadResource:           newServerMethodInfo(serverMethod((*Server).readResource), 0),
+	methodSetLevel:               newServerMethodInfo(serverSessionMethod((*ServerSession).setLevel), 0),
+	methodSubscribe:              newServerMethodInfo(serverMethod((*Server).subscribe), 0),
+	methodUnsubscribe:            newServerMethodInfo(serverMethod((*Server).unsubscribe), 0),
+	notificationInitialized:      newServerMethodInfo(serverSessionMethod((*ServerSession).initialized), notification|missingParamsOK),
+	notificationRootsListChanged: newServerMethodInfo(serverMethod((*Server).callRootsListChangedHandler), notification|missingParamsOK),
+	notificationProgress:         newServerMethodInfo(serverSessionMethod((*ServerSession).callProgressNotificationHandler), notification),
 }
 
 func (ss *ServerSession) sendingMethodInfos() map[string]methodInfo { return clientMethodInfos }
@@ -757,15 +770,17 @@ func (ss *ServerSession) sendingMethodInfos() map[string]methodInfo { return cli
 func (ss *ServerSession) receivingMethodInfos() map[string]methodInfo { return serverMethodInfos }
 
 func (ss *ServerSession) sendingMethodHandler() methodHandler {
-	ss.server.mu.Lock()
-	defer ss.server.mu.Unlock()
-	return ss.server.sendingMethodHandler_
+	s := ss.server
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sendingMethodHandler_
 }
 
 func (ss *ServerSession) receivingMethodHandler() methodHandler {
-	ss.server.mu.Lock()
-	defer ss.server.mu.Unlock()
-	return ss.server.receivingMethodHandler_
+	s := ss.server
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.receivingMethodHandler_
 }
 
 // getConn implements [session.getConn].
@@ -808,13 +823,14 @@ func (ss *ServerSession) initialize(ctx context.Context, params *InitializeParam
 		version = latestProtocolVersion
 	}
 
+	s := ss.server
 	return &InitializeResult{
 		// TODO(rfindley): alter behavior when falling back to an older version:
 		// reject unsupported features.
 		ProtocolVersion: version,
-		Capabilities:    ss.server.capabilities(),
-		Instructions:    ss.server.opts.Instructions,
-		ServerInfo:      ss.server.impl,
+		Capabilities:    s.capabilities(),
+		Instructions:    s.opts.Instructions,
+		ServerInfo:      s.impl,
 	}, nil
 }
 

--- a/mcp/server_example_test.go
+++ b/mcp/server_example_test.go
@@ -16,10 +16,10 @@ type SayHiParams struct {
 	Name string `json:"name"`
 }
 
-func SayHi(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[SayHiParams]) (*mcp.CallToolResultFor[any], error) {
+func SayHi(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[SayHiParams]]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: "Hi " + params.Arguments.Name},
+			&mcp.TextContent{Text: "Hi " + req.Params.Arguments.Name},
 		},
 	}, nil
 }

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -281,10 +281,10 @@ func TestServerCapabilities(t *testing.T) {
 				s.AddResourceTemplate(&ResourceTemplate{URITemplate: "file:///rt"}, nil)
 			},
 			serverOpts: ServerOptions{
-				SubscribeHandler: func(ctx context.Context, _ *ServerSession, sp *SubscribeParams) error {
+				SubscribeHandler: func(context.Context, *ServerRequest[*SubscribeParams]) error {
 					return nil
 				},
-				UnsubscribeHandler: func(ctx context.Context, _ *ServerSession, up *UnsubscribeParams) error {
+				UnsubscribeHandler: func(context.Context, *ServerRequest[*UnsubscribeParams]) error {
 					return nil
 				},
 			},
@@ -307,7 +307,7 @@ func TestServerCapabilities(t *testing.T) {
 			name:            "With completions",
 			configureServer: func(s *Server) {},
 			serverOpts: ServerOptions{
-				CompletionHandler: func(ctx context.Context, ss *ServerSession, params *CompleteParams) (*CompleteResult, error) {
+				CompletionHandler: func(context.Context, *ServerRequest[*CompleteParams]) (*CompleteResult, error) {
 					return nil, nil
 				},
 			},
@@ -325,13 +325,13 @@ func TestServerCapabilities(t *testing.T) {
 				s.AddTool(tool, nil)
 			},
 			serverOpts: ServerOptions{
-				SubscribeHandler: func(ctx context.Context, _ *ServerSession, sp *SubscribeParams) error {
+				SubscribeHandler: func(context.Context, *ServerRequest[*SubscribeParams]) error {
 					return nil
 				},
-				UnsubscribeHandler: func(ctx context.Context, _ *ServerSession, up *UnsubscribeParams) error {
+				UnsubscribeHandler: func(context.Context, *ServerRequest[*UnsubscribeParams]) error {
 					return nil
 				},
-				CompletionHandler: func(ctx context.Context, ss *ServerSession, params *CompleteParams) (*CompleteResult, error) {
+				CompletionHandler: func(context.Context, *ServerRequest[*CompleteParams]) (*CompleteResult, error) {
 					return nil, nil
 				},
 			},

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
@@ -132,7 +133,8 @@ func handleReceive[S Session](ctx context.Context, session S, jreq *jsonrpc.Requ
 	}
 
 	mh := session.receivingMethodHandler().(MethodHandler)
-	req := info.newRequest(session, params)
+	ti, _ := jreq.Meta.(*auth.TokenInfo)
+	req := info.newRequest(session, params, ti)
 	// mh might be user code, so ensure that it returns the right values for the jsonrpc2 protocol.
 	res, err := mh(ctx, jreq.Method, req)
 	if err != nil {
@@ -179,7 +181,7 @@ type methodInfo struct {
 	// Unmarshal params from the wire into a Params struct.
 	// Used on the receive side.
 	unmarshalParams func(json.RawMessage) (Params, error)
-	newRequest      func(Session, Params) Request
+	newRequest      func(Session, Params, *auth.TokenInfo) Request
 	// Run the code when a call to the method is received.
 	// Used on the receive side.
 	handleMethod methodHandler
@@ -214,7 +216,7 @@ const (
 
 func newClientMethodInfo[P paramsPtr[T], R Result, T any](d typedClientMethodHandler[P, R], flags methodFlags) methodInfo {
 	mi := newMethodInfo[P, R](flags)
-	mi.newRequest = func(s Session, p Params) Request {
+	mi.newRequest = func(s Session, p Params, _ *auth.TokenInfo) Request {
 		r := &ClientRequest[P]{Session: s.(*ClientSession)}
 		if p != nil {
 			r.Params = p.(P)
@@ -229,19 +231,15 @@ func newClientMethodInfo[P paramsPtr[T], R Result, T any](d typedClientMethodHan
 
 func newServerMethodInfo[P paramsPtr[T], R Result, T any](d typedServerMethodHandler[P, R], flags methodFlags) methodInfo {
 	mi := newMethodInfo[P, R](flags)
-	mi.newRequest = func(s Session, p Params) Request {
-		r := &ServerRequest[P]{Session: s.(*ServerSession)}
+	mi.newRequest = func(s Session, p Params, ti *auth.TokenInfo) Request {
+		r := &ServerRequest[P]{Session: s.(*ServerSession), TokenInfo: ti}
 		if p != nil {
 			r.Params = p.(P)
 		}
 		return r
 	}
 	mi.handleMethod = MethodHandler(func(ctx context.Context, _ string, req Request) (Result, error) {
-		rf := &ServerRequest[P]{Session: req.GetSession().(*ServerSession)}
-		if req.GetParams() != nil {
-			rf.Params = req.GetParams().(P)
-		}
-		return d(ctx, rf)
+		return d(ctx, req.(*ServerRequest[P]))
 	})
 	return mi
 }
@@ -395,8 +393,9 @@ type ClientRequest[P Params] struct {
 
 // A ServerRequest is a request to a server.
 type ServerRequest[P Params] struct {
-	Session *ServerSession
-	Params  P
+	Session   *ServerSession
+	Params    P
+	TokenInfo *auth.TokenInfo // bearer token info (e.g. from OAuth) if any
 }
 
 func (*ClientRequest[P]) isRequest() {}

--- a/mcp/sse_example_test.go
+++ b/mcp/sse_example_test.go
@@ -18,10 +18,10 @@ type AddParams struct {
 	X, Y int
 }
 
-func Add(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallToolParamsFor[AddParams]) (*mcp.CallToolResultFor[any], error) {
+func Add(ctx context.Context, req *mcp.ServerRequest[*mcp.CallToolParamsFor[AddParams]]) (*mcp.CallToolResultFor[any], error) {
 	return &mcp.CallToolResultFor[any]{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: fmt.Sprintf("%d", params.Arguments.X+params.Arguments.Y)},
+			&mcp.TextContent{Text: fmt.Sprintf("%d", req.Params.Arguments.X+req.Params.Arguments.Y)},
 		},
 	}, nil
 }

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
@@ -458,12 +459,13 @@ func (t *StreamableServerTransport) servePOST(w http.ResponseWriter, req *http.R
 	// This also requires access to the negotiated version, which would either be
 	// set by the MCP-Protocol-Version header, or would require peeking into the
 	// session.
-	incoming, _, err := readBatch(body)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("malformed payload: %v", err), http.StatusBadRequest)
 		return
 	}
+	incoming, _, err := readBatch(body)
 	requests := make(map[jsonrpc.ID]struct{})
+	tokenInfo := auth.TokenInfoFromContext(req.Context())
 	for _, msg := range incoming {
 		if req, ok := msg.(*jsonrpc.Request); ok {
 			// Preemptively check that this is a valid request, so that we can fail
@@ -473,6 +475,7 @@ func (t *StreamableServerTransport) servePOST(w http.ResponseWriter, req *http.R
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
+			req.Meta = tokenInfo
 			if req.ID.IsValid() {
 				requests[req.ID] = struct{}{}
 			}
@@ -996,6 +999,10 @@ func (c *streamableClientConn) Read(ctx context.Context) (jsonrpc.Message, error
 	}
 }
 
+// testAuth controls whether a fake Authorization header is added to outgoing requests.
+// TODO: replace with a better mechanism when client-side auth is in place.
+var testAuth = false
+
 // Write implements the [Connection] interface.
 func (c *streamableClientConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	if err := c.failure(); err != nil {
@@ -1013,6 +1020,9 @@ func (c *streamableClientConn) Write(ctx context.Context, msg jsonrpc.Message) e
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
+	if testAuth {
+		req.Header.Set("Authorization", "Bearer foo")
+	}
 	c.setMCPHeaders(req)
 
 	resp, err := c.client.Do(req)

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
@@ -892,4 +893,52 @@ func TestStreamableStateless(t *testing.T) {
 
 	// Verify we can make another request without session ID
 	checkRequest(`{"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"greet","arguments":{"name":"World"}}}`)
+}
+
+func TestTokenInfo(t *testing.T) {
+	defer func(b bool) { testAuth = b }(testAuth)
+	testAuth = true
+	ctx := context.Background()
+
+	// Create a server with a tool that returns TokenInfo.
+	tokenInfo := func(ctx context.Context, req *ServerRequest[*CallToolParamsFor[struct{}]]) (*CallToolResultFor[any], error) {
+		return &CallToolResultFor[any]{Content: []Content{&TextContent{Text: fmt.Sprintf("%v", req.TokenInfo)}}}, nil
+	}
+	server := NewServer(testImpl, nil)
+	AddTool(server, &Tool{Name: "tokenInfo", Description: "return token info"}, tokenInfo)
+
+	streamHandler := NewStreamableHTTPHandler(func(req *http.Request) *Server { return server }, nil)
+	verifier := func(context.Context, string) (*auth.TokenInfo, error) {
+		return &auth.TokenInfo{
+			Scopes: []string{"scope"},
+			// Expiration is far, far in the future.
+			Expiration: time.Date(5000, 1, 2, 3, 4, 5, 0, time.Local),
+		}, nil
+	}
+	handler := auth.RequireBearerToken(verifier, nil)(streamHandler)
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+
+	transport := NewStreamableClientTransport(httpServer.URL, nil)
+	client := NewClient(testImpl, nil)
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect() failed: %v", err)
+	}
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &CallToolParams{Name: "tokenInfo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Content) == 0 {
+		t.Fatal("missing content")
+	}
+	tc, ok := res.Content[0].(*TextContent)
+	if !ok {
+		t.Fatal("not TextContent")
+	}
+	if g, w := tc.Text, "&{[scope] 5000-01-02 03:04:05 -0500 EST map[]}"; g != w {
+		t.Errorf("got %q, want %q", g, w)
+	}
 }

--- a/mcp/tool.go
+++ b/mcp/tool.go
@@ -66,8 +66,9 @@ func newServerTool[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*serverTool
 		}
 		// TODO(jba): improve copy
 		res, err := h(ctx, &ServerRequest[*CallToolParamsFor[In]]{
-			Session: req.Session,
-			Params:  params,
+			Session:   req.Session,
+			Params:    params,
+			TokenInfo: req.TokenInfo,
 		})
 		// TODO(rfindley): investigate why server errors are embedded in this strange way,
 		// rather than returned as jsonrpc2 server errors.

--- a/mcp/tool_test.go
+++ b/mcp/tool_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // testToolHandler is used for type inference in TestNewServerTool.
-func testToolHandler[In, Out any](context.Context, *ServerSession, *CallToolParamsFor[In]) (*CallToolResultFor[Out], error) {
+func testToolHandler[In, Out any](context.Context, *ServerRequest[*CallToolParamsFor[In]]) (*CallToolResultFor[Out], error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
If there is a TokenInfo in the request context of a StreamableServerTransport, then propagate it through to the ServerRequest that is passed to server methods like callTool.