### PR TITLE
mcp/tool: duplicate tools should not error

### DIFF
--- a/mcp/tool.go
+++ b/mcp/tool.go
@@ -97,31 +97,11 @@ func setSchema[T any](sfield **jsonschema.Schema, rfield **jsonschema.Resolved) 
 	var err error
 	if *sfield == nil {
 		*sfield, err = jsonschema.For[T](nil)
-		if err != nil {
-			return err
-		}
 	}
-	// Resolve operates with internal state and cannot be called twice on the same
-	// Schema instance. Deep-copy the schema before resolving to avoid mutating the
-	// original (which may be reused when adding the same tool again).
-	cloned, err := func(orig *jsonschema.Schema) (*jsonschema.Schema, error) {
-		if orig == nil {
-			return nil, nil
-		}
-		b, err := json.Marshal(orig)
-		if err != nil {
-			return nil, err
-		}
-		var cp jsonschema.Schema
-		if err := json.Unmarshal(b, &cp); err != nil {
-			return nil, err
-		}
-		return &cp, nil
-	}(*sfield)
 	if err != nil {
 		return err
 	}
-	*rfield, err = cloned.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
+	*rfield, err = (*sfield).Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
 	return err
 }
 


### PR DESCRIPTION
mcp/tool: duplicate tools should not error

These changes touch SetSchema, since that was the best place that I could find resolve this issue. 

This is my first time contributing to open source, I hope that I've followed expected formatting and if not I would happy to fix whatever you all need :)

All tests are passing and I duplicated tools in one of the examples(was hello/) and it ran without error. 

Fixes #217 

