### PR TITLE
mcp: allow correct 'Accept' header values (#290)

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -98,9 +98,12 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 	var jsonOK, streamOK bool
 	for _, c := range accept {
 		switch strings.TrimSpace(c) {
-		case "application/json":
+		case "application/json", "application/*":
 			jsonOK = true
-		case "text/event-stream":
+		case "text/event-stream", "text/*":
+			streamOK = true
+		case "*/*":
+			jsonOK = true
 			streamOK = true
 		}
 	}


### PR DESCRIPTION
Allow other header values for the 'Accept' header that imply application/json and text/event-stream for requests to the Streamable HTTP Transport.

Fixes #290

Unit tests here seemed like unnecessary complexity and wouldn't fit cleanly with the style of the `streamable_test.go` tests. Happy to add those if desired though.
