### PR TITLE
mcp/server.go: implement server-side logging throughout codebase

### DIFF
--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"sync"
@@ -157,7 +156,9 @@ func connect[H handler, State any](ctx context.Context, t Transport, b binder[H,
 		OnDone: func() {
 			b.disconnect(h)
 		},
-		OnInternalError: func(err error) { log.Printf("jsonrpc2 error: %v", err) },
+		OnInternalError: func(err error) {
+			internalLogger.Error("jsonrpc2 internal error", "error", err)
+		},
 	})
 	assert(preempter.conn != nil, "unbound preempter")
 	return h, nil


### PR DESCRIPTION
mcp/server.go: implement server‑side logging

- Thread a `*slog.Logger` through server paths to improve debuggability
- Introduce no‑op discard handler + `ensureLogger` so loggers are never nil
- Use ensured loggers in `Server`, `SSEHandler`/`SSEServerTransport`; remove nil checks
- Route jsonrpc2 internal errors to an internal logger

All tests are passing and no functionality should change with this PR

Fixes #170