### PR TITLE
Improvements to the stateless streamable transport

### DIFF
--- a/internal/jsonrpc2/conn.go
+++ b/internal/jsonrpc2/conn.go
@@ -742,8 +742,8 @@ func (c *Connection) write(ctx context.Context, msg Message) error {
 	var err error
 	// Fail writes immediately if the connection is shutting down.
 	//
-	// TODO(rfindley): should we allow cancellation notifations through? It could
-	// be the case that writes can still succeed.
+	// TODO(rfindley): should we allow cancellation notifications through? It
+	// could be the case that writes can still succeed.
 	c.updateInFlight(func(s *inFlightState) {
 		err = s.shuttingDown(ErrServerClosing)
 	})

--- a/internal/jsonrpc2/wire.go
+++ b/internal/jsonrpc2/wire.go
@@ -37,6 +37,17 @@ var (
 	ErrServerClosing = NewError(-32004, "server is closing")
 	// ErrClientClosing is a dummy error returned for calls initiated while the client is closing.
 	ErrClientClosing = NewError(-32003, "client is closing")
+
+	// The following errors have special semantics for MCP transports
+
+	// ErrRejected may be wrapped to return errors from calls to Writer.Write
+	// that signal that the request was rejected by the transport layer as
+	// invalid.
+	//
+	// Such failures do not indicate that the connection is broken, but rather
+	// should be returned to the caller to indicate that the specific request is
+	// invalid in the current context.
+	ErrRejected = NewError(-32004, "rejected by transport")
 )
 
 const wireVersion = "2.0"

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -355,6 +355,8 @@ func (s *Server) callTool(ctx context.Context, req *ServerRequest[*CallToolParam
 	if !ok {
 		return nil, fmt.Errorf("%s: unknown tool %q", jsonrpc2.ErrInvalidParams, req.Params.Name)
 	}
+	// TODO: if handler returns nil content, it will serialize as null.
+	// Add a test and fix.
 	return st.handler(ctx, req)
 }
 

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -40,8 +40,8 @@ type Transport interface {
 type Connection interface {
 	// Read reads the next message to process off the connection.
 	//
-	// Read need not be safe for concurrent use: Read is called in a
-	// concurrency-safe manner by the JSON-RPC library.
+	// Connections must allow Read to be called concurrently with Close. In
+	// particular, calling Close should unblock a Read waiting for input.
 	Read(context.Context) (jsonrpc.Message, error)
 
 	// Write writes a new message to the connection.


### PR DESCRIPTION
Several improvements for the stateless streamable mode, plus support for
a 'distributed' (or rather, distributable) version of the stateless
server.

- Add a 'Stateless' option to StreamableHTTPOptions and
  StreamableServerTransport, which controls stateless behavior.
  GetSessionID may still return a non-empty session ID.
- Audit validation of stateless mode to allow requests with a session
  id. Propagate this session ID to the temporary connection.
- Peek at requests to allow 'initialize' and 'initialized' requests to go through to the
  session, so that version negotiation can occur (FIXME: add tests).

Fixes #284
Fixes #10
Updates #148