### PR TITLE
mcp: replace custom randText implementation with crypto/rand.Text

### DIFF
--- a/examples/server/sequentialthinking/main.go
+++ b/examples/server/sequentialthinking/main.go
@@ -486,18 +486,8 @@ func ThinkingHistory(ctx context.Context, req *mcp.ServerRequest[*mcp.ReadResour
 	}, nil
 }
 
-// Copied from crypto/rand.
-// TODO: once 1.24 is assured, just use crypto/rand.
-const base32alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
-
 func randText() string {
-	// ⌈log₃₂ 2¹²⁸⌉ = 26 chars
-	src := make([]byte, 26)
-	rand.Read(src)
-	for i := range src {
-		src[i] = base32alphabet[src[i]%32]
-	}
-	return string(src)
+	return rand.Text()
 }
 
 func main() {

--- a/mcp/util.go
+++ b/mcp/util.go
@@ -14,16 +14,6 @@ func assert(cond bool, msg string) {
 	}
 }
 
-// Copied from crypto/rand.
-// TODO: once 1.24 is assured, just use crypto/rand.
-const base32alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
-
 func randText() string {
-	// ⌈log₃₂ 2¹²⁸⌉ = 26 chars
-	src := make([]byte, 26)
-	rand.Read(src)
-	for i := range src {
-		src[i] = base32alphabet[src[i]%32]
-	}
-	return string(src)
+	return rand.Text()
 }


### PR DESCRIPTION
- Remove custom base32alphabet constant and manual implementation
- Use Go 1.24's crypto/rand.Text() function for secure random text generation
- Simplify code by removing 26 lines of custom implementation
- Maintain same functionality with standard library implementation

This change resolves TODO comments about using crypto/rand.Text once Go 1.24 is assured. The standard library implementation provides the same security guarantees with better maintainability and consistency.

Fixes: #TODO (use crypto/rand.Text)