### PR TITLE
mcp: ensure keepalive goroutine is started exactly once

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -602,9 +602,6 @@ func (ss *ServerSession) initialized(ctx context.Context, params *InitializedPar
 		// params are non-nil.
 		params = new(InitializedParams)
 	}
-	if ss.server.opts.KeepAlive > 0 {
-		ss.startKeepalive(ss.server.opts.KeepAlive)
-	}
 	var wasInit, wasInitd bool
 	ss.updateState(func(state *ServerSessionState) {
 		wasInit = state.InitializeParams != nil
@@ -619,6 +616,9 @@ func (ss *ServerSession) initialized(ctx context.Context, params *InitializedPar
 	}
 	if wasInitd {
 		return nil, fmt.Errorf("duplicate %q received", notificationInitialized)
+	}
+	if ss.server.opts.KeepAlive > 0 {
+		ss.startKeepalive(ss.server.opts.KeepAlive)
 	}
 	if h := ss.server.opts.InitializedHandler; h != nil {
 		h(ctx, serverRequestFor(ss, params))


### PR DESCRIPTION
### change:
Reorder the logic within `ServerSession.initialized` to ensure `ss.startKeepalive` is called only after the session's state is validated. 
The `startKeepalive` function is now only invoked when the session is first transitioning from `initialize` to `initialized` state.

Fixes #313 