### PR TITLE
mcp: rename logging symbols

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -103,8 +103,7 @@ func (e unsupportedProtocolVersionError) Error() string {
 }
 
 // ClientSessionOptions is reserved for future use.
-type ClientSessionOptions struct {
-}
+type ClientSessionOptions struct{}
 
 // Connect begins an MCP session by connecting to a server over the given
 // transport, and initializing the session.
@@ -398,7 +397,7 @@ func (cs *ClientSession) CallTool(ctx context.Context, params *CallToolParams) (
 	return handleSend[*CallToolResult](ctx, methodCallTool, newClientRequest(cs, orZero[Params](params)))
 }
 
-func (cs *ClientSession) SetLevel(ctx context.Context, params *SetLevelParams) error {
+func (cs *ClientSession) SetLoggingLevel(ctx context.Context, params *SetLoggingLevelParams) error {
 	_, err := handleSend[*emptyResult](ctx, methodSetLevel, newClientRequest(cs, orZero[Params](params)))
 	return err
 }

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -404,7 +404,7 @@ func TestEndToEnd(t *testing.T) {
 
 			// Nothing should be logged until the client sets a level.
 			mustLog("info", "before")
-			if err := cs.SetLevel(ctx, &SetLevelParams{Level: "warning"}); err != nil {
+			if err := cs.SetLoggingLevel(ctx, &SetLoggingLevelParams{Level: "warning"}); err != nil {
 				t.Fatal(err)
 			}
 			mustLog("warning", want[0].Data)

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -826,7 +826,7 @@ func (m *SamplingMessage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type SetLevelParams struct {
+type SetLoggingLevelParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
 	Meta `json:"_meta,omitempty"`
@@ -836,9 +836,9 @@ type SetLevelParams struct {
 	Level LoggingLevel `json:"level"`
 }
 
-func (x *SetLevelParams) isParams()              {}
-func (x *SetLevelParams) GetProgressToken() any  { return getProgressToken(x) }
-func (x *SetLevelParams) SetProgressToken(t any) { setProgressToken(x, t) }
+func (x *SetLoggingLevelParams) isParams()              {}
+func (x *SetLoggingLevelParams) GetProgressToken() any  { return getProgressToken(x) }
+func (x *SetLoggingLevelParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
 // Definition for a tool the client can call.
 type Tool struct {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -857,7 +857,7 @@ func (ss *ServerSession) cancel(context.Context, *CancelledParams) (Result, erro
 	return nil, nil
 }
 
-func (ss *ServerSession) setLevel(_ context.Context, params *SetLevelParams) (*emptyResult, error) {
+func (ss *ServerSession) setLevel(_ context.Context, params *SetLoggingLevelParams) (*emptyResult, error) {
 	ss.updateState(func(state *ServerSessionState) {
 		state.LogLevel = params.Level
 	})


### PR DESCRIPTION
Fixes #279.
