### PR TITLE
mcp: replace type struct{} with any for user-defined fields

### DIFF
--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -126,7 +126,7 @@ func (x *CancelledParams) SetProgressToken(t any) { setProgressToken(x, t) }
 // additional capabilities.
 type ClientCapabilities struct {
 	// Experimental, non-standard capabilities that the client supports.
-	Experimental map[string]struct{} `json:"experimental,omitempty"`
+	Experimental map[string]any `json:"experimental,omitempty"`
 	// Present if the client supports listing roots.
 	Roots struct {
 		// Whether the client supports notifications for changes to the roots list.
@@ -242,7 +242,7 @@ type CreateMessageParams struct {
 	Messages  []*SamplingMessage `json:"messages"`
 	// Optional metadata to pass through to the LLM provider. The format of this
 	// metadata is provider-specific.
-	Metadata struct{} `json:"metadata,omitempty"`
+	Metadata any `json:"metadata,omitempty"`
 	// The server's preferences for which model to select. The client may ignore
 	// these preferences.
 	ModelPreferences *ModelPreferences `json:"modelPreferences,omitempty"`
@@ -997,7 +997,7 @@ type ServerCapabilities struct {
 	// Present if the server supports argument autocompletion suggestions.
 	Completions *CompletionCapabilities `json:"completions,omitempty"`
 	// Experimental, non-standard capabilities that the server supports.
-	Experimental map[string]struct{} `json:"experimental,omitempty"`
+	Experimental map[string]any `json:"experimental,omitempty"`
 	// Present if the server supports sending log messages to the client.
 	Logging *LoggingCapabilities `json:"logging,omitempty"`
 	// Present if the server offers any prompt templates.


### PR DESCRIPTION
This change adopts a clearer convention:
- any is used for fields where the structure is defined by the client or server implementer.
- an named empty struct type is the place holder type to be defined by the MCP spec in the future. 

The "Experimental" fields in "ClientCapabilities" and "ServerCapabilities" now use "map[string]any". This allows clients and servers to negotiate custom capabilities that contain complex data, rather than being restricted to a simple on/off flag.

The "Metadata" field in "CreateMessageParams" was also changed to "any" to properly serve its purpose as a flexible container for server-defined data.