### PR TITLE
mcp/streamable: use event store to fix unbounded memory issues

### DIFF
--- a/mcp/event.go
+++ b/mcp/event.go
@@ -274,12 +274,6 @@ func (s *MemoryEventStore) Append(_ context.Context, sessionID string, streamID 
 	// Purge before adding, so at least the current data item will be present.
 	// (That could result in nBytes > maxBytes, but we'll live with that.)
 	s.purge()
-
-	// An empty data slice signals that a stream has been registered.
-	// We ignore it since it contains no content and shouldn't affect the total size.
-	if data == nil {
-		return nil
-	}
 	dl.appendData(data)
 	s.nBytes += len(data)
 	return nil

--- a/mcp/event.go
+++ b/mcp/event.go
@@ -153,6 +153,11 @@ func scanEvents(r io.Reader) iter.Seq2[Event, error] {
 //
 // All of an EventStore's methods must be safe for use by multiple goroutines.
 type EventStore interface {
+	// Open prepares the event store for a given session. It ensures that the
+	// underlying data structure for the sessionID is initialized, making it
+	// ready to store event streams.
+	Open(_ context.Context, sessionID string, streamID StreamID) error
+
 	// Append appends data for an outgoing event to given stream, which is part of the
 	// given session.
 	Append(_ context.Context, sessionID string, _ StreamID, data []byte) error
@@ -256,11 +261,21 @@ func NewMemoryEventStore(opts *MemoryEventStoreOptions) *MemoryEventStore {
 	}
 }
 
-// Append implements [EventStore.Append] by recording data in memory.
-func (s *MemoryEventStore) Append(_ context.Context, sessionID string, streamID StreamID, data []byte) error {
+// Open implements [EventStore.Open]. It ensures that the underlying data
+// structures for the given session and stream IDs are initialized and ready
+// for use.
+func (s *MemoryEventStore) Open(_ context.Context, sessionID string, streamID StreamID) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.init(sessionID, streamID)
+	return nil
+}
 
+// init is an internal helper function that ensures the nested map structure for a
+// given sessionID and streamID exists, creating it if necessary. It returns the
+// dataList associated with the specified IDs.
+// This function must be called within a locked context.
+func (s *MemoryEventStore) init(sessionID string, streamID StreamID) *dataList {
 	streamMap, ok := s.store[sessionID]
 	if !ok {
 		streamMap = make(map[StreamID]*dataList)
@@ -271,6 +286,14 @@ func (s *MemoryEventStore) Append(_ context.Context, sessionID string, streamID 
 		dl = &dataList{}
 		streamMap[streamID] = dl
 	}
+	return dl
+}
+
+// Append implements [EventStore.Append] by recording data in memory.
+func (s *MemoryEventStore) Append(_ context.Context, sessionID string, streamID StreamID, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	dl := s.init(sessionID, streamID)
 	// Purge before adding, so at least the current data item will be present.
 	// (That could result in nBytes > maxBytes, but we'll live with that.)
 	s.purge()

--- a/mcp/event.go
+++ b/mcp/event.go
@@ -283,6 +283,12 @@ func (s *MemoryEventStore) Append(_ context.Context, sessionID string, streamID 
 // index is no longer available.
 var ErrEventsPurged = errors.New("data purged")
 
+// ErrUnknownSession is the error that [EventStore.After] should return if the session ID is unknown.
+var ErrUnknownSession = errors.New("unknown session ID")
+
+// ErrUnknownSession is the error that [EventStore.After] should return if the stream ID is unknown.
+var ErrUnknownStream = errors.New("unknown stream ID")
+
 // After implements [EventStore.After].
 func (s *MemoryEventStore) After(_ context.Context, sessionID string, streamID StreamID, index int) iter.Seq2[[]byte, error] {
 	// Return the data items to yield.
@@ -292,11 +298,11 @@ func (s *MemoryEventStore) After(_ context.Context, sessionID string, streamID S
 		defer s.mu.Unlock()
 		streamMap, ok := s.store[sessionID]
 		if !ok {
-			return nil, fmt.Errorf("MemoryEventStore.After: unknown session ID %q", sessionID)
+			return nil, fmt.Errorf("MemoryEventStore.After: session ID %v: %w", sessionID, ErrUnknownSession)
 		}
 		dl, ok := streamMap[streamID]
 		if !ok {
-			return nil, fmt.Errorf("MemoryEventStore.After: unknown stream ID %v in session %q", streamID, sessionID)
+			return nil, fmt.Errorf("MemoryEventStore.After: stream ID %v in session %q: %w", streamID, sessionID, ErrUnknownStream)
 		}
 		start := index + 1
 		if dl.first > start {

--- a/mcp/event.go
+++ b/mcp/event.go
@@ -274,6 +274,12 @@ func (s *MemoryEventStore) Append(_ context.Context, sessionID string, streamID 
 	// Purge before adding, so at least the current data item will be present.
 	// (That could result in nBytes > maxBytes, but we'll live with that.)
 	s.purge()
+
+	// An empty data slice signals that a stream has been registered.
+	// We ignore it since it contains no content and shouldn't affect the total size.
+	if data == nil {
+		return nil
+	}
 	dl.appendData(data)
 	s.nBytes += len(data)
 	return nil
@@ -282,12 +288,6 @@ func (s *MemoryEventStore) Append(_ context.Context, sessionID string, streamID 
 // ErrEventsPurged is the error that [EventStore.After] should return if the event just after the
 // index is no longer available.
 var ErrEventsPurged = errors.New("data purged")
-
-// ErrUnknownSession is the error that [EventStore.After] should return if the session ID is unknown.
-var ErrUnknownSession = errors.New("unknown session ID")
-
-// ErrUnknownSession is the error that [EventStore.After] should return if the stream ID is unknown.
-var ErrUnknownStream = errors.New("unknown stream ID")
 
 // After implements [EventStore.After].
 func (s *MemoryEventStore) After(_ context.Context, sessionID string, streamID StreamID, index int) iter.Seq2[[]byte, error] {
@@ -298,11 +298,11 @@ func (s *MemoryEventStore) After(_ context.Context, sessionID string, streamID S
 		defer s.mu.Unlock()
 		streamMap, ok := s.store[sessionID]
 		if !ok {
-			return nil, fmt.Errorf("MemoryEventStore.After: session ID %v: %w", sessionID, ErrUnknownSession)
+			return nil, fmt.Errorf("MemoryEventStore.After: unknown session ID %q", sessionID)
 		}
 		dl, ok := streamMap[streamID]
 		if !ok {
-			return nil, fmt.Errorf("MemoryEventStore.After: stream ID %v in session %q: %w", streamID, sessionID, ErrUnknownStream)
+			return nil, fmt.Errorf("MemoryEventStore.After: unknown stream ID %v in session %q", streamID, sessionID)
 		}
 		start := index + 1
 		if dl.first > start {


### PR DESCRIPTION
This CL utilizes the event store to write outgoing messages and removes the unbounded outgoing data structure.

For #190