### PR TITLE
mcp: remove references to ClientRequest[T] for concrete T

### DIFF
--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -211,7 +211,7 @@ func TestClientCapabilities(t *testing.T) {
 			name:            "With sampling",
 			configureClient: func(s *Client) {},
 			clientOpts: ClientOptions{
-				CreateMessageHandler: func(context.Context, *ClientRequest[*CreateMessageParams]) (*CreateMessageResult, error) {
+				CreateMessageHandler: func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error) {
 					return nil, nil
 				},
 			},

--- a/mcp/requests.go
+++ b/mcp/requests.go
@@ -8,17 +8,30 @@ package mcp
 
 // TODO: expand the aliases
 type (
-	CallToolRequest              = ServerRequest[*CallToolParams]
-	CompleteRequest              = ServerRequest[*CompleteParams]
-	GetPromptRequest             = ServerRequest[*GetPromptParams]
-	InitializedRequest           = ServerRequest[*InitializedParams]
-	ListPromptsRequest           = ServerRequest[*ListPromptsParams]
-	ListResourcesRequest         = ServerRequest[*ListResourcesParams]
-	ListResourceTemplatesRequest = ServerRequest[*ListResourceTemplatesParams]
-	ListToolsRequest             = ServerRequest[*ListToolsParams]
-	ProgressNotificationRequest  = ServerRequest[*ProgressNotificationParams]
-	ReadResourceRequest          = ServerRequest[*ReadResourceParams]
-	RootsListChangedRequest      = ServerRequest[*RootsListChangedParams]
-	SubscribeRequest             = ServerRequest[*SubscribeParams]
-	UnsubscribeRequest           = ServerRequest[*UnsubscribeParams]
+	CallToolRequest                   = ServerRequest[*CallToolParams]
+	CompleteRequest                   = ServerRequest[*CompleteParams]
+	GetPromptRequest                  = ServerRequest[*GetPromptParams]
+	InitializedServerRequest          = ServerRequest[*InitializedParams]
+	ListPromptsRequest                = ServerRequest[*ListPromptsParams]
+	ListResourcesRequest              = ServerRequest[*ListResourcesParams]
+	ListResourceTemplatesRequest      = ServerRequest[*ListResourceTemplatesParams]
+	ListToolsRequest                  = ServerRequest[*ListToolsParams]
+	ProgressNotificationServerRequest = ServerRequest[*ProgressNotificationParams]
+	ReadResourceRequest               = ServerRequest[*ReadResourceParams]
+	RootsListChangedRequest           = ServerRequest[*RootsListChangedParams]
+	SubscribeRequest                  = ServerRequest[*SubscribeParams]
+	UnsubscribeRequest                = ServerRequest[*UnsubscribeParams]
+)
+
+type (
+	CreateMessageRequest               = ClientRequest[*CreateMessageParams]
+	InitializedClientRequest           = ClientRequest[*InitializedParams]
+	InitializeRequest                  = ClientRequest[*InitializeParams]
+	ListRootsRequest                   = ClientRequest[*ListRootsParams]
+	LoggingMessageRequest              = ClientRequest[*LoggingMessageParams]
+	ProgressNotificationClientRequest  = ClientRequest[*ProgressNotificationParams]
+	PromptListChangedRequest           = ClientRequest[*PromptListChangedParams]
+	ResourceListChangedRequest         = ClientRequest[*ResourceListChangedParams]
+	ResourceUpdatedNotificationRequest = ClientRequest[*ResourceUpdatedNotificationParams]
+	ToolListChangedRequest             = ClientRequest[*ToolListChangedParams]
 )

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -54,14 +54,14 @@ type ServerOptions struct {
 	// Optional instructions for connected clients.
 	Instructions string
 	// If non-nil, called when "notifications/initialized" is received.
-	InitializedHandler func(context.Context, *InitializedRequest)
+	InitializedHandler func(context.Context, *InitializedServerRequest)
 	// PageSize is the maximum number of items to return in a single page for
 	// list methods (e.g. ListTools).
 	PageSize int
 	// If non-nil, called when "notifications/roots/list_changed" is received.
 	RootsListChangedHandler func(context.Context, *RootsListChangedRequest)
 	// If non-nil, called when "notifications/progress" is received.
-	ProgressNotificationHandler func(context.Context, *ProgressNotificationRequest)
+	ProgressNotificationHandler func(context.Context, *ProgressNotificationServerRequest)
 	// If non-nil, called when "completion/complete" is received.
 	CompletionHandler func(context.Context, *CompleteRequest) (*CompleteResult, error)
 	// If non-zero, defines an interval for regular "ping" requests.

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -121,7 +121,7 @@ func TestStreamableTransports(t *testing.T) {
 				HTTPClient: httpClient,
 			}
 			client := NewClient(testImpl, &ClientOptions{
-				CreateMessageHandler: func(context.Context, *ClientRequest[*CreateMessageParams]) (*CreateMessageResult, error) {
+				CreateMessageHandler: func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error) {
 					return &CreateMessageResult{Model: "aModel", Content: &TextContent{}}, nil
 				},
 			})
@@ -255,7 +255,7 @@ func testClientReplay(t *testing.T, test clientReplayTest) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	client := NewClient(testImpl, &ClientOptions{
-		ProgressNotificationHandler: func(ctx context.Context, req *ClientRequest[*ProgressNotificationParams]) {
+		ProgressNotificationHandler: func(ctx context.Context, req *ProgressNotificationClientRequest) {
 			notifications <- req.Params.Message
 		},
 	})
@@ -344,7 +344,7 @@ func TestServerInitiatedSSE(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	client := NewClient(testImpl, &ClientOptions{
-		ToolListChangedHandler: func(context.Context, *ClientRequest[*ToolListChangedParams]) {
+		ToolListChangedHandler: func(context.Context, *ToolListChangedRequest) {
 			notifications <- "toolListChanged"
 		},
 	})


### PR DESCRIPTION
See related PR about ServerRequest[T].
