### PR TITLE
mcp: fix bugs handling pointer types

### DIFF
--- a/mcp/conformance_test.go
+++ b/mcp/conformance_test.go
@@ -8,6 +8,7 @@ package mcp
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -96,6 +97,18 @@ func TestServerConformance(t *testing.T) {
 	}
 }
 
+type input struct {
+	In string `jsonschema:"the input"`
+}
+
+type output struct {
+	Out string `jsonschema:"the output"`
+}
+
+func structuredTool(ctx context.Context, req *CallToolRequest, args *input) (*CallToolResult, *output, error) {
+	return nil, &output{"Ack " + args.In}, nil
+}
+
 // runServerTest runs the server conformance test.
 // It must be executed in a synctest bubble.
 func runServerTest(t *testing.T, test *conformanceTest) {
@@ -109,6 +122,8 @@ func runServerTest(t *testing.T, test *conformanceTest) {
 				Name:        "greet",
 				Description: "say hi",
 			}, sayHi)
+		case "structured":
+			AddTool(s, &Tool{Name: "structured"}, structuredTool)
 		default:
 			t.Fatalf("unknown tool %q", tn)
 		}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -206,7 +206,7 @@ func toolForErr[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHan
 	)
 	if reflect.TypeFor[Out]() != reflect.TypeFor[any]() {
 		var err error
-		elemZero, err = setSchema[Out](&t.OutputSchema, &outputResolved)
+		elemZero, err = setSchema[Out](&tt.OutputSchema, &outputResolved)
 		if err != nil {
 			return nil, nil, fmt.Errorf("output schema: %v", err)
 		}
@@ -257,9 +257,6 @@ func toolForErr[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHan
 			if any(out) == any(z) { // zero is only non-nil if Out is a pointer type
 				res.StructuredContent = elemZero
 			}
-		}
-		if tt.OutputSchema != nil && elemZero != nil {
-			res.StructuredContent = elemZero
 		}
 		return res, nil
 	}

--- a/mcp/testdata/conformance/server/tools.txtar
+++ b/mcp/testdata/conformance/server/tools.txtar
@@ -8,6 +8,7 @@ Fixed bugs:
 
 -- tools --
 greet
+structured
 
 -- client --
 {
@@ -63,6 +64,35 @@ greet
 					"additionalProperties": false
 				},
 				"name": "greet"
+			},
+			{
+				"inputSchema": {
+					"type": "object",
+					"required": [
+						"In"
+					],
+					"properties": {
+						"In": {
+							"type": "string",
+							"description": "the input"
+						}
+					},
+					"additionalProperties": false
+				},
+				"name": "structured",
+				"outputSchema": {
+					"type": "object",
+					"required": [
+						"Out"
+					],
+					"properties": {
+						"Out": {
+							"type": "string",
+							"description": "the output"
+						}
+					},
+					"additionalProperties": false
+				}
 			}
 		]
 	}


### PR DESCRIPTION
Some bad merging in #338 led to a bad bug in the handling of structured output for pointer output types. Add a conformance test and fix the bug.
