### PR TITLE
README: soften the warning, and reference roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,9 @@ This repository contains an unreleased implementation of the official Go
 software development kit (SDK) for the Model Context Protocol (MCP).
 
 > [!WARNING]
-> The SDK should be considered unreleased, and is currently unstable
-> and subject to breaking changes. Please test it out and file bug reports or API
-> proposals, but don't use it in real projects. See the issue tracker for known
-> issues and missing features. We aim to release a stable version of the SDK in
-> August, 2025.
+> The SDK is not yet at v1.0.0 and may still be subject to incompatible API
+> changes. We aim to tag v1.0.0 in September, 2025. See
+> https://github.com/modelcontextprotocol/go-sdk/issues/328 for details.
 
 ## Design
 

--- a/internal/readme/README.src.md
+++ b/internal/readme/README.src.md
@@ -14,11 +14,9 @@ This repository contains an unreleased implementation of the official Go
 software development kit (SDK) for the Model Context Protocol (MCP).
 
 > [!WARNING]
-> The SDK should be considered unreleased, and is currently unstable
-> and subject to breaking changes. Please test it out and file bug reports or API
-> proposals, but don't use it in real projects. See the issue tracker for known
-> issues and missing features. We aim to release a stable version of the SDK in
-> August, 2025.
+> The SDK is not yet at v1.0.0 and may still be subject to incompatible API
+> changes. We aim to tag v1.0.0 in September, 2025. See
+> https://github.com/modelcontextprotocol/go-sdk/issues/328 for details.
 
 ## Design
 


### PR DESCRIPTION
We can warn a little less loudly against using the SDK.