### PR TITLE
mcp: example middleware wrapping ToolHandler

### DIFF
--- a/mcp/example_middleware_test.go
+++ b/mcp/example_middleware_test.go
@@ -136,6 +136,7 @@ func Example_loggingMiddleware() {
 	// time=2025-01-01T00:00:00Z level=INFO msg="MCP method started" method=notifications/initialized session_id="" has_params=true
 	// time=2025-01-01T00:00:00Z level=INFO msg="MCP method completed" method=notifications/initialized session_id="" duration_ms=0 has_result=false
 	// time=2025-01-01T00:00:00Z level=INFO msg="MCP method started" method=tools/call session_id="" has_params=true
+	// time=2025-01-01T00:00:00Z level=INFO msg="Calling tool" name=greet args="{\"name\":\"World\"}"
 	// time=2025-01-01T00:00:00Z level=INFO msg="MCP method completed" method=tools/call session_id="" duration_ms=0 has_result=true
 	// Tool result: Hello, World!
 }


### PR DESCRIPTION
Add to the middleware example to show how to wrap a ToolHandler.

This middleware is very close to, but not the same as, wrapping a ToolHandler directly. The only difference is that the middleware wraps Server.callTool, which looks up the tool by name in the server's list and then calls the handler. That lookup (plus other intervening middleware, of course) is all that distinguishes this way of wrapping from a more direct wrapping.
