### PR TITLE
mcp: unexport InitializeClientRequest

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -153,7 +153,7 @@ func (c *Client) Connect(ctx context.Context, t Transport, _ *ClientSessionOptio
 	if hc, ok := cs.mcpConn.(clientConnection); ok {
 		hc.sessionUpdated(cs.state)
 	}
-	req2 := &InitializedClientRequest{Session: cs, Params: &InitializedParams{}}
+	req2 := &initializedClientRequest{Session: cs, Params: &InitializedParams{}}
 	if err := handleNotify(ctx, notificationInitialized, req2); err != nil {
 		_ = cs.Close()
 		return nil, err

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -75,7 +75,7 @@ func TestEndToEnd(t *testing.T) {
 	}
 
 	sopts := &ServerOptions{
-		InitializedHandler: func(context.Context, *InitializedServerRequest) {
+		InitializedHandler: func(context.Context, *InitializedRequest) {
 			notificationChans["initialized"] <- 0
 		},
 		RootsListChangedHandler: func(context.Context, *RootsListChangedRequest) {

--- a/mcp/requests.go
+++ b/mcp/requests.go
@@ -10,7 +10,7 @@ type (
 	CallToolRequest                   = ServerRequest[*CallToolParams]
 	CompleteRequest                   = ServerRequest[*CompleteParams]
 	GetPromptRequest                  = ServerRequest[*GetPromptParams]
-	InitializedServerRequest          = ServerRequest[*InitializedParams]
+	InitializedRequest                = ServerRequest[*InitializedParams]
 	ListPromptsRequest                = ServerRequest[*ListPromptsParams]
 	ListResourcesRequest              = ServerRequest[*ListResourcesParams]
 	ListResourceTemplatesRequest      = ServerRequest[*ListResourceTemplatesParams]
@@ -25,7 +25,7 @@ type (
 type (
 	CreateMessageRequest               = ClientRequest[*CreateMessageParams]
 	ElicitRequest                      = ClientRequest[*ElicitParams]
-	InitializedClientRequest           = ClientRequest[*InitializedParams]
+	initializedClientRequest           = ClientRequest[*InitializedParams]
 	InitializeRequest                  = ClientRequest[*InitializeParams]
 	ListRootsRequest                   = ClientRequest[*ListRootsParams]
 	LoggingMessageRequest              = ClientRequest[*LoggingMessageParams]

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -54,7 +54,7 @@ type ServerOptions struct {
 	// Optional instructions for connected clients.
 	Instructions string
 	// If non-nil, called when "notifications/initialized" is received.
-	InitializedHandler func(context.Context, *InitializedServerRequest)
+	InitializedHandler func(context.Context, *InitializedRequest)
 	// PageSize is the maximum number of items to return in a single page for
 	// list methods (e.g. ListTools).
 	PageSize int


### PR DESCRIPTION
This request is synthetic, and should not be observed by the user. Unexport it and rename InitializeServerRequest to just InitializeRequest.
