### PR TITLE
mcp/examples: move middleware examples into example folder

### DIFF
--- a/examples/client/middleware/main.go
+++ b/examples/client/middleware/main.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-package mcp_test
+package main
 
 import (
 	"context"
@@ -15,10 +15,9 @@ var nextProgressToken atomic.Int64
 
 // This middleware function adds a progress token to every outgoing request
 // from the client.
-func Example_progressMiddleware() {
-	c := mcp.NewClient(testImpl, nil)
+func main() {
+	c := mcp.NewClient(&mcp.Implementation{Name: "client"}, nil)
 	c.AddSendingMiddleware(addProgressToken[*mcp.ClientSession])
-	_ = c
 }
 
 func addProgressToken[S mcp.Session](h mcp.MethodHandler) mcp.MethodHandler {
@@ -29,3 +28,4 @@ func addProgressToken[S mcp.Session](h mcp.MethodHandler) mcp.MethodHandler {
 		return h(ctx, method, req)
 	}
 }
+

--- a/examples/server/middleware/main.go
+++ b/examples/server/middleware/main.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-package mcp_test
+package main
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 )
 
 // This example demonstrates server side logging using the mcp.Middleware system.
-func Example_loggingMiddleware() {
+func main() {
 	// Create a logger for demonstration purposes.
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,

--- a/mcp/mcp-repo-replace.txt
+++ b/mcp/mcp-repo-replace.txt
@@ -1,9 +1,0 @@
-"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"==>"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
-github.com/modelcontextprotocol/go-sdk/internal/xcontext==>github.com/modelcontextprotocol/go-sdk/internal/xcontext
-github.com/modelcontextprotocol/go-sdk/internal==>github.com/modelcontextprotocol/go-sdk/internal
-github.com/modelcontextprotocol/go-sdk/jsonschema==>github.com/modelcontextprotocol/go-sdk/jsonschema
-github.com/modelcontextprotocol/go-sdk/examples==>github.com/modelcontextprotocol/go-sdk/examples
-github.com/modelcontextprotocol/go-sdk/design==>github.com/modelcontextprotocol/go-sdk/design
-github.com/modelcontextprotocol/go-sdk/mcp==>github.com/modelcontextprotocol/go-sdk/mcp
-governed by an MIT-style==>governed by an MIT-style
-regex:Copyright (20\d\d) The Go Authors==>Copyright \1 The Go MCP SDK Authors


### PR DESCRIPTION
Cleans up examples.