### PR TITLE
mcp/examples: move server example into example folder

### DIFF
--- a/examples/server/basic/main.go
+++ b/examples/server/basic/main.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-package mcp_test
+package main
 
 import (
 	"context"
@@ -24,7 +24,7 @@ func SayHi(ctx context.Context, req *mcp.CallToolRequest, args SayHiParams) (*mc
 	}, nil, nil
 }
 
-func ExampleServer() {
+func main() {
 	ctx := context.Background()
 	clientTransport, serverTransport := mcp.NewInMemoryTransports()
 
@@ -55,20 +55,4 @@ func ExampleServer() {
 	serverSession.Wait()
 
 	// Output: Hi user
-}
-
-// createSessions creates and connects an in-memory client and server session for testing purposes.
-func createSessions(ctx context.Context) (*mcp.ClientSession, *mcp.ServerSession, *mcp.Server) {
-	server := mcp.NewServer(testImpl, nil)
-	client := mcp.NewClient(testImpl, nil)
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-	serverSession, err := server.Connect(ctx, serverTransport, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return clientSession, serverSession, server
 }

--- a/mcp/client_list_test.go
+++ b/mcp/client_list_test.go
@@ -7,6 +7,7 @@ package mcp_test
 import (
 	"context"
 	"iter"
+	"log"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -17,9 +18,19 @@ import (
 
 func TestList(t *testing.T) {
 	ctx := context.Background()
-	clientSession, serverSession, server := createSessions(ctx)
-	defer clientSession.Close()
+	server := mcp.NewServer(testImpl, nil)
+	client := mcp.NewClient(testImpl, nil)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer serverSession.Close()
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer clientSession.Close()
 
 	t.Run("tools", func(t *testing.T) {
 		var wantTools []*mcp.Tool

--- a/mcp/cmd_test.go
+++ b/mcp/cmd_test.go
@@ -22,6 +22,18 @@ import (
 
 const runAsServer = "_MCP_RUN_AS_SERVER"
 
+type SayHiParams struct {
+	Name string `json:"name"`
+}
+
+func SayHi(ctx context.Context, req *mcp.CallToolRequest, args SayHiParams) (*mcp.CallToolResult, any, error) {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: "Hi " + args.Name},
+		},
+	}, nil, nil
+}
+
 func TestMain(m *testing.M) {
 	// If the runAsServer variable is set, execute the relevant serverFunc
 	// instead of running tests (aka the fork and exec trick).


### PR DESCRIPTION
For better organization.