### PR TITLE
mcp: cleanup transport after keepalive ping fails

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -681,9 +681,9 @@ func (s *Server) Run(ctx context.Context, t Transport) error {
 
 // bind implements the binder[*ServerSession] interface, so that Servers can
 // be connected using [connect].
-func (s *Server) bind(mcpConn Connection, conn *jsonrpc2.Connection, state *ServerSessionState) *ServerSession {
+func (s *Server) bind(mcpConn Connection, conn *jsonrpc2.Connection, state *ServerSessionState, onClose func()) *ServerSession {
 	assert(mcpConn != nil && conn != nil, "nil connection")
-	ss := &ServerSession{conn: conn, mcpConn: mcpConn, server: s}
+	ss := &ServerSession{conn: conn, mcpConn: mcpConn, server: s, onClose: onClose}
 	if state != nil {
 		ss.state = *state
 	}
@@ -710,6 +710,8 @@ func (s *Server) disconnect(cc *ServerSession) {
 // ServerSessionOptions configures the server session.
 type ServerSessionOptions struct {
 	State *ServerSessionState
+
+	onClose func()
 }
 
 // Connect connects the MCP server over the given transport and starts handling
@@ -722,10 +724,12 @@ type ServerSessionOptions struct {
 // If opts.State is non-nil, it is the initial state for the server.
 func (s *Server) Connect(ctx context.Context, t Transport, opts *ServerSessionOptions) (*ServerSession, error) {
 	var state *ServerSessionState
+	var onClose func()
 	if opts != nil {
 		state = opts.State
+		onClose = opts.onClose
 	}
-	return connect(ctx, t, s, state)
+	return connect(ctx, t, s, state, onClose)
 }
 
 // TODO: (nit) move all ServerSession methods below the ServerSession declaration.
@@ -792,6 +796,8 @@ func newServerRequest[P Params](ss *ServerSession, params P) *ServerRequest[P] {
 // Call [ServerSession.Close] to close the connection, or await client
 // termination with [ServerSession.Wait].
 type ServerSession struct {
+	onClose func()
+
 	server          *Server
 	conn            *jsonrpc2.Connection
 	mcpConn         Connection
@@ -1018,7 +1024,13 @@ func (ss *ServerSession) Close() error {
 		//    Close is idempotent and conn.Close() handles concurrent calls correctly
 		ss.keepaliveCancel()
 	}
-	return ss.conn.Close()
+	err := ss.conn.Close()
+
+	if ss.onClose != nil {
+		ss.onClose()
+	}
+
+	return err
 }
 
 // Wait waits for the connection to be closed by the client.

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -356,9 +356,7 @@ func TestServerTransportCleanup(t *testing.T) {
 	})
 
 	handler.onTransportDeletion = func(sessionID string) {
-		mu.Lock()
 		chans[sessionID] <- struct{}{}
-		mu.Unlock()
 	}
 
 	httpServer := httptest.NewServer(handler)

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -330,6 +331,78 @@ func testClientReplay(t *testing.T, test clientReplayTest) {
 			t.Errorf("CallTool succeeded unexpectedly")
 		}
 	}
+}
+
+func TestServerTransportCleanup(t *testing.T) {
+	server := NewServer(testImpl, &ServerOptions{KeepAlive: 10 * time.Millisecond})
+
+	nClient := 3
+
+	var mu sync.Mutex
+	var id int = -1 // session id starting from "0", "1", "2"...
+	chans := make(map[string]chan struct{}, nClient)
+
+	handler := NewStreamableHTTPHandler(func(*http.Request) *Server { return server }, &StreamableHTTPOptions{
+		GetSessionID: func() string {
+			mu.Lock()
+			defer mu.Unlock()
+			id++
+			if id == nClient {
+				t.Errorf("creating more than %v session", nClient)
+			}
+			chans[fmt.Sprint(id)] = make(chan struct{}, 1)
+			return fmt.Sprint(id)
+		},
+	})
+
+	handler.onTransportDeletion = func(sessionID string) {
+		mu.Lock()
+		chans[sessionID] <- struct{}{}
+		mu.Unlock()
+	}
+
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Spin up clients connect to the same server but refuse to ping request.
+	for range nClient {
+		client := NewClient(testImpl, nil)
+		pingMiddleware := func(next MethodHandler) MethodHandler {
+			return func(
+				ctx context.Context,
+				method string,
+				req Request,
+			) (Result, error) {
+				if method == "ping" {
+					return &emptyResult{}, errors.New("ping error")
+				}
+				return next(ctx, method, req)
+			}
+		}
+		client.AddReceivingMiddleware(pingMiddleware)
+		clientSession, err := client.Connect(ctx, &StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+		if err != nil {
+			t.Fatalf("client.Connect() failed: %v", err)
+		}
+		defer clientSession.Close()
+	}
+
+	for _, ch := range chans {
+		select {
+		case <-ctx.Done():
+			t.Errorf("did not capture transport deletion event from all session in 10 seconds")
+		case <-ch: // Received transport deletion signal of this session
+		}
+	}
+
+	handler.mu.Lock()
+	if len(handler.transports) != 0 {
+		t.Errorf("want empty transports map, find %v entries from handler's transports map", len(handler.transports))
+	}
+	handler.mu.Unlock()
 }
 
 // TestServerInitiatedSSE verifies that the persistent SSE connection remains

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -122,6 +122,7 @@ func NewInMemoryTransports() (*InMemoryTransport, *InMemoryTransport) {
 }
 
 type binder[T handler, State any] interface {
+	// TODO(rfindley): the bind API has gotten too complicated. Simplify.
 	bind(Connection, *jsonrpc2.Connection, State, func()) T
 	disconnect(T)
 }


### PR DESCRIPTION
An onClose function is passed to the ServerSession and ClientSession to help cleanup resources from the caller.

The onClose function will be executed as part of the ServerSession and ClientSession closure.

Fixes #258
