### PR TITLE
make mcp.handleNotify public

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -154,7 +154,7 @@ func (c *Client) Connect(ctx context.Context, t Transport, _ *ClientSessionOptio
 		hc.sessionUpdated(cs.state)
 	}
 	req2 := &initializedClientRequest{Session: cs, Params: &InitializedParams{}}
-	if err := handleNotify(ctx, notificationInitialized, req2); err != nil {
+	if err := HandleNotify(ctx, notificationInitialized, req2); err != nil {
 		_ = cs.Close()
 		return nil, err
 	}
@@ -662,7 +662,7 @@ func (cs *ClientSession) callProgressNotificationHandler(ctx context.Context, pa
 // This can be used if the client is performing a long-running task that was
 // initiated by the server
 func (cs *ClientSession) NotifyProgress(ctx context.Context, params *ProgressNotificationParams) error {
-	return handleNotify(ctx, notificationProgress, newClientRequest(cs, orZero[Params](params)))
+	return HandleNotify(ctx, notificationProgress, newClientRequest(cs, orZero[Params](params)))
 }
 
 // Tools provides an iterator for all tools available on the server,

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -809,7 +809,7 @@ func (ss *ServerSession) callProgressNotificationHandler(ctx context.Context, p 
 // This is typically used to report on the status of a long-running request
 // that was initiated by the client.
 func (ss *ServerSession) NotifyProgress(ctx context.Context, params *ProgressNotificationParams) error {
-	return handleNotify(ctx, notificationProgress, newServerRequest(ss, orZero[Params](params)))
+	return HandleNotify(ctx, notificationProgress, newServerRequest(ss, orZero[Params](params)))
 }
 
 func newServerRequest[P Params](ss *ServerSession, params P) *ServerRequest[P] {
@@ -896,7 +896,7 @@ func (ss *ServerSession) Log(ctx context.Context, params *LoggingMessageParams) 
 	if compareLevels(params.Level, logLevel) < 0 {
 		return nil
 	}
-	return handleNotify(ctx, notificationLoggingMessage, newServerRequest(ss, orZero[Params](params)))
+	return HandleNotify(ctx, notificationLoggingMessage, newServerRequest(ss, orZero[Params](params)))
 }
 
 // AddSendingMiddleware wraps the current sending method handler using the provided

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -114,7 +114,7 @@ func orZero[T any, P *U, U any](p P) T {
 	return any(p).(T)
 }
 
-func handleNotify(ctx context.Context, method string, req Request) error {
+func HandleNotify(ctx context.Context, method string, req Request) error {
 	mh := req.GetSession().sendingMethodHandler()
 	_, err := mh(ctx, method, req)
 	return err
@@ -351,7 +351,7 @@ func notifySessions[S Session, P Params](sessions []S, method string, params P) 
 	defer cancel()
 	for _, s := range sessions {
 		req := newRequest(s, params)
-		if err := handleNotify(ctx, method, req); err != nil {
+		if err := HandleNotify(ctx, method, req); err != nil {
 			// TODO(jba): surface this error better
 			log.Printf("calling %s: %v", method, err)
 		}


### PR DESCRIPTION
mcp: make handleNotify function public

When implementing an MCP proxy use case, the implementations of `ResourceListChangedHandler`, `ToolListChangeHandler`, or `PromptListChangeHandler` are simpler if these handlers can re-use this function from the mcp package.  For example, to forward ToolListChangeRequests from a ClientSession to a ServerSession, a simple handler could be written like this:

```
    ToolListChangedHandler: func(ctx context.Context, req *mcp.ToolListChangedRequest) {
        _ = mcp.HandleNotify(ctx, "notifications/tools/list_changed", newServerRequest(serverSession, req.Params))
    }
```

Alternatively, since `NotifyProgress`, `Log`, `Elicit`, and `ResourceUpdated` are on the ServerSession or Session, should an analogous `Notify` be available on ServerSession?
