### PR TITLE
Existing MCP servers trigger panics for resource templates

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -371,10 +371,13 @@ func (s *Server) AddResourceTemplate(t *ResourceTemplate, h ResourceHandler) {
 			// Ensure the URI template has a valid scheme
 			u, err := url.Parse(t.URITemplate)
 			if err != nil {
-				panic(err) // url.Parse includes the URI in the error
-			}
-			if !u.IsAbs() {
-				panic(fmt.Errorf("URI template %q needs a scheme", t.URITemplate))
+				//panic(err) // url.Parse includes the URI in the error
+				fmt.Fprintf(os.Stderr, "invalid resource template uri %q: %v\n", t.URITemplate, err)
+			} else {
+				if !u.IsAbs() {
+					//panic(fmt.Errorf("URI template %q needs a scheme", t.URITemplate))
+					fmt.Fprintf(os.Stderr, "invalid resource template uri %q: %v\n", t.URITemplate, err)
+				}
 			}
 			s.resourceTemplates.add(&serverResourceTemplate{t, h})
 			return true

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -14,6 +14,7 @@ import (
 	"iter"
 	"maps"
 	"net/url"
+	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -337,10 +338,13 @@ func (s *Server) AddResource(r *Resource, h ResourceHandler) {
 		func() bool {
 			u, err := url.Parse(r.URI)
 			if err != nil {
-				panic(err) // url.Parse includes the URI in the error
-			}
-			if !u.IsAbs() {
-				panic(fmt.Errorf("URI %s needs a scheme", r.URI))
+				//panic(err) // url.Parse includes the URI in the error
+				fmt.Fprintf(os.Stderr, "invalid resource URI %q: %v\n", r.URI, err)
+			} else {
+				if !u.IsAbs() {
+					//panic(fmt.Errorf("URI %s needs a scheme", r.URI))
+					fmt.Fprintf(os.Stderr, "invalid resource URI %q: %v\n", r.URI, err)
+				}
 			}
 			s.resources.add(&serverResource{r, h})
 			return true


### PR DESCRIPTION
# Background

When building MCP proxies, we might call `AddResource` or `AddResourceTemplate` for proxied servers. When proxying some existing servers that have used questionable custom uri formats, we can get panics at runtime.

For example, these are from the official GitHub mcp.

```
"repo://{owner}/{repo}/contents{/path*}": parse "repo://{owner}/{repo}/contents{/path*}": invalid character "{" in host name
"repo://{owner}/{repo}/refs/heads/{branch}/contents{/path*}": parse "repo://{owner}/{repo}/refs/heads/{branch}/contents{/path*}": invalid character "{" in host name
"repo://{owner}/{repo}/sha/{sha}/contents{/path*}": parse "repo://{owner}/{repo}/sha/{sha}/contents{/path*}": invalid character "{" in host name
invalid resource template uri "repo://{owner}/{repo}/refs/pull/{prNumber}/head/contents{/path*}": parse "repo://{owner}/{repo}/refs/pull/{prNumber}/head/contents{/path*}": invalid character "{" in host name
"repo://{owner}/{repo}/refs/tags/{tag}/contents{/path*}": parse "repo://{owner}/{repo}/refs/tags/{tag}/contents{/path*}": invalid character "{" in host name
```

The wikipedia MCP also has some similar issues.  I think these ones are missing schemes.

```
"/search/{query}": <nil>
"/article/{title}": <nil>
"/summary/{title}": <nil>
"/summary/{title}/query/{query}/length/{max_length}": <nil>
"/summary/{title}/section/{section_title}/length/{max_length}": <nil>
"/sections/{title}": <nil>
"/links/{title}": <nil>
"/facts/{title}/topic/{topic_within_article}/count/{count}": <nil>
"/coordinates/{title}": <nil>
```

These are slipping through because other SDKs are not being this strict. In the above examples, it does seem like the authors of these MCPs are create _custom_ uris, and not observing [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986). However, it's only an issue in the use case I'm working on because I'm proxying servers that weren't necessarily written using this SDK.

# What I did

In this change, I switched the panic to just a log to stderr.

I can actually see the value of a `panic` for someone who is implementing a server directly. This could help them choose a more compliant uri. Maybe we just need to be able to control whether custom uri issues are fatal errors or not. It might be okay if the default is to panic, but I think there are still cases, where you want to register the resource or resource template anyway.

Does anyone have any thoughts? 