### PR TITLE
examples/server/memory: fix misleading code

### DIFF
--- a/examples/server/memory/kb.go
+++ b/examples/server/memory/kb.go
@@ -442,11 +442,6 @@ func (k knowledgeBase) CreateEntities(ctx context.Context, req *mcp.CallToolRequ
 	res.Content = []mcp.Content{
 		&mcp.TextContent{Text: "Entities created successfully"},
 	}
-
-	res.StructuredContent = CreateEntitiesResult{
-		Entities: entities,
-	}
-
 	return &res, CreateEntitiesResult{Entities: entities}, nil
 }
 


### PR DESCRIPTION
Tools shouldn't both set StructuredContent and return a typed output. Remove the assignment.
