### PR TITLE
mcp/streamable: fixes broken DELETE request on session close

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -133,7 +133,7 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 			http.Error(w, "Accept must contain 'text/event-stream' for GET requests", http.StatusBadRequest)
 			return
 		}
-	} else if !jsonOK || !streamOK {
+	} else if (!jsonOK || !streamOK) && req.Method != http.MethodDelete {
 		http.Error(w, "Accept must contain both 'application/json' and 'text/event-stream'", http.StatusBadRequest)
 		return
 	}

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -687,6 +687,10 @@ func TestStreamableServerTransport(t *testing.T) {
 					},
 					wantSessionID: true,
 				},
+				{
+					method:         "DELETE",
+					wantStatusCode: http.StatusNoContent,
+				},
 			},
 		},
 		{
@@ -945,7 +949,9 @@ func (s streamableRequest) do(ctx context.Context, serverURL, sessionID string, 
 		req.Header.Set("Mcp-Session-Id", sessionID)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/event-stream")
+	if s.method != http.MethodDelete { // DELETE expects "No Content" response.
+		req.Header.Set("Accept", "application/json, text/event-stream")
+	}
 	maps.Copy(req.Header, s.headers)
 
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
This commit fixes the accept header check for DELETE request on connection close. Previously, the accept content type was checked unconditionally regardless of whether it is DELETE or not in StreamableHTTPHandler.ServeHTTP.

As a result any DELETE request on session close resulted in `"Accept must contain both 'application/json' and 'text/event-stream'` response with the status code 400 (invalid request) as opposed to 204 (no content).