### PR TITLE
mcp: set content to marshaled output

### DIFF
--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -1175,7 +1175,10 @@ func TestStreamableStateless(t *testing.T) {
 				req(2, "tools/call", &CallToolParams{Name: "greet", Arguments: hiParams{Name: "World"}}),
 			},
 			wantMessages: []jsonrpc.Message{
-				resp(2, &CallToolResult{Content: []Content{&TextContent{Text: "hi World"}}}, nil),
+				resp(2, &CallToolResult{
+					Content:           []Content{&TextContent{Text: "hi World"}},
+					StructuredContent: json.RawMessage("null"),
+				}, nil),
 			},
 			wantSessionID: false,
 		},
@@ -1186,7 +1189,10 @@ func TestStreamableStateless(t *testing.T) {
 				req(2, "tools/call", &CallToolParams{Name: "greet", Arguments: hiParams{Name: "foo"}}),
 			},
 			wantMessages: []jsonrpc.Message{
-				resp(2, &CallToolResult{Content: []Content{&TextContent{Text: "hi foo"}}}, nil),
+				resp(2, &CallToolResult{
+					Content:           []Content{&TextContent{Text: "hi foo"}},
+					StructuredContent: json.RawMessage("null"),
+				}, nil),
 			},
 			wantSessionID: false,
 		},


### PR DESCRIPTION
The ToolHandler constructed by ToolFor sets the result's Content to the marshaled output, following the spec's suggestion.

See https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content.

Also, set StructuredContent to the marshaled RawMessage to avoid a double marshal.

Fixes #391.
