### PR TITLE
examples/server/middleware: log tool result

### DIFF
--- a/examples/server/middleware/main.go
+++ b/examples/server/middleware/main.go
@@ -64,6 +64,12 @@ func main() {
 					"duration_ms", duration.Milliseconds(),
 					"has_result", result != nil,
 				)
+				// Log more for tool results.
+				if ctr, ok := result.(*mcp.CallToolResult); ok {
+					logger.Info("tool result",
+						"isError", ctr.IsError,
+						"structuredContent", ctr.StructuredContent)
+				}
 			}
 			return result, err
 		}
@@ -103,7 +109,7 @@ func main() {
 				Content: []mcp.Content{
 					&mcp.TextContent{Text: message},
 				},
-			}, nil, nil
+			}, message, nil
 		},
 	)
 


### PR DESCRIPTION
Log the result of a tool call in the middleware.

This example now fully demonstrates that receiving middleware can effectively wrap a ToolHandler. That means that one reason for ToolFor is moot: you don't need to get your hands on the returned ToolHandler in order to wrap it.
