### PR TITLE
mcp: allow requests before notifications/initialized

### DIFF
--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -1415,7 +1415,7 @@ func TestElicitationCapabilityDeclaration(t *testing.T) {
 			RequestedSchema: &jsonschema.Schema{Type: "object"},
 		})
 		if err != nil {
-			t.Errorf("elicitation should work when capability is declared, got error: %v", err)
+			t.Fatalf("elicitation should work when capability is declared, got error: %v", err)
 		}
 		if result.Action != "cancel" {
 			t.Errorf("got action %q, want %q", result.Action, "cancel")

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -346,9 +346,12 @@ func notifySessions[S Session, P Params](sessions []S, method string, params P) 
 	if sessions == nil {
 		return
 	}
-	// TODO: make this timeout configurable, or call Notify asynchronously.
+	// TODO: make this timeout configurable, or call handleNotify asynchronously.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	// TODO: there's a potential spec violation here, when the feature list
+	// changes before the session (client or server) is initialized.
 	for _, s := range sessions {
 		req := newRequest(s, params)
 		if err := handleNotify(ctx, method, req); err != nil {

--- a/mcp/testdata/conformance/server/lifecycle.txtar
+++ b/mcp/testdata/conformance/server/lifecycle.txtar
@@ -5,6 +5,7 @@ See also modelcontextprotocol/go-sdk#225.
 
 -- client --
 { "jsonrpc":"2.0", "method": "notifications/initialized" }
+{ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }
 {
   "jsonrpc": "2.0",
   "id": 1,
@@ -21,6 +22,14 @@ See also modelcontextprotocol/go-sdk#225.
 { "jsonrpc": "2.0", "id": 3, "method": "tools/list" }
 
 -- server --
+{
+	"jsonrpc": "2.0",
+	"id": 2,
+	"error": {
+		"code": 0,
+		"message": "method \"tools/list\" is invalid during session initialization"
+	}
+}
 {
 	"jsonrpc": "2.0",
 	"id": 1,
@@ -43,9 +52,8 @@ See also modelcontextprotocol/go-sdk#225.
 {
 	"jsonrpc": "2.0",
 	"id": 2,
-	"error": {
-		"code": 0,
-		"message": "method \"tools/list\" is invalid during session initialization"
+	"result": {
+		"tools": []
 	}
 }
 {


### PR DESCRIPTION
Upon a closer reading of the spec, it is OK for the server to response to client requests before it has received notifications/initialized (as long as it has received initialize). This effectively rolls back the fix from #225.

Some hooks are left for enforcing strictness around server->client requests prior to initialized. These will be revisited in subsequent CLs.

For #395