### PR TITLE
mcp: avoid "null" when tools fail to return content

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -496,9 +496,13 @@ func (s *Server) callTool(ctx context.Context, req *CallToolRequest) (*CallToolR
 			Message: fmt.Sprintf("unknown tool %q", req.Params.Name),
 		}
 	}
-	// TODO: if handler returns nil content, it will serialize as null.
-	// Add a test and fix.
-	return st.handler(ctx, req)
+	res, err := st.handler(ctx, req)
+	if err == nil && res != nil && res.Content == nil {
+		res2 := *res
+		res2.Content = []Content{} // avoid "null"
+		res = &res2
+	}
+	return res, err
 }
 
 func (s *Server) listResources(_ context.Context, req *ListResourcesRequest) (*ListResourcesResult, error) {

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -520,7 +520,7 @@ func TestStreamableServerTransport(t *testing.T) {
 					method:         "POST",
 					messages:       []jsonrpc.Message{req(2, "tools/call", &CallToolParams{Name: "tool"})},
 					wantStatusCode: http.StatusOK,
-					wantMessages:   []jsonrpc.Message{resp(2, &CallToolResult{}, nil)},
+					wantMessages:   []jsonrpc.Message{resp(2, &CallToolResult{Content: []Content{}}, nil)},
 				},
 			},
 		},
@@ -547,14 +547,14 @@ func TestStreamableServerTransport(t *testing.T) {
 					headers:        http.Header{"Accept": {"text/plain", "*/*"}},
 					messages:       []jsonrpc.Message{req(4, "tools/call", &CallToolParams{Name: "tool"})},
 					wantStatusCode: http.StatusOK,
-					wantMessages:   []jsonrpc.Message{resp(4, &CallToolResult{}, nil)},
+					wantMessages:   []jsonrpc.Message{resp(4, &CallToolResult{Content: []Content{}}, nil)},
 				},
 				{
 					method:         "POST",
 					headers:        http.Header{"Accept": {"text/*, application/*"}},
 					messages:       []jsonrpc.Message{req(4, "tools/call", &CallToolParams{Name: "tool"})},
 					wantStatusCode: http.StatusOK,
-					wantMessages:   []jsonrpc.Message{resp(4, &CallToolResult{}, nil)},
+					wantMessages:   []jsonrpc.Message{resp(4, &CallToolResult{Content: []Content{}}, nil)},
 				},
 			},
 		},
@@ -592,7 +592,7 @@ func TestStreamableServerTransport(t *testing.T) {
 					wantStatusCode: http.StatusOK,
 					wantMessages: []jsonrpc.Message{
 						req(0, "notifications/progress", &ProgressNotificationParams{}),
-						resp(2, &CallToolResult{}, nil),
+						resp(2, &CallToolResult{Content: []Content{}}, nil),
 					},
 				},
 			},
@@ -624,7 +624,7 @@ func TestStreamableServerTransport(t *testing.T) {
 					wantStatusCode: http.StatusOK,
 					wantMessages: []jsonrpc.Message{
 						req(1, "roots/list", &ListRootsParams{}),
-						resp(2, &CallToolResult{}, nil),
+						resp(2, &CallToolResult{Content: []Content{}}, nil),
 					},
 				},
 			},
@@ -674,7 +674,7 @@ func TestStreamableServerTransport(t *testing.T) {
 					},
 					wantStatusCode: http.StatusOK,
 					wantMessages: []jsonrpc.Message{
-						resp(2, &CallToolResult{}, nil),
+						resp(2, &CallToolResult{Content: []Content{}}, nil),
 					},
 				},
 				{


### PR DESCRIPTION
For some reason, this was a regression from v0.3.1, for some of our examples. Fix it and address the existing TODO.