### PR TITLE
oauthex: new package for oauth extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ software development kit (SDK) for the Model Context Protocol (MCP).
 
 ## Package documentation
 
-The SDK consists of three importable packages:
+The SDK consists of several importable packages:
 
 - The
   [`github.com/modelcontextprotocol/go-sdk/mcp`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp)
@@ -33,6 +33,10 @@ The SDK consists of three importable packages:
 - The
   [`github.com/modelcontextprotocol/go-sdk/auth`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/auth)
   package provides some primitives for supporting oauth.
+
+- The
+  [`github.com/modelcontextprotocol/go-sdk/oauthex`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/oauthex)
+  package provides extensions to the OAuth protocol, such as ProtectedResourceMetadata.
 
 ## Getting started
 

--- a/internal/readme/README.src.md
+++ b/internal/readme/README.src.md
@@ -20,7 +20,7 @@ software development kit (SDK) for the Model Context Protocol (MCP).
 
 ## Package documentation
 
-The SDK consists of three importable packages:
+The SDK consists of several importable packages:
 
 - The
   [`github.com/modelcontextprotocol/go-sdk/mcp`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp)
@@ -32,6 +32,10 @@ The SDK consists of three importable packages:
 - The
   [`github.com/modelcontextprotocol/go-sdk/auth`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/auth)
   package provides some primitives for supporting oauth.
+
+- The
+  [`github.com/modelcontextprotocol/go-sdk/oauthex`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/oauthex)
+  package provides extensions to the OAuth protocol, such as ProtectedResourceMetadata.
 
 ## Getting started
 

--- a/oauthex/oauthex.go
+++ b/oauthex/oauthex.go
@@ -1,0 +1,10 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// Package oauthex implements extensions to OAuth2.
+package oauthex
+
+import "github.com/modelcontextprotocol/go-sdk/internal/oauthex"
+
+type ProtectedResourceMetadata = oauthex.ProtectedResourceMetadata


### PR DESCRIPTION
This package will hold externally visible parts of internal/oauthex.

For now, just add an alias to the ProtectedResourceMetadata struct. This lets one write MCP-compliant servers.