### PR TITLE
internal/oauthex: fix license headers

### DIFF
--- a/internal/oauthex/auth_meta.go
+++ b/internal/oauthex/auth_meta.go
@@ -1,5 +1,5 @@
-// Copyright 2025 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
 // This file implements Authorization Server Metadata.

--- a/internal/oauthex/auth_meta_test.go
+++ b/internal/oauthex/auth_meta_test.go
@@ -1,5 +1,5 @@
-// Copyright 2025 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
 package oauthex

--- a/internal/oauthex/oauth2.go
+++ b/internal/oauthex/oauth2.go
@@ -1,5 +1,5 @@
-// Copyright 2025 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
 // Package oauthex implements extensions to OAuth2.

--- a/internal/oauthex/oauth2_test.go
+++ b/internal/oauthex/oauth2_test.go
@@ -1,5 +1,5 @@
-// Copyright 2025 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
 package oauthex

--- a/internal/oauthex/resource_meta.go
+++ b/internal/oauthex/resource_meta.go
@@ -1,5 +1,5 @@
-// Copyright 2025 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
 // This file implements Protected Resource Metadata.


### PR DESCRIPTION
The files in the oauthex package used the default Go license header, rather than the MCP SDK license header (an accident of tooling). We should fix this while jba@google.com is the only author of this code.

A subsequent PR will add a lint check to prevent this in the future.