### PR TITLE
mcp: remove deprecated transport constructors

### DIFF
--- a/mcp/cmd.go
+++ b/mcp/cmd.go
@@ -27,19 +27,6 @@ type CommandTransport struct {
 	TerminateDuration time.Duration
 }
 
-// NewCommandTransport returns a [CommandTransport] that runs the given command
-// and communicates with it over stdin/stdout.
-//
-// The resulting transport takes ownership of the command, starting it during
-// [CommandTransport.Connect], and stopping it when the connection is closed.
-//
-// Deprecated: use a CommandTransport literal.
-//
-//go:fix inline
-func NewCommandTransport(cmd *exec.Cmd) *CommandTransport {
-	return &CommandTransport{Command: cmd}
-}
-
 // Connect starts the command, and connects to it over stdin/stdout.
 func (t *CommandTransport) Connect(ctx context.Context) (Connection, error) {
 	stdout, err := t.Command.StdoutPipe()

--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -114,19 +114,6 @@ type SSEServerTransport struct {
 	done   chan struct{} // closed when the connection is closed
 }
 
-// NewSSEServerTransport creates a new SSE transport for the given messages
-// endpoint, and hanging GET response.
-//
-// Deprecated: use an SSEServerTransport literal.
-//
-//go:fix inline
-func NewSSEServerTransport(endpoint string, w http.ResponseWriter) *SSEServerTransport {
-	return &SSEServerTransport{
-		Endpoint: endpoint,
-		Response: w,
-	}
-}
-
 // ServeHTTP handles POST requests to the transport endpoint.
 func (t *SSEServerTransport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if t.incoming == nil {
@@ -332,30 +319,6 @@ type SSEClientTransport struct {
 	// HTTPClient is the client to use for making HTTP requests. If nil,
 	// http.DefaultClient is used.
 	HTTPClient *http.Client
-}
-
-// SSEClientTransportOptions provides options for the [NewSSEClientTransport]
-// constructor.
-//
-// Deprecated: use an SSEClientTransport literal.
-type SSEClientTransportOptions struct {
-	// HTTPClient is the client to use for making HTTP requests. If nil,
-	// http.DefaultClient is used.
-	HTTPClient *http.Client
-}
-
-// NewSSEClientTransport returns a new client transport that connects to the
-// SSE server at the provided URL.
-//
-// Deprecated: use an SSEClientTransport literal.
-//
-//go:fix inline
-func NewSSEClientTransport(endpoint string, opts *SSEClientTransportOptions) *SSEClientTransport {
-	t := &SSEClientTransport{Endpoint: endpoint}
-	if opts != nil {
-		t.HTTPClient = opts.HTTPClient
-	}
-	return t
 }
 
 // Connect connects through the client endpoint.

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -323,15 +323,6 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 	transport.ServeHTTP(w, req)
 }
 
-// StreamableServerTransportOptions configures the stramable server transport.
-//
-// Deprecated: use a StreamableServerTransport literal.
-type StreamableServerTransportOptions struct {
-	// Storage for events, to enable stream resumption.
-	// If nil, a [MemoryEventStore] with the default maximum size will be used.
-	EventStore EventStore
-}
-
 // A StreamableServerTransport implements the server side of the MCP streamable
 // transport.
 //
@@ -383,22 +374,6 @@ type StreamableServerTransport struct {
 
 	// connection is non-nil if and only if the transport has been connected.
 	connection *streamableServerConn
-}
-
-// NewStreamableServerTransport returns a new [StreamableServerTransport] with
-// the given session ID and options.
-//
-// Deprecated: use a StreamableServerTransport literal.
-//
-//go:fix inline.
-func NewStreamableServerTransport(sessionID string, opts *StreamableServerTransportOptions) *StreamableServerTransport {
-	t := &StreamableServerTransport{
-		SessionID: sessionID,
-	}
-	if opts != nil {
-		t.EventStore = opts.EventStore
-	}
-	return t
 }
 
 // Connect implements the [Transport] interface.
@@ -1024,34 +999,6 @@ const (
 	// reconnectMaxDelay caps the backoff delay, preventing it from growing indefinitely.
 	reconnectMaxDelay = 30 * time.Second
 )
-
-// StreamableClientTransportOptions provides options for the
-// [NewStreamableClientTransport] constructor.
-//
-// Deprecated: use a StremableClientTransport literal.
-type StreamableClientTransportOptions struct {
-	// HTTPClient is the client to use for making HTTP requests. If nil,
-	// http.DefaultClient is used.
-	HTTPClient *http.Client
-	// MaxRetries is the maximum number of times to attempt a reconnect before giving up.
-	// It defaults to 5. To disable retries, use a negative number.
-	MaxRetries int
-}
-
-// NewStreamableClientTransport returns a new client transport that connects to
-// the streamable HTTP server at the provided URL.
-//
-// Deprecated: use a StreamableClientTransport literal.
-//
-//go:fix inline
-func NewStreamableClientTransport(url string, opts *StreamableClientTransportOptions) *StreamableClientTransport {
-	t := &StreamableClientTransport{Endpoint: url}
-	if opts != nil {
-		t.HTTPClient = opts.HTTPClient
-		t.MaxRetries = opts.MaxRetries
-	}
-	return t
-}
 
 // Connect implements the [Transport] interface.
 //

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -1211,7 +1211,7 @@ func TestTokenInfo(t *testing.T) {
 	httpServer := httptest.NewServer(handler)
 	defer httpServer.Close()
 
-	transport := NewStreamableClientTransport(httpServer.URL, nil)
+	transport := &StreamableClientTransport{Endpoint: httpServer.URL}
 	client := NewClient(testImpl, nil)
 	session, err := client.Connect(ctx, transport, nil)
 	if err != nil {

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -93,16 +93,6 @@ func (*StdioTransport) Connect(context.Context) (Connection, error) {
 	return newIOConn(rwc{os.Stdin, os.Stdout}), nil
 }
 
-// NewStdioTransport constructs a transport that communicates over
-// stdin/stdout.
-//
-// Deprecated: use a StdioTransport literal.
-//
-//go:fix inline
-func NewStdioTransport() *StdioTransport {
-	return &StdioTransport{}
-}
-
 // An InMemoryTransport is a [Transport] that communicates over an in-memory
 // network connection, using newline-delimited JSON.
 type InMemoryTransport struct {
@@ -213,16 +203,6 @@ func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params 
 type LoggingTransport struct {
 	Transport Transport
 	Writer    io.Writer
-}
-
-// NewLoggingTransport creates a new LoggingTransport that delegates to the
-// provided transport, writing RPC logs to the provided io.Writer.
-//
-// Deprecated: use a LoggingTransport literal.
-//
-//go:fix inline
-func NewLoggingTransport(delegate Transport, w io.Writer) *LoggingTransport {
-	return &LoggingTransport{Transport: delegate, Writer: w}
 }
 
 // Connect connects the underlying transport, returning a [Connection] that writes


### PR DESCRIPTION
In #272, we made transports open structs and deprecated their constructors. However, we left the constructors in place to allow go:fix directives to facilitate migration.

Now let's remove the constructors before cutting the release.

Fixes #305