### PR TITLE
transport.go: disable stdio batching for newer protocols

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -624,7 +624,6 @@ func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Reques
 	if protocolVersion == "" {
 		protocolVersion = protocolVersion20250326
 	}
-	protocolVersion = negotiatedVersion(protocolVersion)
 
 	if isBatch && protocolVersion >= protocolVersion20250618 {
 		http.Error(w, fmt.Sprintf("JSON-RPC batching is not supported in %s and later (request version: %s)", protocolVersion20250618, protocolVersion), http.StatusBadRequest)

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -283,7 +283,7 @@ func (r rwc) Close() error {
 //
 // See [msgBatch] for more discussion of message batching.
 type ioConn struct {
-	protocolVersion string
+	protocolVersion string // negotiated version, set during session initialization.
 
 	writeMu sync.Mutex         // guards Write, which must be concurrency safe.
 	rwc     io.ReadWriteCloser // the underlying stream


### PR DESCRIPTION
This PR disables batching support for stdio by storing the negotiated protocol version and comparing it to protocolVersion20250618. 

Fixes: #21
