### PR TITLE
mcp: propertly validate against JSON, independent of Go values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/google/jsonschema-go v0.2.2
+	github.com/google/jsonschema-go v0.2.3-0.20250911201137-bbdc431016d2
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	golang.org/x/tools v0.34.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/jsonschema-go v0.2.2 h1:qb9KM/pATIqIPuE9gEDwPsco8HHCTlA88IGFYHDl03A=
-github.com/google/jsonschema-go v0.2.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.2.3-0.20250911201137-bbdc431016d2 h1:IIj7X4SH1HKy0WfPR4nNEj4dhIJWGdXM5YoBAbfpdoo=
+github.com/google/jsonschema-go v0.2.3-0.20250911201137-bbdc431016d2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -224,7 +224,7 @@ func TestEndToEnd(t *testing.T) {
 		// ListTools is tested in client_list_test.go.
 		gotHi, err := cs.CallTool(ctx, &CallToolParams{
 			Name:      "greet",
-			Arguments: map[string]any{"name": "user"},
+			Arguments: map[string]any{"Name": "user"},
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -648,7 +648,7 @@ func TestServerClosing(t *testing.T) {
 	}()
 	if _, err := cs.CallTool(ctx, &CallToolParams{
 		Name:      "greet",
-		Arguments: map[string]any{"name": "user"},
+		Arguments: map[string]any{"Name": "user"},
 	}); err != nil {
 		t.Fatalf("after connecting: %v", err)
 	}
@@ -1646,7 +1646,7 @@ var testImpl = &Implementation{Name: "test", Version: "v1.0.0"}
 // If anyone asks, we can add an option that controls how pointers are treated.
 func TestPointerArgEquivalence(t *testing.T) {
 	type input struct {
-		In string
+		In string `json:",omitempty"`
 	}
 	type output struct {
 		Out string

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -105,6 +105,13 @@ type CallToolResult struct {
 	IsError bool `json:"isError,omitempty"`
 }
 
+// TODO(#64): consider exposing setError (and getError), by adding an error
+// field on CallToolResult.
+func (r *CallToolResult) setError(err error) {
+	r.Content = []Content{&TextContent{Text: err.Error()}}
+	r.IsError = true
+}
+
 func (*CallToolResult) isResult() {}
 
 // UnmarshalJSON handles the unmarshalling of content into the Content

--- a/mcp/sse_example_test.go
+++ b/mcp/sse_example_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 type AddParams struct {
-	X, Y int
+	X int `json:"x"`
+	Y int `json:"y"`
 }
 
 func Add(ctx context.Context, req *mcp.CallToolRequest, args AddParams) (*mcp.CallToolResult, any, error) {

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -144,7 +144,7 @@ func TestStreamableTransports(t *testing.T) {
 			// The "greet" tool should just work.
 			params := &CallToolParams{
 				Name:      "greet",
-				Arguments: map[string]any{"name": "foo"},
+				Arguments: map[string]any{"Name": "foo"},
 			}
 			got, err := session.CallTool(ctx, params)
 			if err != nil {
@@ -239,10 +239,11 @@ func TestStreamableServerShutdown(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer clientSession.Close()
 
 			params := &CallToolParams{
 				Name:      "greet",
-				Arguments: map[string]any{"name": "foo"},
+				Arguments: map[string]any{"Name": "foo"},
 			}
 			// Verify that we can call a tool.
 			if _, err := clientSession.CallTool(ctx, params); err != nil {

--- a/mcp/testdata/conformance/server/tools.txtar
+++ b/mcp/testdata/conformance/server/tools.txtar
@@ -5,10 +5,17 @@ Fixed bugs:
 - "_meta" should not be nil
 - empty resource or prompts should not be returned as 'null'
 - the server should not crash when params are passed to tools/call
+- missing required input fields should be rejected (#449)
+- output and input should be validated against their actual json, not Go
+	representation
+- When arguments are missing, the request should succeed if all properties are
+	optional, and observe any default values.
 
 -- tools --
 greet
 structured
+tomorrow
+inc
 
 -- client --
 {
@@ -26,9 +33,14 @@ structured
 { "jsonrpc": "2.0", "id": 3, "method": "resources/list" }
 { "jsonrpc": "2.0", "id": 4, "method": "prompts/list" }
 { "jsonrpc": "2.0", "id": 5, "method": "tools/call" }
-{ "jsonrpc": "2.0", "id": 6, "method": "tools/call", "params": {"name": "greet", "arguments": {"name": "you"} } }
+{ "jsonrpc": "2.0", "id": 6, "method": "tools/call", "params": {"name": "greet", "arguments": {"Name": "you"} } }
 { "jsonrpc": "2.0", "id": 1, "result": {} }
 { "jsonrpc": "2.0", "id": 7, "method": "tools/call", "params": {"name": "structured", "arguments": {"In": "input"} } }
+{ "jsonrpc": "2.0", "id": 8, "method": "tools/call", "params": {"name": "structured", "arguments": {} } }
+{ "jsonrpc": "2.0", "id": 9, "method": "tools/call", "params": {"name": "tomorrow", "arguments": { "Now": "2025-06-18T15:04:05Z" } } }
+{ "jsonrpc": "2.0", "id": 10, "method": "tools/call", "params": {"name": "greet" } }
+{ "jsonrpc": "2.0", "id": 11, "method": "tools/call", "params": {"name": "inc", "arguments": { "x": 3 } } }
+{ "jsonrpc": "2.0", "id": 11, "method": "tools/call", "params": {"name": "inc" } }
 
 -- server --
 {
@@ -72,6 +84,31 @@ structured
 			{
 				"inputSchema": {
 					"type": "object",
+					"properties": {
+						"x": {
+							"type": "integer",
+							"default": 6
+						}
+					},
+					"additionalProperties": false
+				},
+				"name": "inc",
+				"outputSchema": {
+					"type": "object",
+					"required": [
+						"y"
+					],
+					"properties": {
+						"y": {
+							"type": "integer"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			{
+				"inputSchema": {
+					"type": "object",
 					"required": [
 						"In"
 					],
@@ -93,6 +130,33 @@ structured
 						"Out": {
 							"type": "string",
 							"description": "the output"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			{
+				"inputSchema": {
+					"type": "object",
+					"required": [
+						"Now"
+					],
+					"properties": {
+						"Now": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				},
+				"name": "tomorrow",
+				"outputSchema": {
+					"type": "object",
+					"required": [
+						"Tomorrow"
+					],
+					"properties": {
+						"Tomorrow": {
+							"type": "string"
 						}
 					},
 					"additionalProperties": false
@@ -152,6 +216,67 @@ structured
 		],
 		"structuredContent": {
 			"Out": "Ack input"
+		}
+	}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 8,
+	"error": {
+		"code": -32602,
+		"message": "invalid params: validating \"arguments\": validating root: required: missing properties: [\"In\"]"
+	}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 9,
+	"result": {
+		"content": [
+			{
+				"type": "text",
+				"text": "{\"Tomorrow\":\"2025-06-19T15:04:05Z\"}"
+			}
+		],
+		"structuredContent": {
+			"Tomorrow": "2025-06-19T15:04:05Z"
+		}
+	}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 10,
+	"error": {
+		"code": -32602,
+		"message": "invalid params: validating \"arguments\": validating root: required: missing properties: [\"Name\"]"
+	}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 11,
+	"result": {
+		"content": [
+			{
+				"type": "text",
+				"text": "{\"y\":4}"
+			}
+		],
+		"structuredContent": {
+			"y": 4
+		}
+	}
+}
+{
+	"jsonrpc": "2.0",
+	"id": 11,
+	"result": {
+		"content": [
+			{
+				"type": "text",
+				"text": "{\"y\":7}"
+			}
+		],
+		"structuredContent": {
+			"y": 7
 		}
 	}
 }


### PR DESCRIPTION
Our validation logic was avoiding double-unmarshalling as much as
possible, by parsing before validation and validating the Go type.

This only works if the Go type has the same structure as its JSON
representation, which may not be the case in the presence of types with
custom MarshalJSON or UnmarshalJSON methods (such as time.Time).

But even if the Go type doesn't use any custom marshalling, validation
is broken, because we can't differentiate zero values from missing
values.

Bite the bullet and use double-unmarshalling for both input and output
schemas. Coincidentally, this fixes three bugs:
- We were accepting case-insensitive JSON keys, since we parsed first,
  even though they should have been rejected. A number of tests were
  wrong.
- Defaults were overriding present-yet-zero values, as noted in an
  incorrect test case.
- When "arguments" was missing, validation wasn't performed, no defaults
  were applied, and unmarshalling failed even if all properties were
  optional.

First unmarshalling to map[string]any allows us to fix all these bugs.
Unfortunately, it means a 3x increase in the number of reflection
operations (we need to unmarshal, apply defaults and validate,
re-marshal with the defaults, and then unmarshal into the Go type).
However, this is not likely to be a significant overhead, and we can
always optimize in the future.

Update github.com/google/jsonschema-go to pick up necessary improvements
supporting this change.

Additionally, fix the error codes for invalid tool parameters, to be
consistent with other SDKs (Invalid Params: -32602).

Fixes https://github.com/modelcontextprotocol/go-sdk/issues/447
Fixes https://github.com/modelcontextprotocol/go-sdk/issues/449
Updates https://github.com/modelcontextprotocol/go-sdk/issues/450