### PR TITLE
mcp: speed up TestCommandTransportDuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.23", "1.24", "1.25.0-rc.3"]
+        go: ["1.23", "1.24", "1.25"]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/mcp/cmd.go
+++ b/mcp/cmd.go
@@ -13,9 +13,7 @@ import (
 	"time"
 )
 
-const (
-	defaultTerminateDuration = 5 * time.Second
-)
+var defaultTerminateDuration = 5 * time.Second // mutable for testing
 
 // A CommandTransport is a [Transport] that runs a command and communicates
 // with it over stdin/stdout, using newline-delimited JSON.

--- a/mcp/cmd_export_test.go
+++ b/mcp/cmd_export_test.go
@@ -1,0 +1,20 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import "time"
+
+// This file exports some helpers for mutating internals of the command
+// transport for testing.
+
+// SetDefaultTerminateDuration sets the default command terminate duration,
+// and returns a function to reset it to the default.
+func SetDefaultTerminateDuration(d time.Duration) (reset func()) {
+	initial := defaultTerminateDuration
+	defaultTerminateDuration = d
+	return func() {
+		defaultTerminateDuration = initial
+	}
+}


### PR DESCRIPTION
At 7s, this test was 70% of our test execution time on my computer. Speed it up by mutating the defaultTerminateDuration for the purposes of the test.

Also update our test workflow to use go1.25, now that it's out.