### PR TITLE
mcp: allow injecting custom streams in StdioTransport

### DIFF
--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -86,11 +86,23 @@ type serverConnection interface {
 
 // A StdioTransport is a [Transport] that communicates over stdin/stdout using
 // newline-delimited JSON.
-type StdioTransport struct{}
+type StdioTransport struct {
+	In  io.ReadCloser
+	Out io.WriteCloser
+}
 
 // Connect implements the [Transport] interface.
-func (*StdioTransport) Connect(context.Context) (Connection, error) {
-	return newIOConn(rwc{os.Stdin, os.Stdout}), nil
+func (t *StdioTransport) Connect(context.Context) (Connection, error) {
+	in := t.In
+	out := t.Out
+
+	if in == nil {
+		in = os.Stdin
+	}
+	if out == nil {
+		out = os.Stdout
+	}
+	return newIOConn(rwc{in, out}), nil
 }
 
 // An InMemoryTransport is a [Transport] that communicates over an in-memory


### PR DESCRIPTION
Previously, `StdioTransport` was hardcoded to use `os.Stdin` and `os.Stdout`, making it difficult to test transport behavior with controlled input/output. With this change, users can inject custom streams (like `io.Pipe()`) for testing while maintaining backward compatibility.

This change modifies the `Connect` method to check the fields, defaulting back to the standard streams as defaults if nil. 