### PR TITLE
mcp: add a benchmark for the MemoryEventStore; remove validation

### DIFF
--- a/mcp/event.go
+++ b/mcp/event.go
@@ -23,8 +23,8 @@ import (
 )
 
 // If true, MemoryEventStore will do frequent validation to check invariants, slowing it down.
-// Remove when we're confident in the code.
-const validateMemoryEventStore = true
+// Enable for debugging.
+const validateMemoryEventStore = false
 
 // An Event is a server-sent event.
 // See https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#fields.


### PR DESCRIPTION
Add a new benchmark measuring the append and purge performance of the MemoryEventStore. This benchmark revealed that the store is orders of magnitude slower than it should be due to conservative validation (hugely so: 300KB/s vs 568MB/s). Turn off this validation by default.

For #190