### PR TITLE
mcp: add CallToolResult.getError

### DIFF
--- a/mcp/cmd_test.go
+++ b/mcp/cmd_test.go
@@ -226,7 +226,7 @@ func TestCmdTransport(t *testing.T) {
 			&mcp.TextContent{Text: "Hi user"},
 		},
 	}
-	if diff := cmp.Diff(want, got); diff != "" {
+	if diff := cmp.Diff(want, got, ctrCmpOpts...); diff != "" {
 		t.Errorf("greet returned unexpected content (-want +got):\n%s", diff)
 	}
 	if err := session.Close(); err != nil {

--- a/mcp/content_nil_test.go
+++ b/mcp/content_nil_test.go
@@ -72,7 +72,7 @@ func TestContentUnmarshalNil(t *testing.T) {
 			}
 
 			// Verify that the Content field was properly populated
-			if cmp.Diff(tt.want, tt.content) != "" {
+			if cmp.Diff(tt.want, tt.content, ctrCmpOpts...) != "" {
 				t.Errorf("Content is not equal: %v", cmp.Diff(tt.content, tt.content))
 			}
 		})
@@ -222,3 +222,5 @@ func TestContentUnmarshalNilWithInvalidContent(t *testing.T) {
 		})
 	}
 }
+
+var ctrCmpOpts = []cmp.Option{cmp.AllowUnexported(mcp.CallToolResult{})}

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -234,7 +234,7 @@ func TestEndToEnd(t *testing.T) {
 				&TextContent{Text: "hi user"},
 			},
 		}
-		if diff := cmp.Diff(wantHi, gotHi); diff != "" {
+		if diff := cmp.Diff(wantHi, gotHi, ctrCmpOpts...); diff != "" {
 			t.Errorf("tools/call 'greet' mismatch (-want +got):\n%s", diff)
 		}
 
@@ -253,7 +253,7 @@ func TestEndToEnd(t *testing.T) {
 				&TextContent{Text: errTestFailure.Error()},
 			},
 		}
-		if diff := cmp.Diff(wantFail, gotFail); diff != "" {
+		if diff := cmp.Diff(wantFail, gotFail, ctrCmpOpts...); diff != "" {
 			t.Errorf("tools/call 'fail' mismatch (-want +got):\n%s", diff)
 		}
 
@@ -1717,7 +1717,7 @@ func TestPointerArgEquivalence(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if diff := cmp.Diff(r0, r1); diff != "" {
+		if diff := cmp.Diff(r0, r1, ctrCmpOpts...); diff != "" {
 			t.Errorf("CallTool(%v) with no arguments mismatch (-%s +%s):\n%s", args, t0.Name, t1.Name, diff)
 		}
 	}
@@ -1733,7 +1733,7 @@ func TestPointerArgEquivalence(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(r0, r1); diff != "" {
+			if diff := cmp.Diff(r0, r1, ctrCmpOpts...); diff != "" {
 				t.Errorf("CallTool({\"In\": %q}) mismatch (-%s +%s):\n%s", in, t0.Name, t1.Name, diff)
 			}
 		})
@@ -1875,7 +1875,7 @@ func TestToolErrorMiddleware(t *testing.T) {
 	}
 	defer clientSession.Close()
 
-	res, err := clientSession.CallTool(ctx, &CallToolParams{
+	_, err = clientSession.CallTool(ctx, &CallToolParams{
 		Name:      "greet",
 		Arguments: map[string]any{"Name": "al"},
 	})
@@ -1885,7 +1885,7 @@ func TestToolErrorMiddleware(t *testing.T) {
 	if middleErr != nil {
 		t.Errorf("middleware got error %v, want nil", middleErr)
 	}
-	res, err = clientSession.CallTool(ctx, &CallToolParams{
+	res, err := clientSession.CallTool(ctx, &CallToolParams{
 		Name: "fail",
 	})
 	if err != nil {
@@ -1902,3 +1902,5 @@ func TestToolErrorMiddleware(t *testing.T) {
 		t.Errorf("middleware got err %v, want errTestFailure", middleErr)
 	}
 }
+
+var ctrCmpOpts = []cmp.Option{cmp.AllowUnexported(CallToolResult{})}

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -103,6 +103,12 @@ type CallToolResult struct {
 	// tool handler returns an error, and the error string is included as text in
 	// the Content field.
 	IsError bool `json:"isError,omitempty"`
+
+	// The error passed to setError, if any.
+	// It is not marshaled, and therefore it is only visible on the server.
+	// Its only use is in server sending middleware, where it can be accessed
+	// with getError.
+	err error
 }
 
 // TODO(#64): consider exposing setError (and getError), by adding an error
@@ -110,6 +116,13 @@ type CallToolResult struct {
 func (r *CallToolResult) setError(err error) {
 	r.Content = []Content{&TextContent{Text: err.Error()}}
 	r.IsError = true
+	r.err = err
+}
+
+// getError returns the error set with setError, or nil if none.
+// This function always returns nil on clients.
+func (r *CallToolResult) getError() error {
+	return r.err
 }
 
 func (*CallToolResult) isResult() {}

--- a/mcp/protocol_test.go
+++ b/mcp/protocol_test.go
@@ -499,7 +499,7 @@ func TestContentUnmarshal(t *testing.T) {
 		if err := json.Unmarshal(data, out); err != nil {
 			t.Fatal(err)
 		}
-		if diff := cmp.Diff(in, out); diff != "" {
+		if diff := cmp.Diff(in, out, ctrCmpOpts...); diff != "" {
 			t.Errorf("mismatch (-want, +got):\n%s", diff)
 		}
 	}

--- a/mcp/sse_test.go
+++ b/mcp/sse_test.go
@@ -70,7 +70,7 @@ func TestSSEServer(t *testing.T) {
 					&TextContent{Text: "hi user"},
 				},
 			}
-			if diff := cmp.Diff(wantHi, gotHi); diff != "" {
+			if diff := cmp.Diff(wantHi, gotHi, ctrCmpOpts...); diff != "" {
 				t.Errorf("tools/call 'greet' mismatch (-want +got):\n%s", diff)
 			}
 

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -159,7 +159,7 @@ func TestStreamableTransports(t *testing.T) {
 			want := &CallToolResult{
 				Content: []Content{&TextContent{Text: "hi foo"}},
 			}
-			if diff := cmp.Diff(want, got); diff != "" {
+			if diff := cmp.Diff(want, got, ctrCmpOpts...); diff != "" {
 				t.Errorf("CallTool() returned unexpected content (-want +got):\n%s", diff)
 			}
 
@@ -549,8 +549,6 @@ func resp(id int64, result any, err error) *jsonrpc.Response {
 		Error:  err,
 	}
 }
-
-var ()
 
 func TestStreamableServerTransport(t *testing.T) {
 	// This test checks detailed behavior of the streamable server transport, by


### PR DESCRIPTION
Provide a way for middleware to get the error from a tool call, demonstrating that we can add this functionality without making a breaking change.

Leave getError unexported for now; we can export it (and setError) at any time.

For #64.
