### PR TITLE
mcp: correct the JSON used for unstructured content

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -292,7 +292,7 @@ func toolForErr[In, Out any](t *Tool, h ToolHandlerFor[In, Out]) (*Tool, ToolHan
 			// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content.
 			if res.Content == nil {
 				res.Content = []Content{&TextContent{
-					Text: string(outbytes),
+					Text: string(outJSON),
 				}}
 			}
 		}


### PR DESCRIPTION
Recently, I refactored to fix validation and default application for structured output. However, I used the wrong byte slice for the unstructured output. Fix it to use the same bytes as structured output, with a test.

Fixes #475