### PR TITLE
mcp: fix flaky ExampleLoggingTransport

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,12 +39,15 @@ func ExampleLoggingTransport() {
 	if _, err := client.Connect(ctx, logTransport, nil); err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(b.String())
-	// Output:
-	// write: {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"client","version":"v0.0.1"},"protocolVersion":"2025-06-18"}}
-	// read: {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"logging":{}},"protocolVersion":"2025-06-18","serverInfo":{"name":"server","version":"v0.0.1"}}}
-	// write: {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
+	// Sort for stability: reads are concurrent to writes.
+	for _, line := range slices.Sorted(strings.SplitSeq(b.String(), "\n")) {
+		fmt.Println(line)
+	}
 
+	// Output:
+	// read: {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"logging":{}},"protocolVersion":"2025-06-18","serverInfo":{"name":"server","version":"v0.0.1"}}}
+	// write: {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"client","version":"v0.0.1"},"protocolVersion":"2025-06-18"}}
+	// write: {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 }
 ```
 


### PR DESCRIPTION
Reads are technically racy with writes. Sort for stability.