### PR TITLE
DRAFT: automate release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,9 +70,8 @@ jobs:
         run: go mod download
 
       # Optional: sigstore/cosign. required for keyless signing at the cost of a (relatively common) dependency on cosign.
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 #v3.10.0
-
+      # - name: Install Cosign
+      #   uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 #v3.10.0
       # Optional: anchore/syft. generate SBOMs, at the cost of a (relatively common) dependency on anchore/sbom-action
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
@@ -98,10 +97,6 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: sbom.json
-      - name: Sign SBOM with Cosign
-        run: |
-          cosign sign --key cosign.key sbom.json
-
       - name: Create GitHub Release and upload SBOMs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Draft PR to demo the github action based release workflow. Will tidy up comments & commits before opening, but I'll pause here for feedback.

# Benefits:
Benefits over the current manual release workflow:
- attests SLSA build environment provenance, so consumers can validate releases
e.g.  `gh release verify v0.5.0 -R modelcontextprotocol/go-sdk`
- SBOM generation,
- (future) keyless signing of build provenance & assets so consumers can validate artifacts and lineage. 
- Multi‑party approvals: Gate releases behind Environments with required reviewers 
- Transparency & audit trail: CI logs, signed tag verification (“who cut this”), provenance attestations, and attached SBOMs make releases inspectable and defensible.
- Speed & reliability: Tag push triggers a fully automated release (source archives + SBOM + notes), less room for human error.

## Demo
This release was cut automatically: https://github.com/frenchi/go-sdk/releases/tag/v0.5.4
via this workflow run: https://github.com/frenchi/go-sdk/actions/runs/17816393139

With approval gating: pre-approval
<img width="400" src="https://github.com/user-attachments/assets/fb334e38-86e8-437b-b9e7-6a829921e605" />
approved
<img width="400" src="https://github.com/user-attachments/assets/25b4af17-517d-4ced-acf4-041e9ef06745" />

# TODO:

- if the dependency cost is worth it, use sigstore for signing of source/sbom, to be uploaded alongside releases,
- Enable [Immutable Releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases)
- Multi-party approval is possible via:
  - Github Repo Settings
  - -> Environments
  - -> release
  - -> Deployment protection rules
  - -> Required reviewers
<img width="400" height="1104"  src="https://github.com/user-attachments/assets/b501dbf1-23e1-4dfd-bd57-0379043cfecf" />
