### PR TITLE
docs: adjust example code to remove horizontal scroll bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ type Output struct {
 	Greeting string `json:"greeting" jsonschema:"the greeting to tell to the user"`
 }
 
-func SayHi(ctx context.Context, req *mcp.CallToolRequest, input Input) (*mcp.CallToolResult, Output, error) {
+func SayHi(ctx context.Context, req *mcp.CallToolRequest, input Input) (
+	*mcp.CallToolResult,
+	Output, error,
+) {
 	return nil, Output{Greeting: "Hi " + input.Name}, nil
 }
 


### PR DESCRIPTION
This change adjusts the code example in readme so if you view it in github it won't show a horizontal scroll bar in code example.

It's trivial change, but I believe it's still an improvement.