### PR TITLE
jsonschema: experiment with a proxy package

### DIFF
--- a/examples/server/elicitation/main.go
+++ b/examples/server/elicitation/main.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/examples/server/everything/main.go
+++ b/examples/server/everything/main.go
@@ -17,7 +17,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/examples/server/middleware/main.go
+++ b/examples/server/middleware/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/examples/server/toolschemas/main.go
+++ b/examples/server/toolschemas/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/jsonschema/jsonschema.go
+++ b/jsonschema/jsonschema.go
@@ -1,0 +1,31 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package jsonschema
+
+import (
+	"reflect"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+func Ptr[T any](x T) *T {
+	return jsonschema.Ptr(x)
+}
+
+type ForOptions = jsonschema.ForOptions
+
+type Resolved = jsonschema.Resolved
+
+type ResolveOptions = jsonschema.ResolveOptions
+
+type Schema = jsonschema.Schema
+
+func For[T any](opts *ForOptions) (*Schema, error) {
+	return jsonschema.For[T](opts)
+}
+
+func ForType(t reflect.Type, opts *ForOptions) (*Schema, error) {
+	return jsonschema.ForType(t, opts)
+}

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 // A Client is an MCP client, which may be connected to an MCP server

--- a/mcp/client_example_test.go
+++ b/mcp/client_example_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/mcp/client_list_test.go
+++ b/mcp/client_list_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 type Item struct {

--- a/mcp/conformance_test.go
+++ b/mcp/conformance_test.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"golang.org/x/tools/txtar"
 )
 

--- a/mcp/features_test.go
+++ b/mcp/features_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 type SayHiParams struct {

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 type hiParams struct {

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -14,7 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 // Optional annotations for the client. The client can use annotations to inform

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -20,10 +20,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/internal/util"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/yosida95/uritemplate/v3"
 )
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 type testItem struct {

--- a/mcp/streamable_bench_test.go
+++ b/mcp/streamable_bench_test.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 func TestStreamableTransports(t *testing.T) {

--- a/mcp/tool.go
+++ b/mcp/tool.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 // A ToolHandler handles a call to tools/call.

--- a/mcp/tool_example_test.go
+++ b/mcp/tool_example_test.go
@@ -12,7 +12,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/mcp/tool_test.go
+++ b/mcp/tool_test.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
+	"github.com/modelcontextprotocol/go-sdk/jsonschema"
 )
 
 func TestApplySchema(t *testing.T) {


### PR DESCRIPTION
Use a proxy package to limit the visibility of the jsonschema package and guard against incompatible API changes.

DO NOT REVIEW: experiment
DO NOT SUBMIT