### PR TITLE
mcp: decouple HTTPClient concrete implementation from client transports

### DIFF
--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -541,3 +541,11 @@ func startKeepalive(session keepaliveSession, interval time.Duration, cancelPtr 
 		}
 	}()
 }
+
+// HTTPClient is the minimal interface required by client transports for issuing HTTP requests.
+//
+// It matches the method set of (*http.Client).Do, allowing callers to provide custom HTTP clients
+// that incorporate middleware (auth, tracing, retries), or test doubles.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}

--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -326,9 +326,9 @@ type SSEClientTransport struct {
 	// Endpoint is the SSE endpoint to connect to.
 	Endpoint string
 
-	// HTTPClient is the client to use for making HTTP requests. If nil,
-	// http.DefaultClient is used.
-	HTTPClient *http.Client
+	// HTTPClient performs HTTP requests. If nil, http.DefaultClient is used.
+	// Any type implementing a Do(*http.Request) (*http.Response, error) method is supported.
+	HTTPClient HTTPClient
 }
 
 // Connect connects through the client endpoint.
@@ -403,9 +403,9 @@ func (c *SSEClientTransport) Connect(ctx context.Context) (Connection, error) {
 //   - Reads are SSE 'message' events, and pushes them onto a buffered channel.
 //   - Close terminates the GET request.
 type sseClientConn struct {
-	client      *http.Client // HTTP client to use for requests
-	msgEndpoint *url.URL     // session endpoint for POSTs
-	incoming    chan []byte  // queue of incoming messages
+	client      HTTPClient  // HTTP client to use for requests
+	msgEndpoint *url.URL    // session endpoint for POSTs
+	incoming    chan []byte // queue of incoming messages
 
 	mu     sync.Mutex
 	body   io.ReadCloser // body of the hanging GET

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -976,8 +976,10 @@ func (c *streamableServerConn) Close() error {
 // endpoint serving the streamable HTTP transport defined by the 2025-03-26
 // version of the spec.
 type StreamableClientTransport struct {
-	Endpoint   string
-	HTTPClient *http.Client
+	Endpoint string
+	// HTTPClient performs HTTP requests. If nil, http.DefaultClient is used.
+	// Any type implementing a Do(*http.Request) (*http.Response, error) method is supported.
+	HTTPClient HTTPClient
 	// MaxRetries is the maximum number of times to attempt a reconnect before giving up.
 	// It defaults to 5. To disable retries, use a negative number.
 	MaxRetries int
@@ -1034,7 +1036,7 @@ func (t *StreamableClientTransport) Connect(ctx context.Context) (Connection, er
 
 type streamableClientConn struct {
 	url        string
-	client     *http.Client
+	client     HTTPClient
 	ctx        context.Context
 	cancel     context.CancelFunc
 	incoming   chan jsonrpc.Message


### PR DESCRIPTION
# Description
This change decouples client transports from the concrete `net/http.Client` by accepting any HTTP client that implements `Do(http.Request) (http.Response, error)`. This enables middleware (auth, tracing, retries), improves testability, and unifies behavior across streamable and SSE transports.

# What changed
- Introduce `HTTPClient` interface in the `mcp` package.
- `StreamableClientTransport`: change `HTTPClient` field type to the interface; default to `http.DefaultClient` when nil.
- SSEClientTransport: same change as streamable.

# Why
- Flexibility to inject custom HTTP clients with middleware.
- Better testability via interface-based dependencies.
- Consistency across transports (streamable and SSE).

# Compatibility
- Backward compatible: existing code passing `http.Client` continues to work (it satisfies the interface).
- No behavior changes; defaults remain the same when HTTPClient is nil.

# Testing
- `go test ./...` passes locally.
- Existing transport tests validate streamable/SSE flows.

Fixes #522