### PR TITLE
internal/oauthex: address URL attacks in PRM

### DIFF
--- a/internal/oauthex/oauth2.go
+++ b/internal/oauthex/oauth2.go
@@ -65,3 +65,21 @@ func getJSON[T any](ctx context.Context, c *http.Client, url string, limit int64
 	}
 	return &t, nil
 }
+
+// checkURLScheme ensures that its argument is a valid URL with a scheme
+// that prevents XSS attacks.
+// See #526.
+func checkURLScheme(u string) error {
+	if u == "" {
+		return nil
+	}
+	uu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	scheme := strings.ToLower(uu.Scheme)
+	if scheme == "javascript" || scheme == "data" || scheme == "vbscript" {
+		return fmt.Errorf("URL has disallowed scheme %q", scheme)
+	}
+	return nil
+}

--- a/oauthex/oauthex.go
+++ b/oauthex/oauthex.go
@@ -5,7 +5,9 @@
 // Package oauthex implements extensions to OAuth2.
 package oauthex
 
-import "github.com/modelcontextprotocol/go-sdk/internal/oauthex"
+import (
+	"github.com/modelcontextprotocol/go-sdk/internal/oauthex"
+)
 
 // ProtectedResourceMetadata is the metadata for an OAuth 2.0 protected resource,
 // as defined in section 2 of https://www.rfc-editor.org/rfc/rfc9728.html.


### PR DESCRIPTION
Fix Protected Resource Metadata to prevent URL attacks, as described in the issue.

For #526