### PR TITLE
docs: Update readme generation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,11 +111,11 @@ The top-level `README.md` file is generated from `internal/readme/README.src.md`
 and should not be edited directly. To update the README:
 
 1. Make your changes to `internal/readme/README.src.md`
-2. Run `make` in the `internal/readme/` directory to regenerate `README.md`
+2. Run `go generate ./internal/readme` from the repository root to regenerate `README.md`
 3. Commit both files together
 
 The CI system will automatically check that the README is up-to-date by running
-`make` and verifying no changes result. If you see a CI failure about the
+`go generate ./internal/readme` and verifying no changes result. If you see a CI failure about the
 README being out of sync, follow the steps above to regenerate it.
 
 ## Timeouts

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ servers.
 
 ## Contributing
 
-We welcome contributions to the SDK! Please see See
+We welcome contributions to the SDK! Please see
 [CONTRIBUTING.md](/CONTRIBUTING.md) for details of how to contribute.
 
 ## Acknowledgements / Alternatives

--- a/internal/readme/README.src.md
+++ b/internal/readme/README.src.md
@@ -48,7 +48,7 @@ servers.
 
 ## Contributing
 
-We welcome contributions to the SDK! Please see See
+We welcome contributions to the SDK! Please see
 [CONTRIBUTING.md](/CONTRIBUTING.md) for details of how to contribute.
 
 ## Acknowledgements / Alternatives


### PR DESCRIPTION
docs: update README generation instructions in CONTRIBUTING.md

This change updates the "Updating the README" section in CONTRIBUTING.md to reflect the correct workflow for regenerating the top-level README.md. The previous instructions referenced a Makefile and `make` command, but the actual process uses Go's `go generate` directive as defined in `internal/readme/doc.go`.

With this update, contributors are now instructed to edit `internal/readme/README.src.md` and run `go generate ./internal/readme` from the repository root to regenerate `README.md`.

This improves contributor experience and ensures documentation is accurate and up-to-date.

Fixes #554 