### PR TITLE
Correct go run commands to run the logging file

### DIFF
--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -13,14 +13,14 @@ The example implements:
 Start the Server
 
 ```bash
-go run main.go server
+go run . server
 ```
 This starts an MCP server on `http://localhost:8080` (default) that provides a `cityTime` tool.
 
 To run a client in another terminal:
 
 ```bash
-go run main.go client
+go run . client
 ```
 
 The client will:
@@ -32,7 +32,7 @@ The client will:
 At any given time you can pass a custom URL to the program to run it on a custom host/port:
 
 ```
-go run main.go -host 0.0.0.0 -port 9000 server
+go run . -host 0.0.0.0 -port 9000 server
 ```
 
 ## Testing with real-world MCP Clients


### PR DESCRIPTION
Readme update and clarification

Targeting only the main.go doesn't add the logging file and causes errors when finding additional functions. 

```
mcp-server-testing main*​ ☸ prod-3-d 33s 
❯ go run main.go server
# command-line-arguments
./main.go:127:24: undefined: LoggingHandler

mcp-server-testing main*​ ☸ prod-3-d 
❯ go run . server      
2025/10/09 11:33:13 MCP server listening on localhost:8000
2025/10/09 11:33:13 Available tool: cityTime (cities: nyc, sf, boston)
```