### PR TITLE
mcp: clean up stream metadata after completion

### DIFF
--- a/examples/client/loadtest/main.go
+++ b/examples/client/loadtest/main.go
@@ -34,6 +34,7 @@ var (
 	timeout  = flag.Duration("timeout", 1*time.Second, "request timeout")
 	qps      = flag.Int("qps", 100, "tool calls per second, per worker")
 	verbose  = flag.Bool("v", false, "if set, enable verbose logging")
+	cleanup  = flag.Bool("cleanup", true, "whether to clean up sessions at the end of the test")
 )
 
 func main() {
@@ -76,7 +77,9 @@ func main() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			defer cs.Close()
+			if *cleanup {
+				defer cs.Close()
+			}
 
 			ticker := time.NewTicker(1 * time.Second / time.Duration(*qps))
 			defer ticker.Stop()


### PR DESCRIPTION
Address longstanding TODOs to clean up stream metadata after streams are complete:

- Interpret a missing stream as a complete stream.
- Remove the request->stream mapping when the request completes. Any writes after that point will fail as there can be no recipient.

Tested using examples/client/loadtest, and updating TestStreamableTransports to check in-band and out-of-band behavior.