### PR TITLE
oauthex: add missing build tag

### DIFF
--- a/oauthex/oauthex.go
+++ b/oauthex/oauthex.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build mcp_go_client_oauth
+
 // Package oauthex implements extensions to OAuth2.
 package oauthex
 


### PR DESCRIPTION
The file oauthex/oauthex.go was missing the mcp_go_client_oauth build tag, making the package importable. I believe that was accidental.