### PR TITLE
auth: clone the client request body before roundtripping

### DIFF
--- a/auth/client.go
+++ b/auth/client.go
@@ -69,9 +69,6 @@ func (t *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	base := t.opts.Base
 	t.mu.Unlock()
 
-	// req1 is our first request in the authorization flow.
-	//
-	// If we mutate its body, we must clone it first.
 	var (
 		// If haveBody is set, the request has a nontrivial body, and we need avoid
 		// reading (or closing) it multiple times. In that case, bodyBytes is its

--- a/auth/client_test.go
+++ b/auth/client_test.go
@@ -122,7 +122,6 @@ func TestHTTPTransport(t *testing.T) {
 		client := &http.Client{Transport: transport}
 
 		resp, err := client.Post(authServer.URL, "application/json", &basicReader{strings.NewReader("{}")})
-		// resp, err := client.Post(authServer.URL, "application/json", strings.NewReader("{}"))
 		if err != nil {
 			t.Fatalf("client.Post() failed: %v", err)
 		}


### PR DESCRIPTION
RoundTrippers may read and close the body, so be careful to clone before roundtripping during client oauth, as the request may be issued multiple times.

Fixes #590