### PR TITLE
.github: fix staticcheck linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: "^1.23"
+          go-version: "^1.25"
       - name: Check formatting
         run: |
           unformatted=$(gofmt -l .)
@@ -33,7 +33,8 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@024238d2898c874f26d723e7d0ff4308c35589a2 # v1
         with:
-          version: "latest"
+          install-go: false
+          version: "v0.6.1"
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the test.yml lint job to run linting with Go 1.25, and use the ambient Go command to run staticcheck. This seems to fix a mysterious bug where staticcheck was failing, presumably in the Go installation step. Using the ambient Go command resulted in staticcheck failures, since some symbols are detected as unused at Go 1.23 due to build tags. Upgrading the Go version for this job avoids those errors.

Also, use a pinned version of staticcheck (as recommended), to avoid future failures when new versions are released.