### PR TITLE
mcp: prototype implementation for SEP 1442

### DIFF
--- a/internal/jsonrpc2/wire.go
+++ b/internal/jsonrpc2/wire.go
@@ -32,7 +32,7 @@ var (
 	// server being temporarily unable to accept any new messages.
 	ErrServerOverloaded = NewError(-32000, "overloaded")
 	// ErrUnknown should be used for all non coded errors.
-	ErrUnknown = NewError(-32001, "unknown error")
+	ErrUnknown = NewError(-32099, "unknown error")
 	// ErrServerClosing is returned for calls that arrive while the server is closing.
 	ErrServerClosing = NewError(-32004, "server is closing")
 	// ErrClientClosing is a dummy error returned for calls initiated while the client is closing.

--- a/mcp/mcp_example_test.go
+++ b/mcp/mcp_example_test.go
@@ -37,7 +37,7 @@ func Example_lifecycle() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	clientSession, err := client.Connect(ctx, t2, nil)
+	clientSession, err := client.Connect(ctx, t2, &mcp.ClientSessionOptions{Initialize: true})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 )
@@ -159,7 +160,7 @@ func TestEndToEnd(t *testing.T) {
 	c.AddRoots(&Root{URI: "file://" + rootAbs})
 
 	// Connect the client.
-	cs, err := c.Connect(ctx, ct, nil)
+	cs, err := c.Connect(ctx, ct, &ClientSessionOptions{Initialize: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +406,7 @@ func TestEndToEnd(t *testing.T) {
 					t.Fatal("timed out waiting for log messages")
 				}
 			}
-			if diff := cmp.Diff(want, got); diff != "" {
+			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(LoggingMessageParams{}, "Meta")); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}
 		}
@@ -760,7 +761,7 @@ func TestMiddleware(t *testing.T) {
 	c.AddSendingMiddleware(traceCalls[*ClientSession](&cbuf, "S1"), traceCalls[*ClientSession](&cbuf, "S2"))
 	c.AddReceivingMiddleware(traceCalls[*ClientSession](&cbuf, "R1"), traceCalls[*ClientSession](&cbuf, "R2"))
 
-	cs, err := c.Connect(ctx, ct, nil)
+	cs, err := c.Connect(ctx, ct, &ClientSessionOptions{Initialize: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -347,6 +347,29 @@ func (r *CreateMessageResult) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// DiscoverParams is sent from the client to the server to request information
+// about the server's capabilities and other metadata.
+type DiscoverParams struct {
+	// This property is reserved by the protocol to allow clients and servers to
+	// attach additional metadata to their responses.
+	Meta `json:"_meta,omitempty"`
+}
+
+func (*DiscoverParams) isParams() {}
+
+// DiscoverResult is the server's response to a server/discover request.
+type DiscoverResult struct {
+	// This property is reserved by the protocol to allow clients and servers to
+	// attach additional metadata to their responses.
+	Meta            `json:"_meta,omitempty"`
+	ProtocolVersion string              `json:"protocolVersion"`
+	ServerInfo      *Implementation     `json:"serverInfo"`
+	Capabilities    *ServerCapabilities `json:"capabilities"`
+	Instructions    string              `json:"instructions,omitempty"`
+}
+
+func (*DiscoverResult) isResult() {}
+
 type GetPromptParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -406,6 +429,7 @@ type InitializeResult struct {
 	// support this version, it must disconnect.
 	ProtocolVersion string          `json:"protocolVersion"`
 	ServerInfo      *Implementation `json:"serverInfo"`
+	SessionID       string          `json:"sessionId,omitempty"`
 }
 
 func (*InitializeResult) isResult() {}
@@ -1162,4 +1186,5 @@ const (
 	methodSubscribe                 = "resources/subscribe"
 	notificationToolListChanged     = "notifications/tools/list_changed"
 	methodUnsubscribe               = "resources/unsubscribe"
+	methodServerDiscover            = "server/discover"
 )

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -223,48 +223,6 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	sessionID := req.Header.Get(sessionIDHeader)
-	var sessInfo *sessionInfo
-	if sessionID != "" {
-		h.mu.Lock()
-		sessInfo = h.sessions[sessionID]
-		h.mu.Unlock()
-		if sessInfo == nil && !h.opts.Stateless {
-			// Unless we're in 'stateless' mode, which doesn't perform any Session-ID
-			// validation, we require that the session ID matches a known session.
-			//
-			// In stateless mode, a temporary transport is be created below.
-			http.Error(w, "session not found", http.StatusNotFound)
-			return
-		}
-	}
-
-	if req.Method == http.MethodDelete {
-		if sessionID == "" {
-			http.Error(w, "Bad Request: DELETE requires an Mcp-Session-Id header", http.StatusBadRequest)
-			return
-		}
-		if sessInfo != nil { // sessInfo may be nil in stateless mode
-			// Closing the session also removes it from h.sessions, due to the
-			// onClose callback.
-			sessInfo.session.Close()
-		}
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	switch req.Method {
-	case http.MethodPost, http.MethodGet:
-		if req.Method == http.MethodGet && (h.opts.Stateless || sessionID == "") {
-			http.Error(w, "GET requires an active session", http.StatusMethodNotAllowed)
-			return
-		}
-	default:
-		w.Header().Set("Allow", "GET, POST, DELETE")
-		http.Error(w, "Method Not Allowed: streamable MCP servers support GET, POST, and DELETE requests", http.StatusMethodNotAllowed)
-		return
-	}
-
 	// [§2.7] of the spec (2025-06-18) states:
 	//
 	// "If using HTTP, the client MUST include the MCP-Protocol-Version:
@@ -294,13 +252,71 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 	//
 	// This logic matches the typescript SDK.
 	//
-	// [§2.7]: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#protocol-version-header
+	// For backwards compatibility, if the server does not receive an
+	// MCP-Protocol-Version header, and has no other way to identify the version -
+	// for example, by relying on the protocol version negotiated during
+	// initialization - the server SHOULD assume protocol version 2025-03-26.
+	//
+	// If the server receives a request with an invalid or unsupported
+	// MCP-Protocol-Version, it MUST respond with 400 Bad Request."
+	//
+	// Since this wasn't present in the 2025-03-26 version of the spec, this
+	// effectively means:
+	//  1. IF the client provides a version header, it must be a supported
+	//     version.
+	//  2. In stateless mode, where we've lost the state of the initialize
+	//     request, we assume that whatever the client tells us is the truth (or
+	//     assume 2025-03-26 if the client doesn't say anything).
+	//
+	// This logic matches the typescript SDK.
 	protocolVersion := req.Header.Get(protocolVersionHeader)
 	if protocolVersion == "" {
 		protocolVersion = protocolVersion20250326
 	}
 	if !slices.Contains(supportedProtocolVersions, protocolVersion) {
 		http.Error(w, fmt.Sprintf("Bad Request: Unsupported protocol version (supported versions: %s)", strings.Join(supportedProtocolVersions, ",")), http.StatusBadRequest)
+		return
+	}
+
+	sessionID := req.Header.Get(sessionIDHeader)
+	var sessInfo *sessionInfo
+	if sessionID != "" {
+		h.mu.Lock()
+		sessInfo = h.sessions[sessionID]
+		h.mu.Unlock()
+		if sessInfo == nil && !h.opts.Stateless && compareProtocolVersions(protocolVersion, protocolVersion20251130) < 0 {
+			// Unless we're in 'stateless' mode, which doesn't perform any Session-ID
+			// validation, we require that the session ID matches a known session.
+			//
+			// In stateless mode, a temporary transport is be created below.
+			http.Error(w, "session not found: "+protocolVersion, http.StatusNotFound)
+			return
+		}
+	}
+
+	if req.Method == http.MethodDelete {
+		if sessionID == "" {
+			http.Error(w, "Bad Request: DELETE requires an Mcp-Session-Id header", http.StatusBadRequest)
+			return
+		}
+		if sessInfo != nil { // sessInfo may be nil in stateless mode
+			// Closing the session also removes it from h.sessions, due to the
+			// onClose callback.
+			sessInfo.session.Close()
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	switch req.Method {
+	case http.MethodPost, http.MethodGet:
+		if req.Method == http.MethodGet && (h.opts.Stateless || sessionID == "") {
+			http.Error(w, "GET requires an active session", http.StatusMethodNotAllowed)
+			return
+		}
+	default:
+		w.Header().Set("Allow", "GET, POST, DELETE")
+		http.Error(w, "Method Not Allowed: streamable MCP servers support GET, POST, and DELETE requests", http.StatusMethodNotAllowed)
 		return
 	}
 
@@ -429,6 +445,8 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 			h.mu.Unlock()
 			defer func() {
 				// If initialization failed, clean up the session (#578).
+				// TODO(SEP 1442): what should the lifecycle be here?
+				// Should we persist the session forever?
 				if session.InitializeParams() == nil {
 					// Initialization failed.
 					session.Close()
@@ -1322,6 +1340,7 @@ type streamableClientConn struct {
 	// Guard the initialization state.
 	mu                sync.Mutex
 	initializedResult *InitializeResult
+	protocolVersion   string // explicit protocol version, if no InitializeResult
 	sessionID         string
 }
 
@@ -1341,22 +1360,30 @@ var _ clientConnection = (*streamableClientConn)(nil)
 func (c *streamableClientConn) sessionUpdated(state clientSessionState) {
 	c.mu.Lock()
 	c.initializedResult = state.InitializeResult
+	c.protocolVersion = state.ProtocolVersion
+	// FIXME: document this.
+	// We only accept synthetic session IDs if not initializing.
+	if state.InitializeResult == nil {
+		c.sessionID = state.SessionID
+	}
 	c.mu.Unlock()
 
-	// Start the standalone SSE stream as soon as we have the initialized
-	// result.
-	//
-	// § 2.2: The client MAY issue an HTTP GET to the MCP endpoint. This can be
-	// used to open an SSE stream, allowing the server to communicate to the
-	// client, without the client first sending data via HTTP POST.
-	//
-	// We have to wait for initialized, because until we've received
-	// initialized, we don't know whether the server requires a sessionID.
-	//
-	// § 2.5: A server using the Streamable HTTP transport MAY assign a session
-	// ID at initialization time, by including it in an Mcp-Session-Id header
-	// on the HTTP response containing the InitializeResult.
-	c.connectStandaloneSSE()
+	if state.InitializeResult != nil {
+		// Start the standalone SSE stream as soon as we have the initialized
+		// result.
+		//
+		// § 2.2: The client MAY issue an HTTP GET to the MCP endpoint. This can be
+		// used to open an SSE stream, allowing the server to communicate to the
+		// client, without the client first sending data via HTTP POST.
+		//
+		// We have to wait for initialized, because until we've received
+		// initialized, we don't know whether the server requires a sessionID.
+		//
+		// § 2.5: A server using the Streamable HTTP transport MAY assign a session
+		// ID at initialization time, by including it in an Mcp-Session-Id header
+		// on the HTTP response containing the InitializeResult.
+		c.connectStandaloneSSE()
+	}
 }
 
 func (c *streamableClientConn) connectStandaloneSSE() {
@@ -1548,6 +1575,8 @@ func (c *streamableClientConn) setMCPHeaders(req *http.Request) {
 
 	if c.initializedResult != nil {
 		req.Header.Set(protocolVersionHeader, c.initializedResult.ProtocolVersion)
+	} else if c.protocolVersion != "" && compareProtocolVersions(c.protocolVersion, protocolVersion20251130) >= 0 {
+		req.Header.Set(protocolVersionHeader, c.protocolVersion)
 	}
 	if c.sessionID != "" {
 		req.Header.Set(sessionIDHeader, c.sessionID)
@@ -1742,7 +1771,9 @@ func (c *streamableClientConn) Close() error {
 	c.closeOnce.Do(func() {
 		if errors.Is(c.failure(), errSessionMissing) {
 			// If the session is missing, no need to delete it.
-		} else {
+		} else if c.sessionID != "" {
+			// TODO(rfindley): we should check that sessionID is nonempty here, independent
+			// of SEP 1442.
 			req, err := http.NewRequestWithContext(c.ctx, http.MethodDelete, c.url, nil)
 			if err != nil {
 				c.closeErr = err

--- a/mcp/streamable_client_test.go
+++ b/mcp/streamable_client_test.go
@@ -166,7 +166,7 @@ func TestStreamableClientTransportLifecycle(t *testing.T) {
 
 	transport := &StreamableClientTransport{Endpoint: httpServer.URL}
 	client := NewClient(testImpl, nil)
-	session, err := client.Connect(ctx, transport, nil)
+	session, err := client.Connect(ctx, transport, &ClientSessionOptions{Initialize: true})
 	if err != nil {
 		t.Fatalf("client.Connect() failed: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestStreamableClientRedundantDelete(t *testing.T) {
 
 	transport := &StreamableClientTransport{Endpoint: httpServer.URL}
 	client := NewClient(testImpl, nil)
-	session, err := client.Connect(ctx, transport, nil)
+	session, err := client.Connect(ctx, transport, &ClientSessionOptions{Initialize: true})
 	if err != nil {
 		t.Fatalf("client.Connect() failed: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestStreamableClientGETHandling(t *testing.T) {
 
 			transport := &StreamableClientTransport{Endpoint: httpServer.URL}
 			client := NewClient(testImpl, nil)
-			session, err := client.Connect(ctx, transport, nil)
+			session, err := client.Connect(ctx, transport, &ClientSessionOptions{Initialize: true})
 			if err == nil {
 				defer session.Close()
 			}
@@ -313,7 +313,7 @@ func TestStreamableClientStrictness(t *testing.T) {
 		// mode.
 		{"unstrict GET on StatusNotFound", false, http.StatusOK, http.StatusNotFound, false},
 		{"unstrict GET on StatusBadRequest", false, http.StatusOK, http.StatusBadRequest, false},
-		{"GET on InternlServerError", false, http.StatusOK, http.StatusInternalServerError, true},
+		{"GET on InternalServerError", false, http.StatusOK, http.StatusInternalServerError, true},
 	}
 	for _, test := range tests {
 		t.Run(test.label, func(t *testing.T) {
@@ -354,7 +354,7 @@ func TestStreamableClientStrictness(t *testing.T) {
 
 			transport := &StreamableClientTransport{Endpoint: httpServer.URL, strict: test.strict}
 			client := NewClient(testImpl, nil)
-			session, err := client.Connect(ctx, transport, nil)
+			session, err := client.Connect(ctx, transport, &ClientSessionOptions{Initialize: true})
 			if (err != nil) != test.wantConnectError {
 				t.Errorf("client.Connect() returned error %v; want error: %t", err, test.wantConnectError)
 			}
@@ -394,7 +394,7 @@ func TestStreamableClientUnresumableRequest(t *testing.T) {
 
 	transport := &StreamableClientTransport{Endpoint: httpServer.URL}
 	client := NewClient(testImpl, nil)
-	cs, err := client.Connect(ctx, transport, nil)
+	cs, err := client.Connect(ctx, transport, &ClientSessionOptions{Initialize: true})
 	if err == nil {
 		cs.Close()
 		t.Fatalf("Connect succeeded unexpectedly")

--- a/mcp/streamable_example_test.go
+++ b/mcp/streamable_example_test.go
@@ -24,7 +24,9 @@ func ExampleStreamableHTTPHandler() {
 	//
 	// Here, we configure it to serves application/json responses rather than
 	// text/event-stream, just so the output below doesn't use random event ids.
-	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "v0.1.0"}, nil)
+	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "v0.1.0"}, &mcp.ServerOptions{
+		GetSessionID: func() string { return "123" },
+	})
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server
 	}, &mcp.StreamableHTTPOptions{JSONResponse: true})
@@ -35,7 +37,7 @@ func ExampleStreamableHTTPHandler() {
 	resp := mustPostMessage(`{"jsonrpc": "2.0", "id": 1, "method":"initialize", "params": {}}`, httpServer.URL)
 	fmt.Println(resp)
 	// Output:
-	// {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"logging":{}},"protocolVersion":"2025-06-18","serverInfo":{"name":"server","version":"v0.1.0"}}}
+	// {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"logging":{}},"protocolVersion":"2025-11-30","serverInfo":{"name":"server","version":"v0.1.0"},"sessionId":"123"}}
 }
 
 // !-streamablehandler

--- a/mcp/testdata/conformance/server/lifecycle.txtar
+++ b/mcp/testdata/conformance/server/lifecycle.txtar
@@ -25,9 +25,8 @@ See also modelcontextprotocol/go-sdk#225.
 {
 	"jsonrpc": "2.0",
 	"id": 2,
-	"error": {
-		"code": 0,
-		"message": "method \"tools/list\" is invalid during session initialization"
+	"result": {
+		"tools": []
 	}
 }
 {

--- a/mcp/testdata/conformance/server/version-latest.txtar
+++ b/mcp/testdata/conformance/server/version-latest.txtar
@@ -20,7 +20,7 @@ response with its latest supported version.
 		"capabilities": {
 			"logging": {}
 		},
-		"protocolVersion": "2025-06-18",
+		"protocolVersion": "2025-11-30",
 		"serverInfo": {
 			"name": "testServer",
 			"version": "v1.0.0"

--- a/mcp/transport_example_test.go
+++ b/mcp/transport_example_test.go
@@ -30,7 +30,9 @@ func ExampleLoggingTransport() {
 	}
 	defer serverSession.Close()
 
-	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "v0.0.1"}, nil)
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "v0.0.1"}, &mcp.ClientOptions{
+		ProtocolVersion: "2025-06-18",
+	})
 	var b bytes.Buffer
 	logTransport := &mcp.LoggingTransport{Transport: t2, Writer: &b}
 	clientSession, err := client.Connect(ctx, logTransport, nil)


### PR DESCRIPTION
This PR is the result of spending a few hours going through and attempting to implement SEP 1442
(modelcontextprotocol/modelcontextprotocol#1442).

Implemented:
 - skipping initialization
 - new protocol version and session ID treatment
 - server/discover
 - unsupported version errors
 - new _meta fields
 - client capability embedding

Still TODO:
 - client-initiated streams
 - ergonomics and documentation for handling capabilities from application code
 - many, many more tests (and corresponding bug fixes)

This is very much quick and dirty, though I learned a lot about the SEP in the process. Tests pass, albeit largely because I configure the client to keep initialization, or downgrade the protocol version.

Notably, server->client requests do work in the context of an uninitialized session.

Additional observations will be noted in PR comments.