### PR TITLE
streamable HTTP client: Don't block on standalone SSE Get

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -1356,7 +1356,7 @@ func (c *streamableClientConn) sessionUpdated(state clientSessionState) {
 	// § 2.5: A server using the Streamable HTTP transport MAY assign a session
 	// ID at initialization time, by including it in an Mcp-Session-Id header
 	// on the HTTP response containing the InitializeResult.
-	c.connectStandaloneSSE()
+	go c.connectStandaloneSSE()
 }
 
 func (c *streamableClientConn) connectStandaloneSSE() {
@@ -1394,7 +1394,7 @@ func (c *streamableClientConn) connectStandaloneSSE() {
 		c.fail(err)
 		return
 	}
-	go c.handleSSE(summary, resp, true, nil)
+	c.handleSSE(summary, resp, true, nil)
 }
 
 // fail handles an asynchronous error while reading.

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -590,6 +590,9 @@ func TestServerTransportCleanup(t *testing.T) {
 
 // TestServerInitiatedSSE verifies that the persistent SSE connection remains
 // open and can receive server-initiated events.
+// TODO: This test is flaky. Sometimes the server fails to send the notifications/tools/list_changed message
+// with error `rejected by transport: undelivered message`.
+// Both the `streamableServerConn.eventStore` and `deliver` are nil when it fails
 func TestServerInitiatedSSE(t *testing.T) {
 	notifications := make(chan string)
 	server := NewServer(testImpl, nil)


### PR DESCRIPTION
# Problem
When connecting to some MCP servers that supports making SSE GET requests, client.Connect gets hung up waiting for the first notification from the server. 

More details in issue #633

# Solution

This change modifies the tests to simulate a server that keeps the stand alone SSE connection open. It then adjusts the connection setup to run the standalone SSE connection in the background.

# Open question
Work was done 2 weeks ago in #604 / #583 to make some errors from starting the stand alone SSE connection be returned as part of client.Connect. I'm not clear on why that is necessary. Clients are not required to accept SSE messages from servers. Stateless clients will want to opt out of even attempting to create the standalone SSE connection.
This PR undoes some of it so may not be the correct solution. 

I'll clean up the tests once I know more.