### PR TITLE
mcp: introduce options for AddTool

### DIFF
--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -562,7 +562,7 @@ func testToolForSchema[In, Out any](t *testing.T, tool *Tool, in string, out Out
 	th := func(context.Context, *CallToolRequest, In) (*CallToolResult, Out, error) {
 		return nil, out, nil
 	}
-	gott, goth, err := toolForErr(tool, th)
+	gott, goth, err := toolForErr(tool, th, &jsonschema.ForOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This change introduces a non-breaking API for passing options to `mcp.AddTool()`. The first option introduced is the `jsonschema.ForOptions`, which allows jsonschema to use a specified mapping of Go types to schemas defined by the caller, which are used instead of inference via reflection. This is very useful for example for Go structs implementing the `MarshalJSON` and `UnmarshalJSON` interfaces in order to represent the struct as a string. For example, imagine a MonthID struct containing Year and Month as integers, and whose serialization format implemented by `MarshalJSON` is `YYYYMM`. From the jsonschema perspective the type must be string, but the representation in Go can be rich through a struct.

Fixes #658