### PR TITLE
docs: document non-pointer receiver for AudioContent

### DIFF
--- a/docs/rough_edges.md
+++ b/docs/rough_edges.md
@@ -23,3 +23,6 @@ v2.
     other notification param types.
   - Similarly, `ProgressNotificationParams` should probably have been
     `ProgressParams`.
+
+- `AudioContent.MarshalJSON` should have had a pointer receiver, to be
+  consistent with other content types.

--- a/internal/docs/rough_edges.src.md
+++ b/internal/docs/rough_edges.src.md
@@ -22,3 +22,6 @@ v2.
     other notification param types.
   - Similarly, `ProgressNotificationParams` should probably have been
     `ProgressParams`.
+
+- `AudioContent.MarshalJSON` should have had a pointer receiver, to be
+  consistent with other content types.


### PR DESCRIPTION
AudioContent should have had a non-pointer receiver, to be consistent with other content types. Add this to our log of rough edges to reconsider for v2.

Fixes #641