### PR TITLE
fix: handle Windows CRLF in MCP client(#664)

### DIFF
--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -381,7 +381,8 @@ func newIOConn(rwc io.ReadWriteCloser) *ioConn {
 				var tr [1]byte
 				if n, readErr := dec.Buffered().Read(tr[:]); n > 0 {
 					// If read byte is not a newline, it is an error.
-					if tr[0] != '\n' {
+					// Support both Unix (\n) and Windows (\r\n) line endings.
+					if tr[0] != '\n' && tr[0] != '\r' {
 						err = fmt.Errorf("invalid trailing data at the end of stream")
 					}
 				} else if readErr != nil && readErr != io.EOF {

--- a/mcp/transport_test.go
+++ b/mcp/transport_test.go
@@ -84,6 +84,11 @@ func TestIOConnRead(t *testing.T) {
 			protocolVersion: "",
 		},
 		{
+			name:  "windows newline at the end of first valid json input",
+			input: "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"test\",\"params\":{}}\r\n",
+			want:  "",
+		},
+		{
 			name:            "batching old protocol",
 			input:           `[{"jsonrpc":"2.0","id":1,"method":"test1"},{"jsonrpc":"2.0","id":2,"method":"test2"}]`,
 			want:            "",


### PR DESCRIPTION
This change updates the MCP client stdio JSON decoder to correctly handle
both Unix (`\n`) and Windows (`\r\n`) line endings. 

Fixes #664
