### PR TITLE
mcp: add NewInMemoryTransport constructor for custom connections

### DIFF
--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -126,6 +126,15 @@ func (t *InMemoryTransport) Connect(context.Context) (Connection, error) {
 	return newIOConn(t.rwc), nil
 }
 
+// NewInMemoryTransport returns an [InMemoryTransport] that wraps the provided
+// io.ReadWriteCloser. This allows external consumers to provide their own
+// bidirectional connection (e.g., custom network connections, test doubles).
+//
+// The transport will use newline-delimited JSON over the provided rwc.
+func NewInMemoryTransport(rwc io.ReadWriteCloser) *InMemoryTransport {
+	return &InMemoryTransport{rwc: rwc}
+}
+
 // NewInMemoryTransports returns two [InMemoryTransport] objects that connect
 // to each other.
 //
@@ -134,7 +143,7 @@ func (t *InMemoryTransport) Connect(context.Context) (Connection, error) {
 // clients, as the client initializes the MCP session during connection.
 func NewInMemoryTransports() (*InMemoryTransport, *InMemoryTransport) {
 	c1, c2 := net.Pipe()
-	return &InMemoryTransport{c1}, &InMemoryTransport{c2}
+	return NewInMemoryTransport(c1), NewInMemoryTransport(c2)
 }
 
 type binder[T handler, State any] interface {

--- a/mcp/transport_example_test.go
+++ b/mcp/transport_example_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"slices"
 	"strings"
 
@@ -51,3 +52,36 @@ func ExampleLoggingTransport() {
 }
 
 // !-loggingtransport
+
+// !+newinmemorytransport
+
+func ExampleNewInMemoryTransport() {
+	ctx := context.Background()
+
+	// Create a custom pair of connected pipes
+	c1, c2 := net.Pipe()
+
+	// Wrap them in InMemoryTransport using the new constructor
+	t1 := mcp.NewInMemoryTransport(c1)
+	t2 := mcp.NewInMemoryTransport(c2)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "v0.0.1"}, nil)
+	serverSession, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	fmt.Println("Connected successfully!")
+	// Output:
+	// Connected successfully!
+}
+
+// !-newinmemorytransport


### PR DESCRIPTION
## Summary

- Add `NewInMemoryTransport(io.ReadWriteCloser)` constructor to allow external consumers to provide their own bidirectional connections
- Refactor existing `NewInMemoryTransports()` to use the new constructor internally
- Add example test demonstrating usage with custom `net.Pipe()` connections

## Motivation

This change enables external consumers to:
- Provide custom network connections (e.g., Unix domain sockets, custom net.Conn implementations)
- Create mock implementations for testing scenarios
- Have more control over the underlying transport layer

## Backwards Compatibility

This change is fully backwards compatible:
- The existing `NewInMemoryTransports()` function signature is unchanged
- All existing tests pass without modification
- The internal behavior remains identical

## Test Plan

- All existing tests pass
- Added `ExampleNewInMemoryTransport` demonstrating the new constructor