### PR TITLE
mcp/mcp_test: tests for elicit content validation

### DIFF
--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -1424,6 +1424,9 @@ func TestElicitContentValidation(t *testing.T) {
 	}
 	defer ss.Close()
 
+	// Set up a client that exercises valid/invalid elicitation: the returned
+	// Content from the handler ("potato") is validated against the schemas
+	// defined in the testcases below.
 	c := NewClient(testImpl, &ClientOptions{
 		ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
 			return &ElicitResult{Action: "accept", Content: map[string]any{"test": "potato"}}, nil


### PR DESCRIPTION
This adds a simple schema and checks that the content returned by an elicitation handler is validated against the schema. Previously, we had no test coverage checking if the content was validated (i.e., we would see no test failures if we removed content validation against the schema).

The bulk of the actual validation logic is handled by the jsonschema library so adding comprehensive tests covering different schema-features is redundant, we simply need to see that some validation is happening.

See https://github.com/modelcontextprotocol/go-sdk/issues/625 for more details on the motivation of this change.

Fixes #625
