### PR TITLE
.github: add permissions to the nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   vulncheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is best practice, and I'd missed it while adding the nightly vulncheck workflow.