### PR TITLE
auth, mcp: add UserID to TokenInfo for session hijacking prevention

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -17,6 +17,11 @@ import (
 type TokenInfo struct {
 	Scopes     []string
 	Expiration time.Time
+	// UserID is an optional identifier for the authenticated user.
+	// If set by a TokenVerifier, it can be used by transports to prevent
+	// session hijacking by ensuring that all requests for a given session
+	// come from the same user.
+	UserID string
 	// TODO: add standard JWT fields
 	Extra map[string]any
 }


### PR DESCRIPTION
Add a UserID field to auth.TokenInfo that TokenVerifiers can populate from JWT "sub" claims or token introspection. The streamable HTTP transport uses this to bind sessions to users, rejecting requests where the user ID doesn't match the session's original user.

Fixes #589