### PR TITLE
docs: add GitHub Pages redirect to latest release documentation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,24 @@
+name: Publish Docs to GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          publish_branch: gh-pages
+          enable_jekyll: true

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,15 @@
+---
+---
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MCP Go SDK Documentation</title>
+  <meta http-equiv="refresh" content="0; url=https://github.com/modelcontextprotocol/go-sdk/blob/{{ site.github.latest_release.tag_name }}/docs/README.md">
+  <link rel="canonical" href="https://github.com/modelcontextprotocol/go-sdk/blob/{{ site.github.latest_release.tag_name }}/docs/README.md">
+</head>
+<body>
+  <p>Redirecting to <a href="https://github.com/modelcontextprotocol/go-sdk/blob/{{ site.github.latest_release.tag_name }}/docs/README.md">MCP Go SDK documentation ({{ site.github.latest_release.tag_name }})</a>...</p>
+  <p>For API reference, see <a href="https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk">pkg.go.dev</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
**Context:** I am working on getting documentation up for each MCP SDK at `https://modelcontextprotocol.github.io/*-sdk/`.  I realize the Go ecosystem has its own idioms for generating and hosting documentation, so I am proposing we make https://modelcontextprotocol.github.io/go-sdk/ redirect to the latest tag of https://github.com/modelcontextprotocol/go-sdk/blob/v1.1.0/docs/README.md.

---

Adds a redirect page at https://modelcontextprotocol.github.io/go-sdk/ that automatically redirects visitors to the `docs/README.md` of the latest release tag. Uses Jekyll templating with `site.github.latest_release` to dynamically resolve the current release version at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
