### PR TITLE
mcp: add documentation for the streamable implementation

### DIFF
--- a/internal/jsonrpc2/conn.go
+++ b/internal/jsonrpc2/conn.go
@@ -55,9 +55,16 @@ type ConnectionOptions struct {
 }
 
 // Connection manages the jsonrpc2 protocol, connecting responses back to their
-// calls.
-// Connection is bidirectional; it does not have a designated server or client
-// end.
+// calls. Connection is bidirectional; it does not have a designated server or
+// client end.
+//
+// Note that the word 'Connection' is overloaded: the mcp.Connection represents
+// the bidirectional stream of messages between client an server. The
+// jsonrpc2.Connection layers RPC logic on top of that stream, dispatching RPC
+// handlers, and correlating requests with responses from the peer.
+//
+// Some of the complexity of the Connection type is grown out of its usage in
+// gopls: it could probably be simplified based on our usage in MCP.
 type Connection struct {
 	seq int64 // must only be accessed using atomic operations
 

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -394,7 +394,7 @@ func notifySessions[S Session, P Params](sessions []S, method string, params P) 
 	for _, s := range sessions {
 		req := newRequest(s, params)
 		if err := handleNotify(ctx, method, req); err != nil {
-			// TODO(jba): surface this error better
+			// TODO(#218): surface this error better
 			log.Printf("calling %s: %v", method, err)
 		}
 	}
@@ -469,14 +469,22 @@ type RequestExtra struct {
 	TokenInfo *auth.TokenInfo // bearer token info (e.g. from OAuth) if any
 	Header    http.Header     // header from HTTP request, if any
 
-	// CloseStream closes the current request stream, if the current transport
-	// supports replaying requests.
+	// If set, CloseStream explicitly closes the current request stream.
 	//
-	// If reconnectAfter is nonzero, it signals to the client to reconnect after
-	// the given duration. Otherwise, clients may determine their own
-	// reconnection policy.
+	// [SEP-1699] introduced server-side SSE stream disconnection: for
+	// long-running requests, servers may opt to close the SSE stream and
+	// ask the client to retry at a later time. CloseStream implements this
+	// feature; if reconnectAfter is set, an event is sent with a `retry:` field
+	// to configure the reconnection delay.
+	//
+	// [SEP-1699]: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1699
 	CloseStream func(reconnectAfter time.Duration)
 }
+
+// TODO(cleanup): switch to an args struct here for forwards compatibility.
+// type CloseStreamArgs struct {
+// 	After time.Duration
+// }
 
 func (*ClientRequest[P]) isRequest() {}
 func (*ServerRequest[P]) isRequest() {}

--- a/mcp/streamable_client.go
+++ b/mcp/streamable_client.go
@@ -1,0 +1,226 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// TODO: move client-side streamable HTTP logic from streamable.go to this file.
+
+package mcp
+
+/*
+Streamable HTTP Client Design
+
+This document describes the client-side implementation of the MCP streamable
+HTTP transport, as defined by the MCP spec:
+https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http
+
+# Overview
+
+The client-side streamable transport allows an MCP client to communicate with a
+server over HTTP, sending messages via POST and receiving responses via either
+JSON or server-sent events (SSE). The implementation consists of two main
+components:
+
+	┌─────────────────────────────────────────────────────────────────┐
+	│                 [StreamableClientTransport]                     │
+	│   Transport configuration; creates connections via Connect()    │
+	└─────────────────────────────────────────────────────────────────┘
+	                              │
+	                              ▼
+	┌─────────────────────────────────────────────────────────────────┐
+	│                   [streamableClientConn]                        │
+	│   Connection implementation; handles HTTP request/response      │
+	└─────────────────────────────────────────────────────────────────┘
+	                              │
+	                              ├──────────────────────────────────────┐
+	                              ▼                                      ▼
+	┌─────────────────────────────────────────┐  ┌────────────────────────────────────┐
+	│        POST request handlers            │  │      Standalone SSE stream         │
+	│   (one per outgoing message/call)       │  │   (server-initiated messages)      │
+	└─────────────────────────────────────────┘  └────────────────────────────────────┘
+
+# Sessions
+
+The client maintains a session with the server, identified by a session ID
+(Mcp-Session-Id header):
+
+  - Session ID is received from the server after initialization
+  - Client includes the session ID in all subsequent requests
+  - Session ends when the client calls Close() (sends DELETE) or server returns 404
+
+[streamableClientConn] stores the session state:
+  - [streamableClientConn.sessionID]: Server-assigned session identifier
+  - [streamableClientConn.initializedResult]: Protocol version and server capabilities
+
+# Connection Lifecycle
+
+1. Connect: [StreamableClientTransport.Connect] creates a [streamableClientConn]
+   with a detached context for the connection's lifetime. The context is detached
+   to prevent the standalone SSE stream from being cancelled when the original
+   Connect context times out.
+
+2. Initialize: The MCP client sends initialize/initialized messages. Upon
+   receiving [InitializeResult], the connection:
+   - Stores the negotiated protocol version for the Mcp-Protocol-Version header
+   - Captures the session ID from the Mcp-Session-Id response header
+   - Starts the standalone SSE stream via [streamableClientConn.connectStandaloneSSE]
+
+3. Operation: Messages are sent via POST, responses received via JSON or SSE.
+
+4. Close: [streamableClientConn.Close] sends a DELETE request to terminate
+   the session (unless the session is already gone), then cancels the connection
+   context to clean up the standalone SSE stream.
+
+# Sending Messages (Write)
+
+[streamableClientConn.Write] sends all outgoing messages via HTTP POST:
+
+	POST /endpoint
+	Content-Type: application/json
+	Accept: application/json, text/event-stream
+	Mcp-Protocol-Version: <negotiated version>
+	Mcp-Session-Id: <session ID, if established>
+
+	<JSON-RPC message>
+
+The server may respond with:
+  - 202 Accepted: Message received, no response body (notifications/responses)
+  - 200 OK with application/json: Single JSON-RPC response
+  - 200 OK with text/event-stream: SSE stream of responses
+
+# Receiving Messages (Read)
+
+[streamableClientConn.Read] returns messages from the [streamableClientConn.incoming]
+channel, which is populated by multiple concurrent goroutines:
+
+1. POST response handlers ([streamableClientConn.handleJSON] and
+   [streamableClientConn.handleSSE]): Process responses from POST requests
+
+2. Standalone SSE stream: Receives server-initiated requests and notifications
+
+The client handles both response formats:
+  - JSON: [streamableClientConn.handleJSON] reads body, decodes message
+  - SSE: [streamableClientConn.handleSSE] scans events, decodes each message
+
+# Standalone SSE Stream
+
+After initialization, [streamableClientConn.sessionUpdated] triggers
+[streamableClientConn.connectStandaloneSSE] to open a GET request for
+server-initiated messages:
+
+	GET /endpoint
+	Accept: text/event-stream
+	Mcp-Session-Id: <session ID>
+
+Stream behavior:
+  - Optional: Server may return 405 Method Not Allowed (spec-compliant) or
+    other 4xx errors (tolerated in non-strict mode for compatibility)
+  - Persistent: Runs for the connection lifetime in a background goroutine
+  - Resumable: Uses Last-Event-ID header on reconnection if server provides event IDs
+  - Reconnects: Automatic reconnection with exponential backoff on interruption
+
+# Stream Resumption
+
+When an SSE stream (standalone or POST response) is interrupted, the client
+attempts to reconnect using [streamableClientConn.connectSSE]:
+
+Event ID tracking:
+  - [streamableClientConn.processStream] tracks the last received event ID
+  - On reconnection, the Last-Event-ID header is set to resume from that point
+  - Server replays missed events if it has an [EventStore] configured
+
+See [calculateReconnectDelay] for the reconnect delay details.
+
+Server-initiated reconnection (SEP-1699)
+  - SSE retry field: Sets the delay for the next reconnect attempt
+  - If server doesn't provide event IDs, non-standalone streams don't reconnect
+
+# Response Formats
+
+The client must handle two response formats from POST requests:
+
+1. application/json: Single JSON-RPC response
+   - Body contains one JSON-RPC message
+   - Handled by [streamableClientConn.handleJSON]
+   - Simpler but doesn't support streaming or server-initiated messages
+
+2. text/event-stream: SSE stream of messages
+   - Body contains SSE events with JSON-RPC messages
+   - Handled by [streamableClientConn.handleSSE]
+   - Supports multiple messages and server-initiated communication
+   - Stream completes when the response to the originating call is received
+
+# HTTP Methods
+
+  - POST: Send JSON-RPC messages (requests, responses, notifications)
+    - Used by [streamableClientConn.Write]
+    - Response may be JSON or SSE
+
+  - GET: Open or resume SSE stream for server-initiated messages
+    - Used by [streamableClientConn.connectSSE]
+    - Always expects text/event-stream response (or 405)
+
+  - DELETE: Terminate the session
+    - Used by [streamableClientConn.Close]
+    - Skipped if session is already known to be gone ([errSessionMissing])
+
+# Error Handling
+
+Errors are categorized and handled differently:
+
+1. Transient (recoverable via reconnection):
+   - Network interruption during SSE streaming
+   - Connection reset or timeout
+   - Triggers reconnection in [streamableClientConn.handleSSE]
+
+2. Terminal (breaks the connection):
+   - 404 Not Found: Session terminated by server ([errSessionMissing])
+   - Message decode errors: Protocol violation
+   - Context cancellation: Client closed connection
+   - Mismatched session IDs: Protocol error
+	 - See issue #683: our terminal errors are too strict.
+
+Terminal errors are stored via [streamableClientConn.fail] and returned by
+subsequent [streamableClientConn.Read] calls. The [streamableClientConn.failed]
+channel signals that the connection is broken.
+
+Special case: [errSessionMissing] indicates the server has terminated the session,
+so [streamableClientConn.Close] skips the DELETE request.
+
+# Protocol Version Header
+
+After initialization, all requests include:
+
+	Mcp-Protocol-Version: <negotiated version>
+
+This header (set by [streamableClientConn.setMCPHeaders]):
+  - Allows the server to handle requests per the negotiated protocol
+  - Is omitted before initialization completes
+  - Uses the version from [streamableClientConn.initializedResult]
+
+# Key Implementation Details
+
+[StreamableClientTransport] configuration:
+  - [StreamableClientTransport.Endpoint]: URL of the MCP server
+  - [StreamableClientTransport.HTTPClient]: Custom HTTP client (optional)
+  - [StreamableClientTransport.MaxRetries]: Reconnection attempts (default 5)
+
+[streamableClientConn] handles the [Connection] interface:
+  - [streamableClientConn.Read]: Returns messages from incoming channel
+  - [streamableClientConn.Write]: Sends messages via POST, starts response handlers
+  - [streamableClientConn.Close]: Sends DELETE, cancels context, closes done channel
+
+State management:
+  - [streamableClientConn.incoming]: Buffered channel for received messages
+  - [streamableClientConn.sessionID]: Server-assigned session identifier
+  - [streamableClientConn.initializedResult]: Cached for protocol version header
+  - [streamableClientConn.failed]: Channel closed on terminal error
+  - [streamableClientConn.done]: Channel closed on graceful shutdown
+  - [streamableClientConn.ctx]: Detached context for connection lifetime
+  - [streamableClientConn.cancel]: Cancels ctx to terminate SSE streams
+
+Context handling:
+  - Connection context is detached from [StreamableClientTransport.Connect] context
+    using [xcontext.Detach] to preserve context values (for auth middleware) while
+    preventing premature cancellation of the standalone SSE stream
+  - Individual POST requests use caller-provided contexts for cancellation
+*/

--- a/mcp/streamable_server.go
+++ b/mcp/streamable_server.go
@@ -1,0 +1,153 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// TODO: move server-side streamable HTTP logic from streamable.go to this file.
+
+package mcp
+
+/*
+Streamable HTTP Server Design
+
+This document describes the server-side implementation of the MCP streamable
+HTTP transport, as defined by the MCP spec:
+https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http
+
+# Overview
+
+The streamable HTTP transport enables MCP communication over HTTP, with
+server-sent events (SSE) for server-to-client messages. The implementation
+consists of several layered components:
+
+	┌─────────────────────────────────────────────────────────────────┐
+	│                   [StreamableHTTPHandler]                       │
+	│   http.Handler that manages sessions and routes HTTP requests   │
+	└─────────────────────────────────────────────────────────────────┘
+	                              │
+	                              ▼
+	┌─────────────────────────────────────────────────────────────────┐
+	│                  [StreamableServerTransport]                    │
+	│  transport implementation, one per session; exposes ServeHTTP   │
+	└─────────────────────────────────────────────────────────────────┘
+	                              │
+	                              ▼
+	┌─────────────────────────────────────────────────────────────────┐
+	│                   [streamableServerConn]                        │
+	│        Connection implementation, handles message routing       │
+	└─────────────────────────────────────────────────────────────────┘
+	                              │
+	                              ▼
+	┌─────────────────────────────────────────────────────────────────┐
+	│                         [stream]                                │
+	│   Logical message channel within a session, may be resumed      │
+	└─────────────────────────────────────────────────────────────────┘
+
+# Sessions
+
+As with other transports, a session represents a logical MCP connection between
+a client and server. In the streamable transport, sessions are identified by a
+unique session ID (Mcp-Session-Id header) and persist across multiple HTTP
+requests.
+
+[StreamableHTTPHandler] maintains a map of active sessions ([sessionInfo]),
+each containing:
+  - The [ServerSession] (MCP-level session state)
+  - The [StreamableServerTransport] (for message I/O)
+  - Optional timeout management for idle session cleanup
+
+Sessions are created on the first POST request (typically containing the
+initialize request) and destroyed either by:
+  - Client sending a DELETE request
+  - Session timeout due to inactivity
+  - Server explicitly closing the session
+
+# Streams
+
+Within a session, there can be multiple concurrent "streams" - logical channels
+for message delivery. This is distinct from HTTP streams; a single [stream] may
+span multiple HTTP request/response cycles (via resumption).
+
+There are two types of streams:
+
+1. Optional standalone SSE stream (id = ""):
+   - Created when client sends a GET request to the endpoint
+   - Used for server-initiated messages (requests/notifications to client)
+   - Persists for the lifetime of the session
+   - Only one standalone stream per session
+
+2. Request streams (id = random string):
+   - Created for each POST request containing JSON-RPC calls
+   - Used to route responses back to the originating HTTP request
+   - Completed when all responses have been sent
+   - Can be resumed via GET with Last-Event-ID if interrupted
+
+# Message Routing
+
+When the server writes a message, it must be routed to the correct [stream]:
+
+  - Responses: Routed to the stream that originated the request
+  - Requests/Notifications made during request handling: Routed to the same
+    stream as the triggering request (via context)
+  - Requests/Notifications made outside request handling: Routed to the
+    standalone SSE stream
+
+This routing is implemented using:
+  - [streamableServerConn.requestStreams] maps request IDs to stream IDs
+  - [idContextKey] is used to store the originating request ID in Context
+  - [streamableServerConn.streams] maps stream IDs to [stream] objects
+
+# Stream Resumption
+
+If an HTTP connection is interrupted (network issues, etc.), clients can
+resume a stream by sending a GET request with the Last-Event-ID header.
+This requires an [EventStore] to be configured on the server.
+
+  - [EventStore.Open] is called when a new stream is created
+  - [EventStore.Append] is called for each message written to the stream
+  - [EventStore.After] is called to replay messages after a given index
+  - [EventStore.SessionClosed] is called when the session ends
+
+Event IDs are formatted as "<streamID>_<index>" to identify both the
+stream and position within that stream (see [formatEventID] and [parseEventID]).
+
+# Stateless Mode
+
+For simpler deployments, the handler supports "stateless" mode
+([StreamableHTTPOptions.Stateless]) where:
+  - No session ID validation is performed
+  - Each request creates a temporary session that's closed after the request
+  - Server-to-client requests are not supported (no way to receive response)
+
+This mode is useful for simple tool servers that don't need bidirectional
+communication.
+
+# Response Formats
+
+The server can respond to POST requests in two formats:
+
+1. text/event-stream (default): Messages sent as SSE events, supports
+   streaming multiple messages and server-initiated communication during
+   request handling.
+
+2. application/json ([StreamableHTTPOptions.JSONResponse]): Single JSON
+   response, simpler but doesn't support streaming. Server-initiated messages
+   during request handling go to the standalone SSE stream instead.
+
+# HTTP Methods
+
+  - POST: Send JSON-RPC messages (requests, responses, notifications)
+  - GET: Open standalone SSE stream or resume an interrupted stream
+  - DELETE: Terminate the session
+
+# Key Implementation Details
+
+The [stream] struct manages delivery of messages to HTTP responses:
+  - [stream.deliver], if set, writes data to the current HTTP response
+  - [stream.closeLocked] sends a close event with retry delay
+  - [stream.requests] tracks pending request IDs (stream completes when empty)
+
+[streamableServerConn] handles the [Connection] interface:
+  - [streamableServerConn.Read] receives messages from the incoming channel (fed by POST handlers)
+  - [streamableServerConn.Write] routes messages to appropriate streams
+  - [streamableServerConn.Close] terminates the session and notifies the [EventStore]
+*/


### PR DESCRIPTION
Two commits to be rebased:
- add a constant for lastEventID
- add significant documentation

See individual commits for details.