### PR TITLE
mcp: simplify stream state management in streamable transport

### DIFF
--- a/mcp/streamable_server.go
+++ b/mcp/streamable_server.go
@@ -141,10 +141,17 @@ The server can respond to POST requests in two formats:
 
 # Key Implementation Details
 
-The [stream] struct manages delivery of messages to HTTP responses:
-  - [stream.deliver], if set, writes data to the current HTTP response
-  - [stream.closeLocked] sends a close event with retry delay
+The [stream] struct manages delivery of messages to HTTP responses.
+
+Fields:
+  - [stream.w] is the ResponseWriter for the current HTTP response (non-nil indicates claimed)
+  - [stream.done] is closed to release the hanging HTTP request
   - [stream.requests] tracks pending request IDs (stream completes when empty)
+
+Methods:
+  - [stream.deliverLocked] delivers a message to the stream
+  - [stream.close] sends a close event and releases the stream
+  - [stream.release] releases the stream from the HTTP request, allowing resumption
 
 [streamableServerConn] handles the [Connection] interface:
   - [streamableServerConn.Read] receives messages from the incoming channel (fed by POST handlers)


### PR DESCRIPTION
Replace closure-based deliver and closeLocked fields with explicit state:
- pendingJSONMessages: signals JSON mode and collects messages
- w: indicates stream is claimed by HTTP request
- done: signals stream completion (non-nil implies w is non-nil)
- lastIdx, supportsPrimeClose, logger: moved from closures to fields

Add stream methods to consolidate logic:
- close: sends close event and closes done channel
- release: releases stream from HTTP request for resumption
- deliverLocked: writes/stores messages, handles request accounting

Factor out hangResponse to document HTTP response lifecycle.

Inline writeEvent to eliminate confusing pointer-based index management.
