### PR TITLE
mcp: fix stray log.Printf in notifySessions

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -508,7 +508,7 @@ func (s *Server) changeAndNotify(notification string, params Params, change func
 		sessions = slices.Clone(s.sessions)
 	}
 	s.mu.Unlock()
-	notifySessions(sessions, notification, params)
+	notifySessions(sessions, notification, params, s.opts.Logger)
 }
 
 // Sessions returns an iterator that yields the current set of server sessions.
@@ -708,7 +708,7 @@ func (s *Server) ResourceUpdated(ctx context.Context, params *ResourceUpdatedNot
 	subscribedSessions := s.resourceSubscriptions[params.URI]
 	sessions := slices.Collect(maps.Keys(subscribedSessions))
 	s.mu.Unlock()
-	notifySessions(sessions, notificationResourceUpdated, params)
+	notifySessions(sessions, notificationResourceUpdated, params, s.opts.Logger)
 	s.opts.Logger.Info("resource updated notification sent", "uri", params.URI, "subscriber_count", len(sessions))
 	return nil
 }

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -15,7 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"reflect"
 	"slices"
@@ -381,7 +381,8 @@ const (
 
 // notifySessions calls Notify on all the sessions.
 // Should be called on a copy of the peer sessions.
-func notifySessions[S Session, P Params](sessions []S, method string, params P) {
+// The logger must be non-nil.
+func notifySessions[S Session, P Params](sessions []S, method string, params P, logger *slog.Logger) {
 	if sessions == nil {
 		return
 	}
@@ -394,8 +395,7 @@ func notifySessions[S Session, P Params](sessions []S, method string, params P) 
 	for _, s := range sessions {
 		req := newRequest(s, params)
 		if err := handleNotify(ctx, method, req); err != nil {
-			// TODO(#218): surface this error better
-			log.Printf("calling %s: %v", method, err)
+			logger.Warn(fmt.Sprintf("calling %s: %v", method, err))
 		}
 	}
 }

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -1453,7 +1453,7 @@ func (t *StreamableClientTransport) Connect(ctx context.Context) (Connection, er
 		done:       make(chan struct{}),
 		maxRetries: maxRetries,
 		strict:     t.strict,
-		logger:     t.logger,
+		logger:     ensureLogger(t.logger), // must be non-nil for safe logging
 		ctx:        connCtx,
 		cancel:     cancel,
 		failed:     make(chan struct{}),
@@ -1555,9 +1555,7 @@ func (c *streamableClientConn) connectStandaloneSSE() {
 		// stream.
 		//
 		// Treat this like MethodNotAllowed in non-strict mode.
-		if c.logger != nil {
-			c.logger.Warn(fmt.Sprintf("got %d instead of 405 for standalone SSE stream", resp.StatusCode))
-		}
+		c.logger.Warn(fmt.Sprintf("got %d instead of 405 for standalone SSE stream", resp.StatusCode))
 		resp.Body.Close()
 		return
 	}
@@ -1686,9 +1684,7 @@ func (c *streamableClientConn) Write(ctx context.Context, msg jsonrpc.Message) e
 			// Some servers return 200, even with an empty json body.
 			//
 			// In strict mode, return an error to the caller.
-			if c.logger != nil {
-				c.logger.Warn(errMsg)
-			}
+			c.logger.Warn(errMsg)
 			if c.strict {
 				return errors.New(errMsg)
 			}


### PR DESCRIPTION
I encountered these logs, and they were distracting and noisy. We shouldn't log to stderr unless configured by the user. Thread through the logger.

Also, use ensureLogger in the streamable client to simplify call sites.

Updates #708
Updates #684