### PR TITLE
mcp: add Capabilities fields to ServerOptions and ClientOptions

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -4,6 +4,9 @@
 1. [Roots](#roots)
 1. [Sampling](#sampling)
 1. [Elicitation](#elicitation)
+1. [Capabilities](#capabilities)
+	1. [Capability inference](#capability-inference)
+	1. [Explicit capabilities](#explicit-capabilities)
 
 ## Roots
 
@@ -130,7 +133,9 @@ allows servers to request user inputs. It is implemented in the SDK as follows:
 **Client-side**: To add the `elicitation` capability to a client, set
 [`ClientOptions.ElicitationHandler`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp#ClientOptions.ElicitationHandler).
 The elicitation handler must return a result that matches the requested schema;
-otherwise, elicitation returns an error.
+otherwise, elicitation returns an error. If your handler supports [URL mode
+elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-elicitation-requests),
+you must declare that capability explicitly (see [Capabilities](#capabilities))
 
 **Server-side**: To use elicitation from the server, call
 [`ServerSession.Elicit`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp#ServerSession.Elicit).
@@ -171,3 +176,60 @@ func Example_elicitation() {
 	// Output: value
 }
 ```
+
+## Capabilities
+
+Client capabilities are advertised to servers during the initialization
+handshake. [By default](rough_edges.md), the SDK advertises the `logging`
+capability. Additional capabilities are automatically added when server
+features are added (e.g. via `AddTool`), or when handlers are set in the
+`ServerOptions` struct (e.g., setting `CompletionHandler` adds the
+`completions` capability), or may be configured explicitly.
+
+### Capability inference
+
+When handlers are set on `ClientOptions` (e.g., `CreateMessageHandler` or
+`ElicitationHandler`), the corresponding capability is automatically added if
+not already present, with a default configuration.
+
+For elicitation, if the handler is set but no `Capabilities.Elicitation` is
+specified, the client defaults to form elicitation. To enable URL elicitation
+or both modes, [configure `Capabilities.Elicitation`
+explicitly](#explicit-capabilities).
+
+See the [`ClientCapabilities`
+documentation](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp#ClientCapabilities)
+for further details on inference.
+
+### Explicit capabilities
+
+To explicitly declare capabilities, or to override the [default inferred
+capability](#capability-inference), set
+[`ClientOptions.Capabilities`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp#ClientOptions.Capabilities).
+This sets the initial client capabilities, before any capabilities are added
+based on configured handlers. If a capability is already present in
+`Capabilities`, adding a handler will not change its configuration.
+
+This allows you to:
+
+- **Disable default capabilities**: Pass an empty `&ClientCapabilities{}` to
+  disable all defaults, including roots.
+- **Disable listChanged notifications**: Set `ListChanged: false` on a
+  capability to prevent the client from sending list-changed notifications
+  when roots are added or removed.
+- **Configure elicitation modes**: Specify which elicitation modes (form, URL)
+  the client supports.
+
+```go
+// Configure elicitation modes and disable roots.
+client := mcp.NewClient(impl, &mcp.ClientOptions{
+    Capabilities: &mcp.ClientCapabilities{
+        Elicitation: &mcp.ElicitationCapabilities{
+            Form: &mcp.FormElicitationCapabilities{},
+            URL:  &mcp.URLElicitationCapabilities{},
+        },
+    },
+    ElicitationHandler: handler,
+})
+```
+

--- a/docs/rough_edges.md
+++ b/docs/rough_edges.md
@@ -36,3 +36,12 @@ v2.
 
   **Workaround**: use `ClientCapabilities.RootsV2`, which aligns with the
   semantics of other capability fields.
+
+- Default capabilities should have been empty. Instead, servers default to
+  advertising `logging`, and clients default to advertising `roots` with
+  `listChanged: true`. This is confusing because a nil `Capabilities` field
+  does not mean "no capabilities".
+
+  **Workaround**: to advertise no capabilities, set
+  `ServerOptions.Capabilities` or `ClientOptions.Capabilities` to an empty
+  `&ServerCapabilities{}` or `&ClientCapabilities{}` respectively.

--- a/docs/server.md
+++ b/docs/server.md
@@ -7,6 +7,9 @@
 1. [Utilities](#utilities)
 	1. [Completion](#completion)
 	1. [Logging](#logging)
+1. [Capabilities](#capabilities)
+	1. [Capability inference](#capability-inference)
+	1. [Explicit capabilities](#explicit-capabilities)
 	1. [Pagination](#pagination)
 
 ## Prompts
@@ -534,6 +537,53 @@ func Example_logging() {
 	// warn shows up 3
 }
 ```
+
+## Capabilities
+
+Server capabilities are advertised to clients during the initialization
+handshake. By default, the SDK advertises only the `logging` capability.
+Additional capabilities are automatically added when features are registered
+(e.g., adding a tool adds the `tools` capability).
+
+### Capability inference
+
+When features such as tools, prompts, or resources are added to the server
+(e.g., via `Server.AddTool`), their capability is automatically inferred, with
+default value `{listChanged:true}`. Similarly, if the
+`ServerOptions.SubscribeHandler` or `ServerOptions.CompletionHandler` are set,
+the corresponding capability is added.
+
+### Explicit capabilities
+
+To explicitly declare capabilities, or to override the [default inferred
+capability](#capability-inference), set
+[`ServerOptions.Capabilities`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp#ServerOptions.Capabilities).
+This sets the default server capabilities, before any capabilities are added
+based on configured handlers. If a capability is already present as a field in
+`Capabilities`, adding a feature or handler will not change its configuration.
+
+This allows you to:
+
+- **Disable default capabilities**: Pass an empty `&ServerCapabilities{}` to
+  disable all defaults, including logging.
+- **Disable listChanged notifications**: Set `ListChanged: false` on a
+  capability to prevent the server from sending list-changed notifications
+  when features are added or removed.
+- **Pre-declare capabilities**: Declare capabilities before features are
+  registered, useful for servers that load features dynamically.
+
+```go
+// Disable listChanged notifications for tools
+server := mcp.NewServer(impl, &mcp.ServerOptions{
+    Capabilities: &mcp.ServerCapabilities{
+        Logging: &mcp.LoggingCapabilities{},
+        Tools:   &mcp.ToolCapabilities{ListChanged: false},
+    },
+})
+```
+
+**Deprecated**: The `HasPrompts`, `HasResources`, and `HasTools` fields on
+`ServerOptions` are deprecated. Use `Capabilities` instead.
 
 ### Pagination
 

--- a/internal/docs/rough_edges.src.md
+++ b/internal/docs/rough_edges.src.md
@@ -35,3 +35,12 @@ v2.
 
   **Workaround**: use `ClientCapabilities.RootsV2`, which aligns with the
   semantics of other capability fields.
+
+- Default capabilities should have been empty. Instead, servers default to
+  advertising `logging`, and clients default to advertising `roots` with
+  `listChanged: true`. This is confusing because a nil `Capabilities` field
+  does not mean "no capabilities".
+
+  **Workaround**: to advertise no capabilities, set
+  `ServerOptions.Capabilities` or `ClientOptions.Capabilities` to an empty
+  `&ServerCapabilities{}` or `&ClientCapabilities{}` respectively.

--- a/internal/docs/server.src.md
+++ b/internal/docs/server.src.md
@@ -243,6 +243,53 @@ Call [`ClientSession.SetLevel`](https://pkg.go.dev/github.com/modelcontextprotoc
 
 %include ../../mcp/server_example_test.go logging -
 
+## Capabilities
+
+Server capabilities are advertised to clients during the initialization
+handshake. By default, the SDK advertises only the `logging` capability.
+Additional capabilities are automatically added when features are registered
+(e.g., adding a tool adds the `tools` capability).
+
+### Capability inference
+
+When features such as tools, prompts, or resources are added to the server
+(e.g., via `Server.AddTool`), their capability is automatically inferred, with
+default value `{listChanged:true}`. Similarly, if the
+`ServerOptions.SubscribeHandler` or `ServerOptions.CompletionHandler` are set,
+the corresponding capability is added.
+
+### Explicit capabilities
+
+To explicitly declare capabilities, or to override the [default inferred
+capability](#capability-inference), set
+[`ServerOptions.Capabilities`](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk/mcp#ServerOptions.Capabilities).
+This sets the default server capabilities, before any capabilities are added
+based on configured handlers. If a capability is already present as a field in
+`Capabilities`, adding a feature or handler will not change its configuration.
+
+This allows you to:
+
+- **Disable default capabilities**: Pass an empty `&ServerCapabilities{}` to
+  disable all defaults, including logging.
+- **Disable listChanged notifications**: Set `ListChanged: false` on a
+  capability to prevent the server from sending list-changed notifications
+  when features are added or removed.
+- **Pre-declare capabilities**: Declare capabilities before features are
+  registered, useful for servers that load features dynamically.
+
+```go
+// Disable listChanged notifications for tools
+server := mcp.NewServer(impl, &mcp.ServerOptions{
+    Capabilities: &mcp.ServerCapabilities{
+        Logging: &mcp.LoggingCapabilities{},
+        Tools:   &mcp.ToolCapabilities{ListChanged: false},
+    },
+})
+```
+
+**Deprecated**: The `HasPrompts`, `HasResources`, and `HasTools` fields on
+`ServerOptions` are deprecated. Use `Capabilities` instead.
+
 ### Pagination
 
 Server-side feature lists may be

--- a/mcp/capabilities_go125_test.go
+++ b/mcp/capabilities_go125_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.25
+
+package mcp
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// TestServerListChangedNotifications verifies that listChanged notifications
+// are correctly sent or suppressed based on capability configuration.
+func TestServerListChangedNotifications(t *testing.T) {
+	tool := &Tool{Name: "test-tool", InputSchema: &jsonschema.Schema{Type: "object"}}
+
+	testCases := []struct {
+		name            string
+		serverOpts      *ServerOptions
+		wantNotifyCount int64
+	}{
+		{
+			name:            "Default: notification sent",
+			serverOpts:      nil,
+			wantNotifyCount: 1,
+		},
+		{
+			name: "ListChanged false: notification suppressed",
+			serverOpts: &ServerOptions{
+				Capabilities: &ServerCapabilities{
+					Tools: &ToolCapabilities{ListChanged: false},
+				},
+			},
+			wantNotifyCount: 0,
+		},
+		{
+			name: "ListChanged true: notification sent",
+			serverOpts: &ServerOptions{
+				Capabilities: &ServerCapabilities{
+					Tools: &ToolCapabilities{ListChanged: true},
+				},
+			},
+			wantNotifyCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := context.Background()
+
+				// Create server.
+				impl := &Implementation{Name: "testServer", Version: "v1.0.0"}
+				server := NewServer(impl, tc.serverOpts)
+
+				// Track notifications.
+				var notifyCount atomic.Int64
+
+				// Connect client and server.
+				cTransport, sTransport := NewInMemoryTransports()
+				ss, err := server.Connect(ctx, sTransport, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer ss.Close()
+
+				client := NewClient(&Implementation{Name: "testClient", Version: "v1.0.0"}, &ClientOptions{
+					ToolListChangedHandler: func(ctx context.Context, req *ToolListChangedRequest) {
+						notifyCount.Add(1)
+					},
+				})
+				cs, err := client.Connect(ctx, cTransport, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer cs.Close()
+
+				// Add a tool, which may or may not trigger notification.
+				server.AddTool(tool, nil)
+
+				// Sleep an arbitrary time longer than the debounce delay (synctest
+				// makes this practical).
+				time.Sleep(1 * time.Second)
+
+				// Wait for all goroutines to be blocked (notification delivered).
+				synctest.Wait()
+
+				if got, want := notifyCount.Load(), tc.wantNotifyCount; got != want {
+					t.Errorf("notification count: got %d, want %d", got, want)
+				}
+			})
+		})
+	}
+}
+
+// TestClientListChangedNotifications verifies that roots listChanged notifications
+// are correctly sent or suppressed based on client capability configuration.
+func TestClientListChangedNotifications(t *testing.T) {
+	root := &Root{URI: "file:///test"}
+
+	testCases := []struct {
+		name            string
+		clientOpts      *ClientOptions
+		wantNotifyCount int64
+	}{
+		{
+			name:            "Default: notification sent",
+			clientOpts:      nil,
+			wantNotifyCount: 1,
+		},
+		{
+			name: "ListChanged false: notification suppressed",
+			clientOpts: &ClientOptions{
+				Capabilities: &ClientCapabilities{
+					RootsV2: &RootCapabilities{ListChanged: false},
+				},
+			},
+			wantNotifyCount: 0,
+		},
+		{
+			name: "ListChanged true: notification sent",
+			clientOpts: &ClientOptions{
+				Capabilities: &ClientCapabilities{
+					RootsV2: &RootCapabilities{ListChanged: true},
+				},
+			},
+			wantNotifyCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := context.Background()
+
+				// Track notifications.
+				var notifyCount atomic.Int64
+
+				// Create server with roots list changed handler.
+				server := NewServer(&Implementation{Name: "testServer", Version: "v1.0.0"}, &ServerOptions{
+					RootsListChangedHandler: func(ctx context.Context, req *RootsListChangedRequest) {
+						notifyCount.Add(1)
+					},
+				})
+
+				// Connect client and server.
+				cTransport, sTransport := NewInMemoryTransports()
+				ss, err := server.Connect(ctx, sTransport, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer ss.Close()
+
+				client := NewClient(&Implementation{Name: "testClient", Version: "v1.0.0"}, tc.clientOpts)
+				cs, err := client.Connect(ctx, cTransport, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer cs.Close()
+
+				// Add a root, which may or may not trigger notification.
+				client.AddRoots(root)
+
+				// Wait for all goroutines to be blocked (notification delivered).
+				synctest.Wait()
+
+				if got, want := notifyCount.Load(), tc.wantNotifyCount; got != want {
+					t.Errorf("notification count: got %d, want %d", got, want)
+				}
+			})
+		})
+	}
+}

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -196,10 +196,11 @@ func TestClientCapabilities(t *testing.T) {
 		name             string
 		configureClient  func(s *Client)
 		clientOpts       ClientOptions
+		protocolVersion  string // defaults to latestProtocolVersion if empty
 		wantCapabilities *ClientCapabilities
 	}{
 		{
-			name:            "With initial capabilities",
+			name:            "default",
 			configureClient: func(s *Client) {},
 			wantCapabilities: &ClientCapabilities{
 				Roots:   RootCapabilities{ListChanged: true},
@@ -207,7 +208,7 @@ func TestClientCapabilities(t *testing.T) {
 			},
 		},
 		{
-			name:            "With sampling",
+			name:            "with sampling",
 			configureClient: func(s *Client) {},
 			clientOpts: ClientOptions{
 				CreateMessageHandler: func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error) {
@@ -221,14 +222,14 @@ func TestClientCapabilities(t *testing.T) {
 			},
 		},
 		{
-			name:            "With form elicitation",
+			name:            "with elicitation",
 			configureClient: func(s *Client) {},
 			clientOpts: ClientOptions{
-				ElicitationModes: []string{"form"},
 				ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
 					return nil, nil
 				},
 			},
+			protocolVersion: protocolVersion20251125,
 			wantCapabilities: &ClientCapabilities{
 				Roots:   RootCapabilities{ListChanged: true},
 				RootsV2: &RootCapabilities{ListChanged: true},
@@ -238,10 +239,31 @@ func TestClientCapabilities(t *testing.T) {
 			},
 		},
 		{
-			name:            "With URL elicitation",
+			name:            "with elicitation (old protocol)",
 			configureClient: func(s *Client) {},
 			clientOpts: ClientOptions{
-				ElicitationModes: []string{"url"},
+				ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
+					return nil, nil
+				},
+			},
+			protocolVersion: protocolVersion20250618,
+			wantCapabilities: &ClientCapabilities{
+				Roots:       RootCapabilities{ListChanged: true},
+				RootsV2:     &RootCapabilities{ListChanged: true},
+				Elicitation: &ElicitationCapabilities{},
+			},
+		},
+		{
+			name:            "with URL elicitation",
+			configureClient: func(s *Client) {},
+			clientOpts: ClientOptions{
+				Capabilities: &ClientCapabilities{
+					Roots:   RootCapabilities{ListChanged: true},
+					RootsV2: &RootCapabilities{ListChanged: true},
+					Elicitation: &ElicitationCapabilities{
+						URL: &URLElicitationCapabilities{},
+					},
+				},
 				ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
 					return nil, nil
 				},
@@ -255,10 +277,17 @@ func TestClientCapabilities(t *testing.T) {
 			},
 		},
 		{
-			name:            "With both form and URL elicitation",
+			name:            "with form and URL elicitation",
 			configureClient: func(s *Client) {},
 			clientOpts: ClientOptions{
-				ElicitationModes: []string{"form", "url"},
+				Capabilities: &ClientCapabilities{
+					Roots:   RootCapabilities{ListChanged: true},
+					RootsV2: &RootCapabilities{ListChanged: true},
+					Elicitation: &ElicitationCapabilities{
+						Form: &FormElicitationCapabilities{},
+						URL:  &URLElicitationCapabilities{},
+					},
+				},
 				ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
 					return nil, nil
 				},
@@ -272,15 +301,189 @@ func TestClientCapabilities(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:            "no capabilities",
+			configureClient: func(s *Client) {},
+			clientOpts: ClientOptions{
+				Capabilities: &ClientCapabilities{},
+			},
+			wantCapabilities: &ClientCapabilities{},
+		},
+		{
+			name:            "no roots",
+			configureClient: func(s *Client) {},
+			clientOpts: ClientOptions{
+				Capabilities: &ClientCapabilities{
+					Sampling: &SamplingCapabilities{},
+				},
+			},
+			wantCapabilities: &ClientCapabilities{
+				Sampling: &SamplingCapabilities{},
+			},
+		},
+		{
+			name:            "roots-no list",
+			configureClient: func(s *Client) {},
+			clientOpts: ClientOptions{
+				Capabilities: &ClientCapabilities{
+					RootsV2: &RootCapabilities{ListChanged: false},
+				},
+			},
+			wantCapabilities: &ClientCapabilities{
+				RootsV2: &RootCapabilities{ListChanged: false},
+			},
+		},
+		{
+			name:            "custom capabilities with sampling",
+			configureClient: func(s *Client) {},
+			clientOpts: ClientOptions{
+				Capabilities: &ClientCapabilities{
+					RootsV2: &RootCapabilities{ListChanged: true},
+				},
+				CreateMessageHandler: func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error) {
+					return nil, nil
+				},
+			},
+			wantCapabilities: &ClientCapabilities{
+				Roots:    RootCapabilities{ListChanged: true},
+				RootsV2:  &RootCapabilities{ListChanged: true},
+				Sampling: &SamplingCapabilities{},
+			},
+		},
+		{
+			name:            "elicitation override",
+			configureClient: func(s *Client) {},
+			clientOpts: ClientOptions{
+				Capabilities: &ClientCapabilities{
+					Elicitation: &ElicitationCapabilities{
+						URL: &URLElicitationCapabilities{},
+					},
+				},
+				ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
+					return nil, nil
+				},
+			},
+			wantCapabilities: &ClientCapabilities{
+				Elicitation: &ElicitationCapabilities{
+					URL: &URLElicitationCapabilities{},
+				},
+			},
+		},
+		{
+			name:            "custom capabilities with experimental",
+			configureClient: func(s *Client) {},
+			clientOpts: ClientOptions{
+				Capabilities: &ClientCapabilities{
+					Experimental: map[string]any{"custom": "value"},
+					RootsV2:      &RootCapabilities{ListChanged: true},
+				},
+			},
+			wantCapabilities: &ClientCapabilities{
+				Experimental: map[string]any{"custom": "value"},
+				Roots:        RootCapabilities{ListChanged: true},
+				RootsV2:      &RootCapabilities{ListChanged: true},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := NewClient(testImpl, &tc.clientOpts)
 			tc.configureClient(client)
-			gotCapabilities := client.capabilities()
+			protocolVersion := tc.protocolVersion
+			if protocolVersion == "" {
+				protocolVersion = latestProtocolVersion
+			}
+			gotCapabilities := client.capabilities(protocolVersion)
 			if diff := cmp.Diff(tc.wantCapabilities, gotCapabilities); diff != "" {
 				t.Errorf("capabilities() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClientCapabilitiesOverWire(t *testing.T) {
+	testCases := []struct {
+		name             string
+		clientOpts       *ClientOptions
+		wantCapabilities *ClientCapabilities
+	}{
+		{
+			name:       "Default capabilities",
+			clientOpts: nil,
+			wantCapabilities: &ClientCapabilities{
+				Roots:   RootCapabilities{ListChanged: true},
+				RootsV2: &RootCapabilities{ListChanged: true},
+			},
+		},
+		{
+			name: "Custom Capabilities with roots listChanged false",
+			clientOpts: &ClientOptions{
+				Capabilities: &ClientCapabilities{
+					RootsV2: &RootCapabilities{ListChanged: false},
+				},
+			},
+			wantCapabilities: &ClientCapabilities{
+				Roots:   RootCapabilities{ListChanged: false},
+				RootsV2: &RootCapabilities{ListChanged: false},
+			},
+		},
+		{
+			name: "Dynamic sampling capability",
+			clientOpts: &ClientOptions{
+				Capabilities: &ClientCapabilities{
+					RootsV2: &RootCapabilities{ListChanged: true},
+				},
+				CreateMessageHandler: func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error) {
+					return nil, nil
+				},
+			},
+			wantCapabilities: &ClientCapabilities{
+				Roots:    RootCapabilities{ListChanged: true},
+				RootsV2:  &RootCapabilities{ListChanged: true},
+				Sampling: &SamplingCapabilities{},
+			},
+		},
+		{
+			name: "Empty capabilities disables defaults",
+			clientOpts: &ClientOptions{
+				Capabilities: &ClientCapabilities{},
+			},
+			wantCapabilities: &ClientCapabilities{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Create client.
+			impl := &Implementation{Name: "testClient", Version: "v1.0.0"}
+			client := NewClient(impl, tc.clientOpts)
+
+			// Connect client and server.
+			cTransport, sTransport := NewInMemoryTransports()
+			server := NewServer(&Implementation{Name: "testServer", Version: "v1.0.0"}, nil)
+			ss, err := server.Connect(ctx, sTransport, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ss.Close()
+
+			cs, err := client.Connect(ctx, cTransport, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cs.Close()
+
+			// Check that the server received the expected capabilities.
+			initParams := ss.InitializeParams()
+			if initParams == nil {
+				t.Fatal("InitializeParams is nil")
+			}
+
+			if diff := cmp.Diff(tc.wantCapabilities, initParams.Capabilities); diff != "" {
+				t.Errorf("Capabilities mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/mcp/elicitation_test.go
+++ b/mcp/elicitation_test.go
@@ -105,7 +105,13 @@ func TestElicitationURLMode(t *testing.T) {
 			defer ss.Close()
 
 			c := NewClient(testImpl, &ClientOptions{
-				ElicitationModes:   []string{"url"},
+				Capabilities: &ClientCapabilities{
+					Roots:   RootCapabilities{ListChanged: true},
+					RootsV2: &RootCapabilities{ListChanged: true},
+					Elicitation: &ElicitationCapabilities{
+						URL: &URLElicitationCapabilities{},
+					},
+				},
 				ElicitationHandler: tc.handler,
 			})
 			cs, err := c.Connect(ctx, ct, nil)
@@ -143,7 +149,13 @@ func TestElicitationCompleteNotification(t *testing.T) {
 	var elicitationCompleteCh = make(chan *ElicitationCompleteParams, 1)
 
 	c := NewClient(testImpl, &ClientOptions{
-		ElicitationModes: []string{"url"},
+		Capabilities: &ClientCapabilities{
+			Roots:   RootCapabilities{ListChanged: true},
+			RootsV2: &RootCapabilities{ListChanged: true},
+			Elicitation: &ElicitationCapabilities{
+				URL: &URLElicitationCapabilities{},
+			},
+		},
 		ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
 			return &ElicitResult{Action: "accept"}, nil
 		},

--- a/mcp/error_test.go
+++ b/mcp/error_test.go
@@ -213,7 +213,13 @@ func TestURLElicitationRequired(t *testing.T) {
 
 		// Create client with elicitation handler and middleware.
 		client := NewClient(testImpl, &ClientOptions{
-			ElicitationModes: []string{"url"},
+			Capabilities: &ClientCapabilities{
+				Roots:   RootCapabilities{ListChanged: true},
+				RootsV2: &RootCapabilities{ListChanged: true},
+				Elicitation: &ElicitationCapabilities{
+					URL: &URLElicitationCapabilities{},
+				},
+			},
 			ElicitationHandler: func(ctx context.Context, req *ElicitRequest) (*ElicitResult, error) {
 				elicitCalled = true
 				elicitURL = req.Params.URL


### PR DESCRIPTION
This allows users to configure default capabilities, disable defaults,
or suppress listChanged notifications by setting ListChanged: false.

Key changes:
- Add ServerOptions.Capabilities and ClientOptions.Capabilities fields.
- Merge user-provided capabilities with dynamically-added ones (tools,
  prompts, resources, sampling, elicitation).
- Check ListChanged before sending list-changed notifications.
- Sync Roots from RootsV2 for backward compatibility (https://github.com/modelcontextprotocol/go-sdk/issues/607).
- Deprecate HasPrompts, HasResources, HasTools on ServerOptions.
- Remove unreleased ElicitationModes field from ClientOptions.
- Add clone methods to capability structs using shallowClone helper.
- Add synctest-based tests for notification behavior (go1.25).
- Add TestClientCapabilitiesOverWire and TestServerCapabilitiesOverWire
- Document the new Capabilities API in docs/

Fixes https://github.com/modelcontextprotocol/go-sdk/issues/706