### PR TITLE
mcp: export ErrSessionMissing for session termination detection

### DIFF
--- a/mcp/streamable_client.go
+++ b/mcp/streamable_client.go
@@ -161,7 +161,7 @@ The client must handle two response formats from POST requests:
 
   - DELETE: Terminate the session
     - Used by [streamableClientConn.Close]
-    - Skipped if session is already known to be gone ([errSessionMissing])
+    - Skipped if session is already known to be gone ([ErrSessionMissing])
 
 # Error Handling
 
@@ -173,7 +173,7 @@ Errors are categorized and handled differently:
    - Triggers reconnection in [streamableClientConn.handleSSE]
 
 2. Terminal (breaks the connection):
-   - 404 Not Found: Session terminated by server ([errSessionMissing])
+   - 404 Not Found: Session terminated by server ([ErrSessionMissing])
    - Message decode errors: Protocol violation
    - Context cancellation: Client closed connection
    - Mismatched session IDs: Protocol error
@@ -183,7 +183,7 @@ Terminal errors are stored via [streamableClientConn.fail] and returned by
 subsequent [streamableClientConn.Read] calls. The [streamableClientConn.failed]
 channel signals that the connection is broken.
 
-Special case: [errSessionMissing] indicates the server has terminated the session,
+Special case: [ErrSessionMissing] indicates the server has terminated the session,
 so [streamableClientConn.Close] skips the DELETE request.
 
 # Protocol Version Header

--- a/mcp/streamable_client_test.go
+++ b/mcp/streamable_client_test.go
@@ -6,6 +6,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -233,6 +234,9 @@ func TestStreamableClientRedundantDelete(t *testing.T) {
 	_, err = session.ListTools(ctx, nil)
 	if err == nil {
 		t.Errorf("Listing tools: got nil error, want non-nil")
+	}
+	if !errors.Is(err, ErrSessionMissing) {
+		t.Errorf("Listing tools: got %v, want error wrapping ErrSessionMissing", err)
 	}
 	_ = session.Wait() // must not hang
 	if missing := fake.missingRequests(); len(missing) > 0 {


### PR DESCRIPTION
Export ErrSessionMissing as a sentinel error that clients can use to detect when a server has terminated or lost their session.

This allows users to implement session recovery logic, creating a new ClientSession when needed.

Updates #715
