### PR TITLE
oauthex: fix content type check in getJSON

### DIFF
--- a/oauthex/oauth2.go
+++ b/oauthex/oauth2.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"strings"
@@ -57,7 +58,9 @@ func getJSON[T any](ctx context.Context, c *http.Client, url string, limit int64
 		return nil, fmt.Errorf("bad status %s", res.Status)
 	}
 	// Specs require application/json.
-	if ct := res.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+	ct := res.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(ct)
+	if err != nil || mediaType != "application/json" {
 		return nil, fmt.Errorf("bad content type %q", ct)
 	}
 


### PR DESCRIPTION
The content type header contains full mimetype string which might contain parameters. The getJSON function doesn't account for this and so some responses fail to parse although they are perfectly acceptable. For example 
```
curl -vv 'https://github.com/.well-known/oauth-authorization-server/login/oauth'
```
returns a content type header with the value
```
content-type: application/json; charset=utf-8
```
which is perfectly valid but fails in the current logic.