### PR TITLE
mcp: add DisableListening option to StreamableClientTransport

### DIFF
--- a/mcp/streamable_client_test.go
+++ b/mcp/streamable_client_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
@@ -694,23 +695,23 @@ func TestStreamableClientTransientErrors(t *testing.T) {
 	}
 }
 
-func TestStreamableClientDisableListening(t *testing.T) {
+func TestStreamableClientDisableStandaloneSSE(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name             string
-		disableListening bool
-		expectGETRequest bool
+		name                 string
+		disableStandaloneSSE bool
+		expectGETRequest     bool
 	}{
 		{
-			name:             "default behavior (listening enabled)",
-			disableListening: false,
-			expectGETRequest: true,
+			name:                 "default behavior (standalone SSE enabled)",
+			disableStandaloneSSE: false,
+			expectGETRequest:     true,
 		},
 		{
-			name:             "listening disabled",
-			disableListening: true,
-			expectGETRequest: false,
+			name:                 "standalone SSE disabled",
+			disableStandaloneSSE: true,
+			expectGETRequest:     false,
 		},
 	}
 
@@ -749,8 +750,8 @@ func TestStreamableClientDisableListening(t *testing.T) {
 			defer httpServer.Close()
 
 			transport := &StreamableClientTransport{
-				Endpoint:         httpServer.URL,
-				DisableListening: test.disableListening,
+				Endpoint:             httpServer.URL,
+				DisableStandaloneSSE: test.disableStandaloneSSE,
 			}
 			client := NewClient(testImpl, nil)
 			session, err := client.Connect(ctx, transport, nil)
@@ -767,8 +768,8 @@ func TestStreamableClientDisableListening(t *testing.T) {
 				t.Fatalf("Expected *streamableClientConn, got %T", session.mcpConn)
 			}
 
-			if got, want := streamableConn.disableListening, test.disableListening; got != want {
-				t.Errorf("disableListening field: got %v, want %v", got, want)
+			if got, want := streamableConn.disableStandaloneSSE, test.disableStandaloneSSE; got != want {
+				t.Errorf("disableStandaloneSSE field: got %v, want %v", got, want)
 			}
 
 			// Clean up
@@ -805,7 +806,7 @@ func TestStreamableClientDisableListening(t *testing.T) {
 			} else {
 				// If we didn't expect a GET request, verify it wasn't sent
 				if getRequestReceived {
-					t.Error("GET request was sent unexpectedly when DisableListening is true")
+					t.Error("GET request was sent unexpectedly when DisableStandaloneSSE is true")
 				}
 			}
 		})


### PR DESCRIPTION
mcp: add DisableListening option to control standalone SSE stream

Currently, StreamableClientTransport always establishes a standalone SSE connection after initialization to receive server-initiated messages. While this is useful for receiving notifications like ToolListChangedNotification, it causes problems in several real-world scenarios:

1. **Unnecessary resource usage**: Many use cases (for me), especially in scientific computing scenarios, only require simple request-response communication. Clients don't need server-initiated notifications, making the persistent SSE connection wasteful.

2. **Server compatibility issues**: Some third-party MCP servers don't properly handle GET requests for SSE streams. When the client automatically tries to establish the SSE connection, it fails or hangs, blocking the entire connection process. This is particularly problematic when using third-party servers that cannot be modified. This issue is similar to what was discussed in issue #634.

3. **Lack of user control**: The MCP specification states that the standalone SSE stream is optional ("The client MAY issue an HTTP GET"), but the current SDK implementation doesn't provide a way to opt out. This implementation is also inconsistent with other MCP SDKs like github.com/mark3labs/mcp-go, which provides getListeningEnabled control (defaults to false, requires explicit enablement).

This change adds a DisableListening boolean field to StreamableClientTransport that allows users to control whether the client establishes the standalone SSE stream. The default value is false, maintaining backward compatibility with current behavior. When set to true, the client skips establishing the standalone SSE connection.

The implementation includes DisableListening bool field in StreamableClientTransport, WithDisableListening() convenience function, conditional logic in sessionUpdated() to respect the option, and comprehensive tests in TestStreamableClientDisableListening.

Fixes #728
