### PR TITLE
go.mod: upgrade to jsonschema v0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/go-cmp v0.7.0
-	github.com/google/jsonschema-go v0.3.0
+	github.com/google/jsonschema-go v0.4.2
 	github.com/yosida95/uritemplate/v3 v3.0.2
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/tools v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeD
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
-github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -812,10 +812,34 @@ func TestToolForSchemas(t *testing.T) {
 
 	var (
 		falseSchema = &schema{Not: &schema{}}
-		inSchema    = &schema{Type: "object", AdditionalProperties: falseSchema, Properties: map[string]*schema{"p": {Type: "integer"}}}
-		inSchema2   = &schema{Type: "object", AdditionalProperties: falseSchema, Properties: map[string]*schema{"p": {Type: "string"}}}
-		outSchema   = &schema{Type: "object", AdditionalProperties: falseSchema, Properties: map[string]*schema{"b": {Type: "boolean"}}}
-		outSchema2  = &schema{Type: "object", AdditionalProperties: falseSchema, Properties: map[string]*schema{"b": {Type: "integer"}}}
+		inSchema    = &schema{
+			Type:                 "object",
+			AdditionalProperties: falseSchema,
+			Properties:           map[string]*schema{"p": {Type: "integer"}},
+			PropertyOrder:        []string{"p"},
+		}
+		inSchema2 = &schema{
+			Type:                 "object",
+			AdditionalProperties: falseSchema,
+			Properties:           map[string]*schema{"p": {Type: "string"}},
+		}
+		inSchema3 = &schema{
+			Type:                 "object",
+			AdditionalProperties: falseSchema,
+			Properties:           map[string]*schema{}, // empty map is preserved
+		}
+		outSchema = &schema{
+			Type:                 "object",
+			AdditionalProperties: falseSchema,
+			Properties:           map[string]*schema{"b": {Type: "boolean"}},
+			PropertyOrder:        []string{"b"},
+		}
+		outSchema2 = &schema{
+			Type:                 "object",
+			AdditionalProperties: falseSchema,
+			Properties:           map[string]*schema{"b": {Type: "integer"}},
+			PropertyOrder:        []string{"b"},
+		}
 	)
 
 	// Infer both schemas.
@@ -829,6 +853,8 @@ func TestToolForSchemas(t *testing.T) {
 	testToolForSchema[in, any](t, &Tool{}, `{"p":"x"}`, 0, inSchema, nil, `want "integer"`)
 	// Tool sets input schema: that is what's used.
 	testToolForSchema[in, any](t, &Tool{InputSchema: inSchema2}, `{"p":3}`, 0, inSchema2, nil, `want "string"`)
+	// Tool sets input schema, empty properties map.
+	testToolForSchema[in, any](t, &Tool{InputSchema: inSchema3}, `{}`, 0, inSchema3, nil, "")
 	// Tool sets output schema: that is what's used, and validation happens.
 	testToolForSchema[in, any](t, &Tool{OutputSchema: outSchema2}, `{"p":3}`, out{true},
 		inSchema, outSchema2, `want "integer"`)
@@ -850,6 +876,7 @@ func TestToolForSchemas(t *testing.T) {
 				"AsOf":    {Type: "string"},
 				"Source":  {Type: "string"},
 			},
+			PropertyOrder: []string{"Summary", "AsOf", "Source"},
 		},
 		"")
 }

--- a/mcp/testdata/conformance/server/spec-sep-973-additional-metadata.txtar
+++ b/mcp/testdata/conformance/server/spec-sep-973-additional-metadata.txtar
@@ -92,15 +92,15 @@ infoWithIcon
 				"description": "return resourceLink content with Icon",
 				"inputSchema": {
 					"type": "object",
-					"required": [
-						"In"
-					],
 					"properties": {
 						"In": {
 							"type": "string",
 							"description": "the input"
 						}
 					},
+					"required": [
+						"In"
+					],
 					"additionalProperties": false
 				},
 				"name": "contentTool",
@@ -110,14 +110,14 @@ infoWithIcon
 				"description": "say hi",
 				"inputSchema": {
 					"type": "object",
-					"required": [
-						"Name"
-					],
 					"properties": {
 						"Name": {
 							"type": "string"
 						}
 					},
+					"required": [
+						"Name"
+					],
 					"additionalProperties": false
 				},
 				"name": "greetWithIcon",

--- a/mcp/testdata/conformance/server/tools.txtar
+++ b/mcp/testdata/conformance/server/tools.txtar
@@ -69,14 +69,14 @@ inc
 				"description": "say hi",
 				"inputSchema": {
 					"type": "object",
-					"required": [
-						"Name"
-					],
 					"properties": {
 						"Name": {
 							"type": "string"
 						}
 					},
+					"required": [
+						"Name"
+					],
 					"additionalProperties": false
 				},
 				"name": "greet"
@@ -95,70 +95,70 @@ inc
 				"name": "inc",
 				"outputSchema": {
 					"type": "object",
-					"required": [
-						"y"
-					],
 					"properties": {
 						"y": {
 							"type": "integer"
 						}
 					},
+					"required": [
+						"y"
+					],
 					"additionalProperties": false
 				}
 			},
 			{
 				"inputSchema": {
 					"type": "object",
-					"required": [
-						"In"
-					],
 					"properties": {
 						"In": {
 							"type": "string",
 							"description": "the input"
 						}
 					},
+					"required": [
+						"In"
+					],
 					"additionalProperties": false
 				},
 				"name": "structured",
 				"outputSchema": {
 					"type": "object",
-					"required": [
-						"Out"
-					],
 					"properties": {
 						"Out": {
 							"type": "string",
 							"description": "the output"
 						}
 					},
+					"required": [
+						"Out"
+					],
 					"additionalProperties": false
 				}
 			},
 			{
 				"inputSchema": {
 					"type": "object",
-					"required": [
-						"Now"
-					],
 					"properties": {
 						"Now": {
 							"type": "string"
 						}
 					},
+					"required": [
+						"Now"
+					],
 					"additionalProperties": false
 				},
 				"name": "tomorrow",
 				"outputSchema": {
 					"type": "object",
-					"required": [
-						"Tomorrow"
-					],
 					"properties": {
 						"Tomorrow": {
 							"type": "string"
 						}
 					},
+					"required": [
+						"Tomorrow"
+					],
 					"additionalProperties": false
 				}
 			}


### PR DESCRIPTION
DO NOT SUBMIT

Visible changes:

- Inference on structs populates PropertyOrder

- An empty map for Schema.Properties marshals as "{}"
