### PR TITLE
mcp: switch icon theme to named string type

### DIFF
--- a/examples/server/everything/main.go
+++ b/examples/server/everything/main.go
@@ -291,6 +291,6 @@ func mcpIcons() []mcp.Icon {
 		Source:   "data:image/png;base64," + base64.StdEncoding.EncodeToString(mcpIconData),
 		MIMEType: "image/png",
 		Sizes:    []string{"48x48"},
-		Theme:    "light", // or "dark" or empty
+		Theme:    mcp.IconThemeLight,
 	}}
 }

--- a/mcp/conformance_test.go
+++ b/mcp/conformance_test.go
@@ -152,7 +152,7 @@ var iconObj = Icon{
 	Source:   "foobar",
 	MIMEType: "image/png",
 	Sizes:    []string{"48x48", "96x96"},
-	Theme:    "light",
+	Theme:    IconThemeLight,
 }
 
 // runServerTest runs the server conformance test.

--- a/mcp/content_test.go
+++ b/mcp/content_test.go
@@ -121,7 +121,7 @@ func TestContent(t *testing.T) {
 				Description: "This resource demonstrates all fields",
 				MIMEType:    "text/plain",
 				Meta:        mcp.Meta{"custom": "metadata"},
-				Icons:       []mcp.Icon{{Source: "foobar", MIMEType: "image/png", Sizes: []string{"48x48"}, Theme: "light"}},
+				Icons:       []mcp.Icon{{Source: "foobar", MIMEType: "image/png", Sizes: []string{"48x48"}, Theme: mcp.IconThemeLight}},
 			},
 			`{"type":"resource_link","mimeType":"text/plain","uri":"https://example.com/resource","name":"Example Resource","title":"A comprehensive example resource","description":"This resource demonstrates all fields","_meta":{"custom":"metadata"},"icons":[{"src":"foobar","mimeType":"image/png","sizes":["48x48"],"theme":"light"}]}`,
 		},
@@ -217,7 +217,7 @@ func TestContentUnmarshal(t *testing.T) {
 				// Meta:        mcp.Meta{"custom": "metadata"},
 				Size:        &valInt64,
 				Annotations: &mcp.Annotations{Audience: []mcp.Role{"user", "assistant"}, LastModified: "2025-01-12T15:00:58Z", Priority: 0.5},
-				Icons:       []mcp.Icon{{Source: "foobar", MIMEType: "image/png", Sizes: []string{"48x48"}, Theme: "light"}},
+				Icons:       []mcp.Icon{{Source: "foobar", MIMEType: "image/png", Sizes: []string{"48x48"}, Theme: mcp.IconThemeLight}},
 			},
 		},
 	}

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -750,6 +750,16 @@ type ProgressNotificationParams struct {
 
 func (*ProgressNotificationParams) isParams() {}
 
+// IconTheme specifies the theme an icon is designed for.
+type IconTheme string
+
+const (
+	// IconThemeLight indicates the icon is designed for a light background.
+	IconThemeLight IconTheme = "light"
+	// IconThemeDark indicates the icon is designed for a dark background.
+	IconThemeDark IconTheme = "dark"
+)
+
 // Icon provides visual identifiers for their resources, tools, prompts, and implementations
 // See [/specification/draft/basic/index#icons] for notes on icons
 //
@@ -763,8 +773,9 @@ type Icon struct {
 	MIMEType string `json:"mimeType,omitempty"`
 	// Optional size specification (e.g., ["48x48"], ["any"] for scalable formats like SVG, or ["48x48", "96x96"] for multiple sizes)
 	Sizes []string `json:"sizes,omitempty"`
-	// Optional Theme of the icon, e.g., "light" or "dark"
-	Theme string `json:"theme,omitempty"`
+	// Optional theme specifier. "light" indicates the icon is designed for a light
+	// background, "dark" indicates the icon is designed for a dark background.
+	Theme IconTheme `json:"theme,omitempty"`
 }
 
 // A prompt or prompt template that the server offers.


### PR DESCRIPTION
To be consistent with logging level, use a named string type for icon themes. This improves readability / discoverability, and is more consistent.

Updates #552
For #725