### PR TITLE
mcp: add ClientOptions.Logger

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -48,13 +48,16 @@ func NewClient(impl *Implementation, opts *ClientOptions) *Client {
 	}
 	c := &Client{
 		impl:                    impl,
-		logger:                  ensureLogger(nil), // ensure we have a logger
+		logger:                  ensureLogger(nil), // overwritten below if opts.Logger is set
 		roots:                   newFeatureSet(func(r *Root) string { return r.URI }),
 		sendingMethodHandler_:   defaultSendingMethodHandler,
 		receivingMethodHandler_: defaultReceivingMethodHandler[*ClientSession],
 	}
 	if opts != nil {
 		c.opts = *opts
+		if opts.Logger != nil {
+			c.logger = opts.Logger
+		}
 	}
 	return c
 }
@@ -127,6 +130,8 @@ type ClientOptions struct {
 	// If the peer fails to respond to pings originating from the keepalive check,
 	// the session is automatically closed.
 	KeepAlive time.Duration
+	// If non-nil, log client activity.
+	Logger *slog.Logger
 }
 
 // bind implements the binder[*ClientSession] interface, so that Clients can

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -7,6 +7,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -487,4 +488,33 @@ func TestClientCapabilitiesOverWire(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClientOptionsLogger(t *testing.T) {
+	t.Run("nil logger uses default", func(t *testing.T) {
+		c := NewClient(&Implementation{Name: "test", Version: "1.0"}, nil)
+		if c.logger == nil {
+			t.Error("expected non-nil logger when no options provided")
+		}
+	})
+
+	t.Run("provided logger is used", func(t *testing.T) {
+		// Create a custom logger
+		customLogger := slog.New(slog.NewTextHandler(nil, nil))
+		c := NewClient(&Implementation{Name: "test", Version: "1.0"}, &ClientOptions{
+			Logger: customLogger,
+		})
+		if c.logger != customLogger {
+			t.Error("expected client to use the provided logger")
+		}
+	})
+
+	t.Run("nil logger in options uses default", func(t *testing.T) {
+		c := NewClient(&Implementation{Name: "test", Version: "1.0"}, &ClientOptions{
+			Logger: nil,
+		})
+		if c.logger == nil {
+			t.Error("expected non-nil logger when Logger option is nil")
+		}
+	})
 }


### PR DESCRIPTION
Add a Logger field to ClientOptions, for symmetry with ServerOptions.Logger.

The client's internal logger is now configurable, allowing users to provide
their own slog.Logger for client activity logging.

Fixes #708