### PR TITLE
mcp: change CompleteParams.Context from pointer to value type

### DIFF
--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -329,7 +329,7 @@ type CompleteParams struct {
 	Meta `json:"_meta,omitempty"`
 	// The argument's information
 	Argument CompleteParamsArgument `json:"argument"`
-	Context  *CompleteContext       `json:"context,omitempty"`
+	Context  CompleteContext       `json:"context"`
 	Ref      *CompleteReference     `json:"ref"`
 }
 


### PR DESCRIPTION
mcp: change CompleteParams.Context from pointer to value type

The `CompleteContext` struct contains only a single field (`Arguments map[string]string`)
which already handles the nil/empty case gracefully. Making `Context` a pointer type
forces all consumers to perform nil checks before accessing `Arguments`, which is
error-prone and has caused nil pointer panics in production (see github/github-mcp-server#1754).

With a value type, consumers can safely access `req.Params.Context.Arguments` directly:
- If the client omits the field, `Arguments` will be `nil` (safe to range over, check length, etc.)
- If the client sends an empty object, `Arguments` will be an empty map

This follows the Go idiom of preferring value types for simple structs where
the zero value is useful, similar to how `time.Time` is typically used as a value.

**Before (requires nil check):**
```go
var resolved map[string]string
if req.Params.Context != nil {
    resolved = req.Params.Context.Arguments
}
```

**After (safe direct access):**
```go
resolved := req.Params.Context.Arguments
```
