### PR TITLE
.github/workflows: add nightly conformance tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,3 +18,19 @@ jobs:
       with:
            go-version-file: go.mod
            go-package: ./...
+
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - name: Set up Go
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      with:
+        go-version: "^1.25"
+    - name: Set up Node.js
+      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      with:
+        node-version: "20"
+    - name: Run conformance tests
+      run: ./scripts/conformance.sh


### PR DESCRIPTION
Add a conformance test job to the nightly GitHub workflow that runs the SDK conformance tests using ./scripts/conformance.sh.

The job:
- Runs on ubuntu-latest
- Sets up Go 1.25
- Sets up Node.js 20 (required for npx)
- Executes the conformance test script

This ensures the SDK is regularly tested against the official MCP conformance test suite to catch regressions early.