### PR TITLE
mcp: update JSON marshaling to not HTML-escape messages

### DIFF
--- a/copyright_test.go
+++ b/copyright_test.go
@@ -17,8 +17,7 @@ import (
 
 func TestCopyrightHeaders(t *testing.T) {
 	var re = regexp.MustCompile(`Copyright \d{4} The Go MCP SDK Authors. All rights reserved.
-Use of this source code is governed by an MIT-style
-license that can be found in the LICENSE file.`)
+Use of this source code is governed by (the license\n|an MIT-style\nlicense )that can be found in the LICENSE file.`)
 
 	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/internal/mcpgodebug/mcpgodebug.go
+++ b/internal/mcpgodebug/mcpgodebug.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+// Package mcpgodebug provides a mechanism to configure compatibility parameters
+// via the MCPGODEBUG environment variable.
+//
+// The value of MCPGODEBUG is a comma-separated list of key=value pairs.
+// For example:
+//
+//	MCPGODEBUG=someoption=1,otheroption=value
+package mcpgodebug
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const compatibilityEnvKey = "MCPGODEBUG"
+
+var compatibilityParams map[string]string
+
+func init() {
+	var err error
+	compatibilityParams, err = parseCompatibility(os.Getenv(compatibilityEnvKey))
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Value returns the value of the compatibility parameter with the given key.
+// It returns an empty string if the key is not set.
+func Value(key string) string {
+	return compatibilityParams[key]
+}
+
+func parseCompatibility(envValue string) (map[string]string, error) {
+	if envValue == "" {
+		return nil, nil
+	}
+
+	params := make(map[string]string)
+	for part := range strings.SplitSeq(envValue, ",") {
+		k, v, ok := strings.Cut(part, "=")
+		if !ok {
+			return nil, fmt.Errorf("MCPGODEBUG: invalid format: %q", part)
+		}
+		params[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return params, nil
+}

--- a/internal/mcpgodebug/mcpgodebug_test.go
+++ b/internal/mcpgodebug/mcpgodebug_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package mcpgodebug
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseCompatibility_Success(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+		want   map[string]string
+	}{
+		{
+			name:   "Basic",
+			envVal: "foo=bar,baz=qux",
+			want: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+		},
+		{
+			name:   "Empty",
+			envVal: "",
+			want:   nil,
+		},
+		{
+			name:   "WithWhitespace",
+			envVal: "  foo = bar  \t,  baz  = qux  ",
+			want: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+		},
+		{
+			name:   "WithEqualsSignInValue",
+			envVal: "foo=bar=baz",
+			want: map[string]string{
+				"foo": "bar=baz",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCompatibility(tt.envVal)
+			if err != nil {
+				t.Fatalf("parseCompatibility() failed: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("parseCompatibility() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParseCompatibility_Failure(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVal string
+	}{
+		{
+			name:   "NoEqualsSign",
+			envVal: "invalidformat",
+		},
+		{
+			name:   "MixedValidAndInvalid",
+			envVal: "foo=bar,baz",
+		},
+		{
+			name:   "EmptyPart",
+			envVal: "foo=bar,,baz=qux",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseCompatibility(tt.envVal)
+			if err == nil {
+				t.Error("parseCompatibility() expected error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
It's causing some servers to fail: #767. I checked with Typescript implementation and it doesn't do any escaping.

It's still a behavior change.

Fixes #238 
Fixes #767
