### PR TITLE
fix: add JSON tags to ElicitationCapabilities fields

### DIFF
--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -988,8 +988,8 @@ type SamplingCapabilities struct{}
 //
 // If neither Form nor URL is set, the 'Form' capabilitiy is assumed.
 type ElicitationCapabilities struct {
-	Form *FormElicitationCapabilities
-	URL  *URLElicitationCapabilities
+	Form *FormElicitationCapabilities `json:"form,omitempty"`
+	URL  *URLElicitationCapabilities  `json:"url,omitempty"`
 }
 
 // FormElicitationCapabilities describes capabilities for form elicitation.


### PR DESCRIPTION
## Summary

The `Form` and `URL` fields in `ElicitationCapabilities` were missing JSON struct tags, causing them to serialize as `"Form"` and `"URL"` (capitalized) instead of the lowercase `"form"` and `"url"` required by the MCP protocol.

## Problem

During client initialization, when advertising elicitation capabilities, the JSON payload would contain:

```json
{"elicitation": {"Form": {}, "URL": {}}}
```

Instead of the correct:

```json
{"elicitation": {"form": {}, "url": {}}}
```

This caused servers to not recognize the elicitation capabilities, leading to initialization failures or unexpected behavior.

## Fix

Added `json:"form,omitempty"` and `json:"url,omitempty"` struct tags to the `ElicitationCapabilities` struct fields.

## Related Issue

Discovered via downstream issue: https://github.com/docker/cagent/issues/1574