### PR TITLE
mcp: allow SSE messages with empty data (SEP-1699)

### DIFF
--- a/conformance/baseline.yml
+++ b/conformance/baseline.yml
@@ -19,4 +19,3 @@ client:
 - auth/client-credentials-jwt
 - auth/client-credentials-basic
 - auth/pre-registration
-- sse-retry

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -1935,6 +1935,15 @@ func (c *streamableClientConn) processStream(ctx context.Context, requestSummary
 				reconnectDelay = time.Duration(n) * time.Millisecond
 			}
 		}
+
+		// According to SSE specification
+		// (https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation)
+		// events with an empty data buffer are allowed.
+		// In MCP these can be priming events (SEP-1699) that carry only a Last-Event-ID for stream resumption.
+		if len(evt.Data) == 0 {
+			continue
+		}
+
 		// According to SSE spec, events with no name default to "message"
 		if evt.Name != "" && evt.Name != "message" {
 			continue


### PR DESCRIPTION
Fixes #768