### PR TITLE
mcp: add max body size limit for SSE + streamable HTTP

### DIFF
--- a/mcp/http_limits.go
+++ b/mcp/http_limits.go
@@ -1,0 +1,47 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"errors"
+	"net/http"
+)
+
+// DefaultMaxBodyBytes is the default maximum size (in bytes) for HTTP request
+// bodies accepted by the built-in SSE and streamable HTTP handlers.
+//
+// This limit exists to prevent accidental or malicious large requests from
+// exhausting server resources.
+const DefaultMaxBodyBytes int64 = 1_000_000
+
+// effectiveMaxBodyBytes converts the user-configured maxBodyBytes value to an
+// effective limit.
+//
+// Semantics:
+//   - maxBodyBytes == 0: use DefaultMaxBodyBytes
+//   - maxBodyBytes  < 0: no limit
+//   - maxBodyBytes  > 0: use maxBodyBytes
+func effectiveMaxBodyBytes(maxBodyBytes int64) int64 {
+	switch {
+	case maxBodyBytes == 0:
+		return DefaultMaxBodyBytes
+	case maxBodyBytes < 0:
+		return 0
+	default:
+		return maxBodyBytes
+	}
+}
+
+func isMaxBytesError(err error) bool {
+	var mbe *http.MaxBytesError
+	return errors.As(err, &mbe)
+}
+
+func writeRequestBodyTooLarge(w http.ResponseWriter) {
+	// Even though http.MaxBytesReader will try to close the connection after the
+	// limit is exceeded, explicitly request closure here too.
+	w.Header().Set("Connection", "close")
+	http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+}

--- a/mcp/http_limits_test.go
+++ b/mcp/http_limits_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+)
+
+func TestSSEServerTransport_MaxBodyBytes(t *testing.T) {
+	tpt := &SSEServerTransport{
+		MaxBodyBytes: 16,
+		incoming:     make(chan jsonrpc.Message, 1),
+		done:         make(chan struct{}),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.invalid/session", bytes.NewReader(bytes.Repeat([]byte("a"), 17)))
+	w := httptest.NewRecorder()
+	tpt.ServeHTTP(w, req)
+
+	resp := w.Result()
+	resp.Body.Close()
+	if got, want := resp.StatusCode, http.StatusRequestEntityTooLarge; got != want {
+		t.Fatalf("status code: got %d, want %d", got, want)
+	}
+}
+
+func TestStreamableHTTPHandler_MaxBodyBytes(t *testing.T) {
+	server := NewServer(testImpl, nil)
+
+	tests := []struct {
+		name      string
+		stateless bool
+	}{
+		{name: "stateful", stateless: false},
+		{name: "stateless", stateless: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewStreamableHTTPHandler(
+				func(*http.Request) *Server { return server },
+				&StreamableHTTPOptions{Stateless: tt.stateless, MaxBodyBytes: 16},
+			)
+			httpServer := httptest.NewServer(handler)
+			defer httpServer.Close()
+
+			req, err := http.NewRequest(http.MethodPost, httpServer.URL, bytes.NewReader(bytes.Repeat([]byte("a"), 17)))
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Header.Set("Accept", "application/json, text/event-stream")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			resp.Body.Close()
+			if got, want := resp.StatusCode, http.StatusRequestEntityTooLarge; got != want {
+				t.Fatalf("status code: got %d, want %d", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a basic DoS guard for the built-in HTTP transports by limiting POST request body size.

- Adds `MaxBodyBytes` to `SSEOptions` and `StreamableHTTPOptions` (default: `DefaultMaxBodyBytes` = 1_000_000; negative disables).
- Adds `MaxBodyBytes` to `SSEServerTransport` and `StreamableServerTransport` for custom handler usage.
- Returns `413 Request Entity Too Large` when the limit is exceeded.
- Includes tests covering both SSE and streamable handlers/transports.

Rationale: avoid unbounded `io.ReadAll(req.Body)` buffering for network-exposed servers.
