### PR TITLE
chore: bump node.js version for conformance test runs.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,6 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
-        node-version: "20"
+        node-version: "22"
     - name: Run server conformance tests
       run: ./scripts/server-conformance.sh


### PR DESCRIPTION
New version of the tests requires Node.js 22.