### PR TITLE
Remediate Case-Insensitive JSON unmarshalling

### DIFF
--- a/internal/jsonrpc2/messages.go
+++ b/internal/jsonrpc2/messages.go
@@ -173,8 +173,10 @@ func EncodeIndent(msg Message, prefix, indent string) ([]byte, error) {
 
 func DecodeMessage(data []byte) (Message, error) {
 	msg := wireCombined{}
-	if err := json.Unmarshal(data, &msg); err != nil {
-		return nil, fmt.Errorf("unmarshaling jsonrpc message: %w", err)
+	// Use strict unmarshalling to prevent message smuggling attacks
+	// This enforces case-sensitive field matching and rejects duplicate keys
+	if err := StrictUnmarshal(data, &msg); err != nil {
+		return nil, fmt.Errorf("strict unmarshal jsonrpc message: %w", err)
 	}
 	if msg.VersionTag != wireVersion {
 		return nil, fmt.Errorf("invalid message version tag %q; expected %q", msg.VersionTag, wireVersion)

--- a/internal/jsonrpc2/strict.go
+++ b/internal/jsonrpc2/strict.go
@@ -1,0 +1,191 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package jsonrpc2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// StrictUnmarshal unmarshals JSON data into v with strict validation rules:
+// - Rejects duplicate keys with different cases (e.g., "name" and "Name")
+// - Validates that JSON field names exactly match struct tags (case-sensitive)
+// - Rejects unknown fields not defined in the struct
+//
+// This prevents message smuggling attacks that exploit Go's case-insensitive
+// JSON unmarshalling behavior, which violates JSON-RPC 2.0 specification
+// requirements for case-sensitive field matching.
+func StrictUnmarshal(data []byte, v interface{}) error {
+	// 1. Check for case-variant duplicate keys
+	if err := validateNoDuplicateKeys(data); err != nil {
+		return fmt.Errorf("strict unmarshal: %w", err)
+	}
+
+	// 2. Validate field names match struct tags exactly (case-sensitive)
+	if err := validateFieldCase(data, v); err != nil {
+		return fmt.Errorf("strict unmarshal: %w", err)
+	}
+
+	// 3. Use strict decoder that disallows unknown fields
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	if err := dec.Decode(v); err != nil {
+		return fmt.Errorf("strict unmarshal: %w", err)
+	}
+
+	return nil
+}
+
+// validateNoDuplicateKeys checks if the JSON data contains duplicate keys
+// with different cases (e.g., both "name" and "Name").
+func validateNoDuplicateKeys(data []byte) error {
+	// Parse into a generic map to get all keys
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		// If it's not an object, no duplicate keys are possible
+		return nil
+	}
+
+	// Check for case-variant duplicates
+	seen := make(map[string]string) // lowercase -> original
+	for key := range raw {
+		lowerKey := strings.ToLower(key)
+		if original, exists := seen[lowerKey]; exists && original != key {
+			return fmt.Errorf("duplicate key with different case: %q and %q", original, key)
+		}
+		seen[lowerKey] = key
+	}
+
+	// Recursively check nested objects and arrays
+	for key, val := range raw {
+		if err := validateNoDuplicateKeysRecursive(val); err != nil {
+			return fmt.Errorf("in field %q: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
+// validateNoDuplicateKeysRecursive recursively validates nested JSON structures
+func validateNoDuplicateKeysRecursive(data json.RawMessage) error {
+	// Try to parse as object
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err == nil {
+		// It's an object, check for duplicates
+		seen := make(map[string]string)
+		for key := range obj {
+			lowerKey := strings.ToLower(key)
+			if original, exists := seen[lowerKey]; exists && original != key {
+				return fmt.Errorf("duplicate key with different case: %q and %q", original, key)
+			}
+			seen[lowerKey] = key
+		}
+
+		// Recursively check nested values
+		for key, val := range obj {
+			if err := validateNoDuplicateKeysRecursive(val); err != nil {
+				return fmt.Errorf("in field %q: %w", key, err)
+			}
+		}
+		return nil
+	}
+
+	// Try to parse as array
+	var arr []json.RawMessage
+	if err := json.Unmarshal(data, &arr); err == nil {
+		// It's an array, check each element
+		for i, elem := range arr {
+			if err := validateNoDuplicateKeysRecursive(elem); err != nil {
+				return fmt.Errorf("in array index %d: %w", i, err)
+			}
+		}
+		return nil
+	}
+
+	// It's a primitive value, no duplicates possible
+	return nil
+}
+
+// validateFieldCase ensures that JSON field names exactly match the struct
+// tags (case-sensitive). This prevents attacks where an attacker sends
+// "Name" instead of "name" to smuggle values.
+func validateFieldCase(data []byte, v interface{}) error {
+	// Get expected field names from struct tags
+	expectedFields := extractExpectedFields(v)
+
+	// Parse JSON to get actual field names
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		// If it's not an object, nothing to validate
+		return nil
+	}
+
+	// Check that all JSON keys match expected fields exactly
+	for key := range raw {
+		// Check if this key exists in expected fields (case-sensitive)
+		if !expectedFields[key] {
+			// Check if a case-insensitive match exists (which would be a smuggling attempt)
+			lowerKey := strings.ToLower(key)
+			for expected := range expectedFields {
+				if strings.ToLower(expected) == lowerKey {
+					return fmt.Errorf("field name case mismatch: got %q, expected %q", key, expected)
+				}
+			}
+			// If no case-insensitive match, it's an unknown field
+			// (will be caught by DisallowUnknownFields)
+		}
+	}
+
+	return nil
+}
+
+// extractExpectedFields uses reflection to extract valid field names from
+// struct tags. Returns a map of field names that are expected in the JSON.
+func extractExpectedFields(v interface{}) map[string]bool {
+	fields := make(map[string]bool)
+
+	// Get the type, handling pointers
+	t := reflect.TypeOf(v)
+	if t == nil {
+		return fields
+	}
+
+	// Dereference pointer types
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	// Only structs have fields
+	if t.Kind() != reflect.Struct {
+		return fields
+	}
+
+	// Extract field names from json tags
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := field.Tag.Get("json")
+
+		// Parse json tag (format: "name,omitempty")
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		// Extract field name (before comma)
+		name := tag
+		if idx := strings.Index(tag, ","); idx != -1 {
+			name = tag[:idx]
+		}
+
+		if name != "" {
+			fields[name] = true
+		}
+	}
+
+	return fields
+}

--- a/internal/jsonrpc2/strict_test.go
+++ b/internal/jsonrpc2/strict_test.go
@@ -1,0 +1,329 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package jsonrpc2
+
+import (
+	"strings"
+	"testing"
+)
+
+// Test struct for unmarshalling
+type testStruct struct {
+	Name      string `json:"name"`
+	Method    string `json:"method"`
+	Arguments any    `json:"arguments,omitempty"`
+}
+
+func TestStrictUnmarshal_RejectsDuplicateKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr string
+	}{
+		{
+			name:    "duplicate with different case - name and Name",
+			json:    `{"name":"legitimate","Name":"smuggled"}`,
+			wantErr: "duplicate key with different case",
+		},
+		{
+			name:    "duplicate with different case - method and METHOD",
+			json:    `{"method":"tools/call","METHOD":"secret"}`,
+			wantErr: "duplicate key with different case",
+		},
+		{
+			name:    "duplicate in nested object",
+			json:    `{"name":"test","arguments":{"key":"value","Key":"smuggled"}}`,
+			wantErr: "duplicate key with different case",
+		},
+		{
+			name:    "triple duplicate with different cases",
+			json:    `{"name":"a","Name":"b","NAME":"c"}`,
+			wantErr: "duplicate key with different case",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result testStruct
+			err := StrictUnmarshal([]byte(tt.json), &result)
+			if err == nil {
+				t.Errorf("StrictUnmarshal() expected error, got nil. Result: %+v", result)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("StrictUnmarshal() error = %v, want error containing %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestStrictUnmarshal_RejectsWrongCase(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr string
+	}{
+		{
+			name:    "Name instead of name",
+			json:    `{"Name":"test"}`,
+			wantErr: "field name case mismatch",
+		},
+		{
+			name:    "METHOD instead of method",
+			json:    `{"METHOD":"tools/call"}`,
+			wantErr: "field name case mismatch",
+		},
+		{
+			name:    "mixed case - some correct, one wrong",
+			json:    `{"name":"test","METHOD":"tools/call"}`,
+			wantErr: "field name case mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result testStruct
+			err := StrictUnmarshal([]byte(tt.json), &result)
+			if err == nil {
+				t.Errorf("StrictUnmarshal() expected error, got nil. Result: %+v", result)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("StrictUnmarshal() error = %v, want error containing %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestStrictUnmarshal_RejectsUnknownFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr string
+	}{
+		{
+			name:    "unknown field",
+			json:    `{"name":"test","unknownField":"value"}`,
+			wantErr: "unknown field",
+		},
+		{
+			name:    "extra field",
+			json:    `{"name":"test","method":"call","extra":"data"}`,
+			wantErr: "unknown field",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result testStruct
+			err := StrictUnmarshal([]byte(tt.json), &result)
+			if err == nil {
+				t.Errorf("StrictUnmarshal() expected error, got nil. Result: %+v", result)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("StrictUnmarshal() error = %v, want error containing %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestStrictUnmarshal_AllowsValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		wantName string
+	}{
+		{
+			name:     "simple valid",
+			json:     `{"name":"test"}`,
+			wantName: "test",
+		},
+		{
+			name:     "multiple fields",
+			json:     `{"name":"greet","method":"tools/call"}`,
+			wantName: "greet",
+		},
+		{
+			name:     "with optional field",
+			json:     `{"name":"test","method":"call","arguments":{"key":"value"}}`,
+			wantName: "test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result testStruct
+			err := StrictUnmarshal([]byte(tt.json), &result)
+			if err != nil {
+				t.Errorf("StrictUnmarshal() unexpected error = %v", err)
+				return
+			}
+			if result.Name != tt.wantName {
+				t.Errorf("StrictUnmarshal() name = %v, want %v", result.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestDecodeMessage_AttackVector(t *testing.T) {
+	// Test the actual attack payload from the vulnerability report
+	attackPayload := `{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/call",
+		"params": {
+			"name": "greet",
+			"Name": "secretTool",
+			"arguments": {"name": "Exploit"}
+		}
+	}`
+
+	_, err := DecodeMessage([]byte(attackPayload))
+	if err == nil {
+		t.Error("DecodeMessage() should reject attack payload with duplicate keys, got nil error")
+		return
+	}
+	if !strings.Contains(err.Error(), "duplicate key") {
+		t.Errorf("DecodeMessage() error = %v, want error containing 'duplicate key'", err)
+	}
+}
+
+func TestStrictUnmarshal_NestedObjects(t *testing.T) {
+	type nestedStruct struct {
+		Name string `json:"name"`
+		Args struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		} `json:"args"`
+	}
+
+	tests := []struct {
+		name    string
+		json    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid nested",
+			json:    `{"name":"test","args":{"key":"k","value":"v"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "duplicate in nested",
+			json:    `{"name":"test","args":{"key":"k","Key":"smuggled"}}`,
+			wantErr: true,
+			errMsg:  "duplicate key",
+		},
+		{
+			name:    "duplicate in deeply nested",
+			json:    `{"name":"test","args":{"key":"k","value":"v","extra":{"a":"1","A":"2"}}}`,
+			wantErr: true,
+			errMsg:  "duplicate key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result nestedStruct
+			err := StrictUnmarshal([]byte(tt.json), &result)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("StrictUnmarshal() expected error, got nil")
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("StrictUnmarshal() error = %v, want error containing %v", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("StrictUnmarshal() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestStrictUnmarshal_ArrayWithDuplicates(t *testing.T) {
+	type arrayStruct struct {
+		Items []map[string]string `json:"items"`
+	}
+
+	tests := []struct {
+		name    string
+		json    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid array",
+			json:    `{"items":[{"key":"value1"},{"key":"value2"}]}`,
+			wantErr: false,
+		},
+		{
+			name:    "duplicate in array element",
+			json:    `{"items":[{"key":"value","Key":"smuggled"}]}`,
+			wantErr: true,
+			errMsg:  "duplicate key",
+		},
+		{
+			name:    "duplicate in second array element",
+			json:    `{"items":[{"key":"value1"},{"name":"test","Name":"smuggled"}]}`,
+			wantErr: true,
+			errMsg:  "duplicate key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result arrayStruct
+			err := StrictUnmarshal([]byte(tt.json), &result)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("StrictUnmarshal() expected error, got nil")
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("StrictUnmarshal() error = %v, want error containing %v", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("StrictUnmarshal() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractExpectedFields(t *testing.T) {
+	type testCase struct {
+		Field1 string `json:"field1"`
+		Field2 int    `json:"field2,omitempty"`
+		Field3 bool   `json:"-"` // ignored
+		Field4 string // no tag
+	}
+
+	fields := extractExpectedFields(&testCase{})
+
+	expected := map[string]bool{
+		"field1": true,
+		"field2": true,
+	}
+
+	if len(fields) != len(expected) {
+		t.Errorf("extractExpectedFields() returned %d fields, want %d", len(fields), len(expected))
+	}
+
+	for name := range expected {
+		if !fields[name] {
+			t.Errorf("extractExpectedFields() missing expected field %q", name)
+		}
+	}
+
+	// Should not include fields without tags or with "-" tag
+	if fields["Field3"] || fields["Field4"] || fields["field4"] {
+		t.Error("extractExpectedFields() should not include fields without proper json tags")
+	}
+}

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -283,8 +283,9 @@ func newMethodInfo[P paramsPtr[T], R Result, T any](flags methodFlags) methodInf
 		unmarshalParams: func(m json.RawMessage) (Params, error) {
 			var p P
 			if m != nil {
-				if err := json.Unmarshal(m, &p); err != nil {
-					return nil, fmt.Errorf("unmarshaling %q into a %T: %w", m, p, err)
+				// Use strict unmarshalling to prevent message smuggling attacks
+				if err := jsonrpc2.StrictUnmarshal(m, &p); err != nil {
+					return nil, fmt.Errorf("strict unmarshal params: %w", err)
 				}
 			}
 			// We must check missingParamsOK here, in addition to checkRequest, to


### PR DESCRIPTION
The go-sdk is vulnerable to a protocol parser differential attack that allows message smuggling through case-variant JSON fields. This vulnerability exploits Go's case-insensitive JSON unmarshalling behavior, which violates the JSON-RPC 2.0 specification's requirement for case-sensitive field matching.

There is a full description in the issue #805

The fix is really to replace json.Unmarshal with a safer StrictUnmarshal which handles clients that try to take advantage of the json.Unmarshal case insensitivity.

# Affected Files
1. internal/jsonrpc2/messages.go - DecodeMessage() function (lines 174-207)
2. mcp/shared.go - newMethodInfo() function's unmarshalParams closure (lines 283-308)
