### PR TITLE
chore: increase timeout for conformance server start.

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           go run ./conformance/everything-server/main.go -http=":3001" &
           # Wait for the server to be ready.
-          timeout 15 bash -c 'until curl -s http://localhost:3001/mcp; do sleep 0.5; done'
+          timeout 30 bash -c 'until curl -s http://localhost:3001/mcp; do sleep 0.5; done'
       - name: "Run conformance tests" 
         uses: modelcontextprotocol/conformance@c2f3fdaf781dcd5a862cb0d2f6454c1c210bf0f0 # v0.1.11
         with:


### PR DESCRIPTION
We're experiencing some timeouts on server conformance test runs. This should fix it.
