### PR TITLE
fix: return 400 instead of 500 when body read fails in stateless mode

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -405,7 +405,7 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 				// stateless servers.
 				body, err := io.ReadAll(req.Body)
 				if err != nil {
-					http.Error(w, "failed to read body", http.StatusInternalServerError)
+					http.Error(w, "failed to read body", http.StatusBadRequest)
 					return
 				}
 				req.Body.Close()


### PR DESCRIPTION
## Summary

Changes `http.StatusInternalServerError` to `http.StatusBadRequest` when `io.ReadAll(req.Body)` fails during stateless mode initialization in the streamable HTTP handler.

Fixes #816

## Rationale

Body read failures are client-side errors (disconnection, timeout, incomplete request), not server errors. Returning 500 is misleading and causes unnecessary alert fatigue for users monitoring their MCP servers.

This makes the behavior consistent with `servePOST` which already returns 400 for the same error condition.

## Testing

- Existing tests pass
- This is a one-line change affecting only the HTTP status code returned