### PR TITLE
docs: publish user docs with mkdocs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,10 +15,18 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: '3.x'
+      - name: Install MkDocs
+        run: python -m pip install mkdocs
+      - name: Build docs site
+        run: mkdocs build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          publish_dir: ./site
           publish_branch: gh-pages
-          enable_jekyll: true
+          enable_jekyll: false

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# MCP Go SDK
+
+This site hosts the user documentation for the Model Context Protocol Go SDK.
+
+Use the navigation to explore the available guides:
+
+- [Protocol](protocol.md) for lifecycle, transport, auth, and security details.
+- [Client features](client.md) for roots, sampling, elicitation, and capability guidance.
+- [Server features](server.md) for prompts, resources, tools, completion, logging, and pagination.
+- [Troubleshooting](troubleshooting.md) for debugging guidance.
+- [Backwards compatibility](mcpgodebug.md) and [rough edges](rough_edges.md) for compatibility notes.
+
+For generated API reference, use [pkg.go.dev](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: MCP Go SDK
+site_description: User documentation for the Model Context Protocol Go SDK
+repo_url: https://github.com/modelcontextprotocol/go-sdk
+edit_uri: ''
+docs_dir: docs
+site_dir: site
+exclude_docs: |
+  index.html
+nav:
+  - Home: index.md
+  - Protocol: protocol.md
+  - Client features: client.md
+  - Server features: server.md
+  - Troubleshooting: troubleshooting.md
+  - Backwards compatibility: mcpgodebug.md
+  - Rough edges: rough_edges.md
+  - API reference: https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk
+markdown_extensions:
+  - tables
+  - toc:
+      permalink: true


### PR DESCRIPTION
## Summary
- add `mkdocs.yml` so the docs directory builds as a MkDocs site
- update the publish-docs workflow to build and publish `./site` instead of pushing raw `./docs`
- add `docs/index.md` as the user-docs homepage with a pkg.go.dev API reference link

## Testing
- `python3 -m venv .tmp-mkdocs-venv && . .tmp-mkdocs-venv/bin/activate && python -m pip install mkdocs && mkdocs build`
- `git diff --check`

Fixes #835
