### PR TITLE
 mcp: accept parameterized Content-Type types 

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -264,12 +264,9 @@ func (h *StreamableHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 			return
 		}
 		// Validate 'Content-Type' header.
-		if req.Method == http.MethodPost {
-			mediaType, _, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
-			if err != nil || mediaType != "application/json" {
-				http.Error(w, "Content-Type must be 'application/json'", http.StatusUnsupportedMediaType)
-				return
-			}
+		if req.Method == http.MethodPost && baseMediaType(req.Header.Get("Content-Type")) != "application/json" {
+			http.Error(w, "Content-Type must be 'application/json'", http.StatusUnsupportedMediaType)
+			return
 		}
 	}
 
@@ -558,6 +555,14 @@ func streamableAccepts(values []string) (jsonOK, streamOK bool) {
 		}
 	}
 	return jsonOK, streamOK
+}
+
+func baseMediaType(value string) string {
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return ""
+	}
+	return mediaType
 }
 
 // A StreamableServerTransport implements the server side of the MCP streamable
@@ -1671,7 +1676,7 @@ func (c *streamableClientConn) connectStandaloneSSE() {
 		resp.Body.Close()
 		return
 	}
-	if resp.Header.Get("Content-Type") != "text/event-stream" {
+	if baseMediaType(resp.Header.Get("Content-Type")) != "text/event-stream" {
 		// modelcontextprotocol/go-sdk#736: some servers return 200 OK or redirect with
 		// non-SSE content type instead of text/event-stream for the standalone
 		// SSE stream.
@@ -1855,7 +1860,7 @@ func (c *streamableClientConn) Write(ctx context.Context, msg jsonrpc.Message) e
 		return nil
 	}
 
-	contentType := strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0])
+	contentType := baseMediaType(resp.Header.Get("Content-Type"))
 	switch contentType {
 	case "application/json":
 		go c.handleJSON(requestSummary, resp)

--- a/mcp/streamable_client_test.go
+++ b/mcp/streamable_client_test.go
@@ -264,6 +264,7 @@ func TestStreamableClientGETHandling(t *testing.T) {
 		contentType         string
 	}{
 		{http.StatusOK, "", "text/event-stream"},
+		{http.StatusOK, "", "text/event-stream; charset=utf-8"},
 		{http.StatusMethodNotAllowed, "", "text/event-stream"},
 		//// The client error status code is not treated as an error in non-strict
 		//// mode.
@@ -274,7 +275,7 @@ func TestStreamableClientGETHandling(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("status=%d", test.status), func(t *testing.T) {
+		t.Run(fmt.Sprintf("status=%d content_type=%q", test.status, test.contentType), func(t *testing.T) {
 			fake := &fakeStreamableServer{
 				t: t,
 				responses: fakeResponses{

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -1506,9 +1506,9 @@ func (s streamableRequest) do(ctx context.Context, serverURL, sessionID string, 
 
 	newSessionID := resp.Header.Get(sessionIDHeader)
 
-	contentType := resp.Header.Get("Content-Type")
+	contentType := baseMediaType(resp.Header.Get("Content-Type"))
 	var respBody []byte
-	if strings.HasPrefix(contentType, "text/event-stream") {
+	if contentType == "text/event-stream" {
 		r := readerInto{resp.Body, new(bytes.Buffer)}
 		for evt, err := range scanEvents(r) {
 			if err != nil {
@@ -1525,7 +1525,7 @@ func (s streamableRequest) do(ctx context.Context, serverURL, sessionID string, 
 			}
 		}
 		respBody = r.w.Bytes()
-	} else if strings.HasPrefix(contentType, "application/json") {
+	} else if contentType == "application/json" {
 		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return newSessionID, resp.StatusCode, nil, fmt.Errorf("reading json body: %w", err)
@@ -2044,6 +2044,28 @@ func TestStreamableGETWithoutEventStreamAccept(t *testing.T) {
 	}
 	if got, want := strings.TrimSpace(string(body)), "Accept must contain 'text/event-stream' for GET requests"; got != want {
 		t.Errorf("body: got %q, want %q", got, want)
+	}
+}
+
+func TestBaseMediaType(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", want: ""},
+		{name: "json", value: "application/json", want: "application/json"},
+		{name: "json with params", value: "Application/JSON; charset=utf-8", want: "application/json"},
+		{name: "event stream with params", value: "Text/Event-Stream; charset=utf-8", want: "text/event-stream"},
+		{name: "invalid", value: "application/json; charset", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := baseMediaType(test.value); got != test.want {
+				t.Errorf("baseMediaType(%q) = %q, want %q", test.value, got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Use a shared helper for Content-Type parsing in streamable transport request validation and client response handling.

Follow up to https://github.com/modelcontextprotocol/go-sdk/pull/853, where we did this for `Accept` headers.

This allows the streamable mcp server to validate the following header `Content-Type: application/json;charset=utf-8`