### PR TITLE
Update README.md

### DIFF
--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -15,7 +15,7 @@ The example implements:
 ```bash
 go run . server
 ```
-This starts an MCP server on `http://localhost:8080` (default) that provides a `cityTime` tool.
+This starts an MCP server on `http://localhost:8000` (default) that provides a `cityTime` tool.
 
 To run a client in another terminal:
 


### PR DESCRIPTION
correct the default address of the locally hosted server, according to `main.go:21` the default is `:8000` not `:8080`