### PR TITLE
feat(mcp): add ServerSession.Notify for custom notification methods

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1080,6 +1081,16 @@ func (ss *ServerSession) callProgressNotificationHandler(ctx context.Context, p 
 		h(ctx, serverRequestFor(ss, p))
 	}
 	return nil, nil
+}
+
+// Notify sends a notification with an arbitrary custom method name.
+// method MUST start with "notifications/". Returns when the peer has
+// acknowledged the write or the context is cancelled.
+func (ss *ServerSession) Notify(ctx context.Context, method string, params any) error {
+	if !strings.HasPrefix(method, "notifications/") {
+		return fmt.Errorf("Notify: method must start with notifications/, got %q", method)
+	}
+	return ss.getConn().Notify(ctx, method, params)
 }
 
 // NotifyProgress sends a progress notification from the server to the client


### PR DESCRIPTION
## Summary

Adds a public `Notify` method on `ServerSession` that allows sending
notifications with arbitrary custom method names (e.g.
`notifications/claude/channel`). The method validates that the method
name starts with `notifications/` per the MCP specification before
delegating to the underlying jsonrpc2 connection.

## Motivation

The Go MCP SDK only exposes typed notification helpers (`NotifyProgress`,
`SetLoggingLevel`, etc.) for built-in MCP notification types. Protocol
extensions (e.g. Claude's channel mode) need to send notifications with
custom method names that aren't part of the core MCP spec. Currently
there's no public API to do this — `handleNotify`, `getConn().Notify`,
and the sending method handler are all unexported.

## Changes

- Add `(*ServerSession).Notify(ctx context.Context, method string, params any) error`
- Validates method name starts with `notifications/` prefix
- Delegates to `getConn().Notify()` which is the same path used by
  `NotifyProgress` and other built-in notification senders

## Testing

The fork is used in production by [agnt](https://github.com/standardbeagle/agnt)
with an end-to-end test that:
1. Creates an in-memory MCP client-server pair
2. Server sends `notifications/claude/channel` with structured params
3. Client reads the raw jsonrpc notification and asserts method + params match

## Alternatives Considered

- **Middleware-only approach**: Client-side middleware can intercept
  custom notifications, but there's no way for the server to *send* them
  without this method.
- **Raw jsonrpc2 access**: Exposing the internal connection would break
  the abstraction boundary. A simple public method is cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)