### PR TITLE
mcp: suppress subprocess exit error during graceful close

### DIFF
--- a/mcp/cmd.go
+++ b/mcp/cmd.go
@@ -6,6 +6,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -88,6 +89,14 @@ func (s *pipeRWC) Close() error {
 		return nil, false
 	}
 	if err, ok := wait(); ok {
+		// The subprocess exited after we closed stdin. A non-zero exit code
+		// is expected here: the server may exit with an error status because
+		// it observed EOF on stdin. This is part of normal graceful shutdown,
+		// not an error in the connection.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil
+		}
 		return err
 	}
 	// Note the condition here: if sending SIGTERM fails, don't wait and just

--- a/mcp/cmd_test.go
+++ b/mcp/cmd_test.go
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 var serverFuncs = map[string]func(){
 	"default":       runServer,
 	"cancelContext": runCancelContextServer,
+	"exitNonZero":   runExitNonZeroServer,
 }
 
 func runServer() {
@@ -65,6 +66,19 @@ func runServer() {
 	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// runExitNonZeroServer runs a server that exits with a non-zero status when the
+// connection is closed, simulating servers (like gopls) that treat EOF on stdin
+// as a fatal error. This exercises the fix for #855.
+func runExitNonZeroServer() {
+	ctx := context.Background()
+	server := mcp.NewServer(testImpl, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "greet", Description: "say hi"}, SayHi)
+	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
+		os.Exit(2) // non-zero exit, as gopls does
+	}
+	os.Exit(2) // also exit non-zero on clean shutdown to test the fix
 }
 
 func runCancelContextServer() {
@@ -226,6 +240,35 @@ func TestCmdTransport(t *testing.T) {
 	}
 	if err := session.Close(); err != nil {
 		t.Fatalf("closing server: %v", err)
+	}
+}
+
+// TestCmdTransportNonZeroExit verifies that ClientSession.Close does not return
+// an error when the subprocess exits with a non-zero status during graceful
+// shutdown. This is a regression test for #855: servers like gopls may exit
+// non-zero when they observe EOF on stdin, and that should not be surfaced as
+// an error from Close.
+func TestCmdTransportNonZeroExit(t *testing.T) {
+	requireExec(t)
+
+	ctx := t.Context()
+	cmd := createServerCommand(t, "exitNonZero")
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, &mcp.CommandTransport{Command: cmd}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make a call to ensure the session is fully established.
+	if _, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "greet",
+		Arguments: map[string]any{"name": "user"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Close should succeed even though the server exits non-zero.
+	if err := session.Close(); err != nil {
+		t.Fatalf("closing server that exits non-zero: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #855. When `ClientSession.Close()` initiates graceful shutdown by closing stdin, the subprocess may exit with a non-zero status. This exit error propagated through `pipeRWC.Close()` as `closeErr`, causing spurious errors from `ClientSession.Close()`.

This matches the analysis by @adonovan in [golang/go#77336](https://github.com/golang/go/issues/77336#issuecomment-4090756198):

> "a bug in mcp causing a race between the active part of Close (which breaks the connection and terminates the child process) and the waiting part of close (which seems to observe an error from the terminated child without realizing that close itself was responsible)"

## Root cause

The error path traced by @adonovan:

1. `ClientSession.Close()` calls `conn.Close()`, which sets `connClosing = true`
2. `updateInFlight` sees idle + closing, calls `s.closer.Close()` (`pipeRWC.Close`)
3. `pipeRWC.Close()` closes stdin, then waits for `cmd.Wait()`
4. The subprocess (e.g. gopls) sees EOF on stdin, treats it as fatal, exits with code 2
5. `cmd.Wait()` returns `*exec.ExitError`, stored as `closeErr`
6. `conn.wait(false)` returns `closeErr` to the caller

The subprocess exited because the client told it to (by closing stdin). The exit code is not meaningful for the client.

## Fix

In `pipeRWC.Close()`, after closing stdin and waiting for the subprocess to exit, suppress `*exec.ExitError`. Errors from the SIGTERM/SIGKILL fallback paths are still propagated, as those indicate the subprocess did not respond to graceful shutdown.

The fix is at the transport layer (not the jsonrpc2 layer) because only the stdio transport has the semantic knowledge that "I closed stdin, so the subprocess exiting is expected."

## Test plan

- Added `TestCmdTransportNonZeroExit`: connects to a server that exits with code 2 on shutdown, verifies `session.Close()` returns nil
- Confirmed the test fails without the fix (`exit status 2`) and passes with it
- Full test suite passes: `GOWORK=off go test ./... -count=1`