### PR TITLE
fix(mcp): prevent SIGSEGV in AddTool when schema is nil

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -437,6 +437,9 @@ func setSchema[T any](sfield *any, rfield **jsonschema.Resolved, cache *SchemaCa
 		if err != nil {
 			return zero, err
 		}
+		if internalSchema == nil {
+			return zero, fmt.Errorf("schema is nil for type %v", rt)
+		}
 		*sfield = internalSchema
 
 		resolved, err := internalSchema.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})
@@ -464,6 +467,10 @@ func setSchema[T any](sfield *any, rfield **jsonschema.Resolved, cache *SchemaCa
 		if err := remarshal(*sfield, &internalSchema); err != nil {
 			return zero, err
 		}
+	}
+
+	if internalSchema == nil {
+		return zero, fmt.Errorf("schema is nil for type %v", rt)
 	}
 
 	resolved, err := internalSchema.Resolve(&jsonschema.ResolveOptions{ValidateDefaults: true})

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -247,6 +247,9 @@ func (s *Server) AddTool(t *Tool, h ToolHandler) {
 		panic(fmt.Errorf("AddTool %q: missing input schema", t.Name))
 	}
 	if s, ok := t.InputSchema.(*jsonschema.Schema); ok {
+		if s == nil {
+			panic(fmt.Errorf("AddTool %q: input schema is nil", t.Name))
+		}
 		if s.Type != "object" {
 			panic(fmt.Errorf(`AddTool %q: input schema must have type "object"`, t.Name))
 		}
@@ -261,6 +264,9 @@ func (s *Server) AddTool(t *Tool, h ToolHandler) {
 	}
 	if t.OutputSchema != nil {
 		if s, ok := t.OutputSchema.(*jsonschema.Schema); ok {
+			if s == nil {
+				panic(fmt.Errorf("AddTool %q: output schema is nil", t.Name))
+			}
 			if s.Type != "object" {
 				panic(fmt.Errorf(`AddTool %q: output schema must have type "object"`, t.Name))
 			}

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"log/slog"
 	"slices"
@@ -601,6 +602,44 @@ func TestAddToolNameValidation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestAddToolNilSchema(t *testing.T) {
+	var nilSchema *jsonschema.Schema
+
+	panicMsg := func(f func()) string {
+		var msg string
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					msg = fmt.Sprintf("%v", r)
+				}
+			}()
+			f()
+		}()
+		return msg
+	}
+
+	// Call s.AddTool directly to exercise the typed-nil checks added to that method.
+	msg := panicMsg(func() {
+		s := NewServer(testImpl, nil)
+		s.AddTool(&Tool{Name: "T", InputSchema: nilSchema}, nil)
+	})
+	if msg == "" {
+		t.Error("typed nil InputSchema: expected panic")
+	} else if !strings.Contains(msg, "input schema is nil") {
+		t.Errorf("typed nil InputSchema: panic message %q does not contain %q", msg, "input schema is nil")
+	}
+
+	msg = panicMsg(func() {
+		s := NewServer(testImpl, nil)
+		s.AddTool(&Tool{Name: "T", InputSchema: &jsonschema.Schema{Type: "object"}, OutputSchema: nilSchema}, nil)
+	})
+	if msg == "" {
+		t.Error("typed nil OutputSchema: expected panic")
+	} else if !strings.Contains(msg, "output schema is nil") {
+		t.Errorf("typed nil OutputSchema: panic message %q does not contain %q", msg, "output schema is nil")
 	}
 }
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -608,18 +608,15 @@ func TestAddToolNameValidation(t *testing.T) {
 func TestAddToolNilSchema(t *testing.T) {
 	var nilSchema *jsonschema.Schema
 
-	panicMsg := func(f func()) string {
-		var msg string
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					msg = fmt.Sprintf("%v", r)
-				}
-			}()
-			f()
-		}()
-		return msg
-	}
+  panicMsg := func(f func()) (msg string) {
+  		defer func() {
+  			if r := recover(); r != nil {
+  				msg = fmt.Sprintf("%v", r)
+  			}
+  		}()
+  		f()
+  		return msg
+  	}
 
 	// Call s.AddTool directly to exercise the typed-nil checks added to that method.
 	msg := panicMsg(func() {

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -649,6 +649,7 @@ tests := []struct {
 			}
 		})
 	}
+}
 
 type schema = jsonschema.Schema
 

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -608,18 +608,18 @@ func TestAddToolNameValidation(t *testing.T) {
 func TestAddToolNilSchema(t *testing.T) {
 	var nilSchema *jsonschema.Schema
 
-  panicMsg := func(f func()) (msg string) {
-  		defer func() {
-  			if r := recover(); r != nil {
-  				msg = fmt.Sprintf("%v", r)
-  			}
-  		}()
-  		f()
-  		return msg
-  	}
+	panicMsg := func(f func()) (msg string) {
+		defer func() {
+			if r := recover(); r != nil {
+				msg = fmt.Sprintf("%v", r)
+			}
+		}()
+		f()
+		return msg
+	}
 
 	// Call s.AddTool directly to exercise the typed-nil checks added to that method.
-tests := []struct {
+	tests := []struct {
 		name        string
 		tool        *Tool
 		wantContain string
@@ -638,7 +638,7 @@ tests := []struct {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewServer(testImpl, nil)
-			
+
 			msg := panicMsg(func() {
 				s.AddTool(tc.tool, nil)
 			})

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -619,26 +619,36 @@ func TestAddToolNilSchema(t *testing.T) {
   	}
 
 	// Call s.AddTool directly to exercise the typed-nil checks added to that method.
-	msg := panicMsg(func() {
-		s := NewServer(testImpl, nil)
-		s.AddTool(&Tool{Name: "T", InputSchema: nilSchema}, nil)
-	})
-	if msg == "" {
-		t.Error("typed nil InputSchema: expected panic")
-	} else if !strings.Contains(msg, "input schema is nil") {
-		t.Errorf("typed nil InputSchema: panic message %q does not contain %q", msg, "input schema is nil")
+tests := []struct {
+		name        string
+		tool        *Tool
+		wantContain string
+	}{
+		{
+			name:        "typed nil InputSchema",
+			tool:        &Tool{Name: "T", InputSchema: nilSchema},
+			wantContain: "input schema is nil",
+		},
+		{
+			name:        "typed nil OutputSchema",
+			tool:        &Tool{Name: "T", InputSchema: &jsonschema.Schema{Type: "object"}, OutputSchema: nilSchema},
+			wantContain: "output schema is nil",
+		},
 	}
-
-	msg = panicMsg(func() {
-		s := NewServer(testImpl, nil)
-		s.AddTool(&Tool{Name: "T", InputSchema: &jsonschema.Schema{Type: "object"}, OutputSchema: nilSchema}, nil)
-	})
-	if msg == "" {
-		t.Error("typed nil OutputSchema: expected panic")
-	} else if !strings.Contains(msg, "output schema is nil") {
-		t.Errorf("typed nil OutputSchema: panic message %q does not contain %q", msg, "output schema is nil")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewServer(testImpl, nil)
+			
+			msg := panicMsg(func() {
+				s.AddTool(tc.tool, nil)
+			})
+			if msg == "" {
+				t.Error("expected panic")
+			} else if !strings.Contains(msg, tc.wantContain) {
+				t.Errorf("panic message %q does not contain %q", msg, tc.wantContain)
+			}
+		})
 	}
-}
 
 type schema = jsonschema.Schema
 


### PR DESCRIPTION
## Bug

`mcp.AddTool` crashes the server with SIGSEGV when input/output struct tags trigger a nil schema.

## Root Cause

In `mcp/server.go`, the function `setSchema` calls `internalSchema.Resolve(...)` without checking if `internalSchema` is nil. If the schema inference (e.g., via `jsonschema.ForType`) or a provided schema results in a nil value, this dereference causes a panic.

## Fix

Added nil checks for `internalSchema` before calling `Resolve` in two locations within `setSchema`:
1. After schema generation via `jsonschema.ForType`.
2. After processing a provided schema (which might be nil or fail to unmarshal).

If `internalSchema` is nil, the function now returns a descriptive error instead of crashing.

## Verification

- `go test ./mcp/...` passes.
- The fix prevents the crash by handling the nil case gracefully.

Closes #916.