### PR TITLE
mcp: close HTTP response body from DELETE request in streamableClientConn.Close

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -2236,8 +2236,10 @@ func (c *streamableClientConn) Close() error {
 			} else {
 				if err := c.setMCPHeaders(req); err != nil {
 					c.closeErr = err
-				} else if _, err := c.client.Do(req); err != nil {
+				} else if resp, err := c.client.Do(req); err != nil {
 					c.closeErr = err
+				} else {
+					resp.Body.Close()
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

The DELETE request that terminates a streamable HTTP session discards the `*http.Response` without closing its body. Per the `net/http` documentation, this prevents the underlying TCP connection from being reused and leaks it.

## The bug

```go
// mcp/streamable.go:2239 (before)
} else if _, err := c.client.Do(req); err != nil {
    c.closeErr = err
}
```

On the success path (no error), the response is silently discarded. The default client is `http.DefaultClient` with keep-alives enabled, so the leaked connection stays open until GC or process exit.

## The fix

```go
// mcp/streamable.go:2239 (after)
} else if resp, err := c.client.Do(req); err != nil {
    c.closeErr = err
} else {
    resp.Body.Close()
}
```

All 10 other `client.Do` call sites in this file close the response body. This one was missed.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -short` passes

Fixes #928