### PR TITLE
mpc: Require Server requests to be associated with a Client request

### DIFF
--- a/mcp/client_example_test.go
+++ b/mcp/client_example_test.go
@@ -78,24 +78,36 @@ func Example_sampling() {
 		},
 	})
 
-	// Connect the server and client...
+	// Create a server with a tool that uses sampling.
+	// Server-to-client requests like CreateMessage must be made within a
+	// client request handler (e.g. a tool call).
 	ct, st := mcp.NewInMemoryTransports()
 	s := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "v0.0.1"}, nil)
+	s.AddTool(&mcp.Tool{Name: "sample", InputSchema: map[string]any{"type": "object"}}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		msg, err := req.Session.CreateMessage(ctx, &mcp.CreateMessageParams{})
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: msg.Content.(*mcp.TextContent).Text}},
+		}, nil
+	})
 	session, err := s.Connect(ctx, st, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer session.Close()
 
-	if _, err := c.Connect(ctx, ct, nil); err != nil {
-		log.Fatal(err)
-	}
-
-	msg, err := session.CreateMessage(ctx, &mcp.CreateMessageParams{})
+	cs, err := c.Connect(ctx, ct, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(msg.Content.(*mcp.TextContent).Text)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "sample"})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(res.Content[0].(*mcp.TextContent).Text)
 	// Output: would have created a message
 }
 
@@ -107,7 +119,27 @@ func Example_elicitation() {
 	ctx := context.Background()
 	ct, st := mcp.NewInMemoryTransports()
 
+	// Create a server with a tool that uses elicitation.
+	// Server-to-client requests like Elicit must be made within a client
+	// request handler (e.g. a tool call).
 	s := mcp.NewServer(&mcp.Implementation{Name: "server", Version: "v0.0.1"}, nil)
+	s.AddTool(&mcp.Tool{Name: "ask", InputSchema: map[string]any{"type": "object"}}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		res, err := req.Session.Elicit(ctx, &mcp.ElicitParams{
+			Message: "Please provide information",
+			RequestedSchema: &jsonschema.Schema{
+				Type: "object",
+				Properties: map[string]*jsonschema.Schema{
+					"test": {Type: "string"},
+				},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: res.Content["test"].(string)}},
+		}, nil
+	})
 	ss, err := s.Connect(ctx, st, nil)
 	if err != nil {
 		log.Fatal(err)
@@ -119,22 +151,16 @@ func Example_elicitation() {
 			return &mcp.ElicitResult{Action: "accept", Content: map[string]any{"test": "value"}}, nil
 		},
 	})
-	if _, err := c.Connect(ctx, ct, nil); err != nil {
-		log.Fatal(err)
-	}
-	res, err := ss.Elicit(ctx, &mcp.ElicitParams{
-		Message: "This should fail",
-		RequestedSchema: &jsonschema.Schema{
-			Type: "object",
-			Properties: map[string]*jsonschema.Schema{
-				"test": {Type: "string"},
-			},
-		},
-	})
+	cs, err := c.Connect(ctx, ct, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(res.Content["test"])
+
+	toolRes, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "ask"})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(toolRes.Content[0].(*mcp.TextContent).Text)
 	// Output: value
 }
 

--- a/mcp/elicitation_test.go
+++ b/mcp/elicitation_test.go
@@ -120,7 +120,7 @@ func TestElicitationURLMode(t *testing.T) {
 			}
 			defer cs.Close()
 
-			result, err := ss.Elicit(ctx, tc.params)
+			result, err := ss.Elicit(clientRequestCtx(ctx), tc.params)
 
 			if tc.wantErrMsg != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErrMsg) {
@@ -170,7 +170,7 @@ func TestElicitationCompleteNotification(t *testing.T) {
 
 		// 1. Server initiates a URL elicitation
 		elicitID := "testElicitationID-123"
-		resp, err := ss.Elicit(ctx, &ElicitParams{
+		resp, err := ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 			Mode:          "url",
 			Message:       "Please complete this form: ",
 			URL:           "https://example.com/form?id=" + elicitID,
@@ -251,7 +251,7 @@ func TestElicitationNoValidationWithoutAccept(t *testing.T) {
 			}
 			defer cs.Close()
 
-			res, err := ss.Elicit(ctx, &ElicitParams{
+			res, err := ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 				Message:         "Test bug",
 				RequestedSchema: schema,
 			})

--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -29,6 +29,13 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
+// clientRequestCtx returns a context that simulates being inside the scope of
+// a client request handler for tests that call server-to-client methods (like
+// CreateMessage, ListRoots, Elicit) directly on a ServerSession.
+func clientRequestCtx(ctx context.Context) context.Context {
+	return context.WithValue(ctx, clientRequestIDKey{}, jsonrpc2.Int64ID(1))
+}
+
 type hiParams struct {
 	Name string
 }
@@ -357,7 +364,7 @@ func TestEndToEnd(t *testing.T) {
 		// ===== roots =====
 		t.Log("Testing roots")
 		{
-			rootRes, err := ss.ListRoots(ctx, &ListRootsParams{})
+			rootRes, err := ss.ListRoots(clientRequestCtx(ctx), &ListRootsParams{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -377,7 +384,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Log("Testing sampling")
 		{
 			// TODO: test that a client that doesn't have the handler returns CodeUnsupportedMethod.
-			res, err := ss.CreateMessage(ctx, &CreateMessageParams{})
+			res, err := ss.CreateMessage(clientRequestCtx(ctx), &CreateMessageParams{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -528,7 +535,7 @@ func TestEndToEnd(t *testing.T) {
 		// ===== elicitation =====
 		t.Log("Testing elicitation")
 		{
-			result, err := ss.Elicit(ctx, &ElicitParams{
+			result, err := ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 				Message: "Please provide information",
 			})
 			if err != nil {
@@ -762,7 +769,7 @@ func TestMiddleware(t *testing.T) {
 	if _, err := cs.ListTools(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ss.ListRoots(ctx, nil); err != nil {
+	if _, err := ss.ListRoots(clientRequestCtx(ctx), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -859,7 +866,7 @@ func TestNoJSONNull(t *testing.T) {
 	if _, err := cs.ListResourceTemplates(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := ss.ListRoots(ctx, nil); err != nil {
+	if _, err := ss.ListRoots(clientRequestCtx(ctx), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1019,7 +1026,7 @@ func TestElicitationUnsupportedMethod(t *testing.T) {
 	defer cs.Close()
 
 	// Test that elicitation fails when no handler is provided
-	_, err = ss.Elicit(ctx, &ElicitParams{
+	_, err = ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 		Message: "This should fail",
 		RequestedSchema: &jsonschema.Schema{
 			Type: "object",
@@ -1241,7 +1248,7 @@ func TestElicitationSchemaValidation(t *testing.T) {
 
 	for _, tc := range validSchemas {
 		t.Run("valid_"+tc.name, func(t *testing.T) {
-			_, err := ss.Elicit(ctx, &ElicitParams{
+			_, err := ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 				Message:         "Test valid schema: " + tc.name,
 				RequestedSchema: tc.schema,
 			})
@@ -1510,7 +1517,7 @@ func TestElicitationSchemaValidation(t *testing.T) {
 
 	for _, tc := range invalidSchemas {
 		t.Run("invalid_"+tc.name, func(t *testing.T) {
-			_, err := ss.Elicit(ctx, &ElicitParams{
+			_, err := ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 				Message:         "Test invalid schema: " + tc.name,
 				RequestedSchema: tc.schema,
 			})
@@ -1597,7 +1604,7 @@ func TestElicitContentValidation(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := ss.Elicit(ctx, &ElicitParams{
+			_, err := ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 				Message:         "Test schema: " + tc.name,
 				RequestedSchema: tc.schema,
 			})
@@ -1646,7 +1653,7 @@ func TestElicitationProgressToken(t *testing.T) {
 		t.Errorf("got progress token %v, want %q", token, "test-token")
 	}
 
-	_, err = ss.Elicit(ctx, params)
+	_, err = ss.Elicit(clientRequestCtx(ctx), params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1680,7 +1687,7 @@ func TestElicitationCapabilityDeclaration(t *testing.T) {
 
 		// The client should have declared elicitation capability during initialization
 		// We can verify this worked by successfully making an elicitation call
-		result, err := ss.Elicit(ctx, &ElicitParams{
+		result, err := ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 			Message:         "Test capability",
 			RequestedSchema: &jsonschema.Schema{Type: "object"},
 		})
@@ -1716,7 +1723,7 @@ func TestElicitationCapabilityDeclaration(t *testing.T) {
 		defer cs.Close()
 
 		// Elicitation should fail with UnsupportedMethod
-		_, err = ss.Elicit(ctx, &ElicitParams{
+		_, err = ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 			Message:         "This should fail",
 			RequestedSchema: &jsonschema.Schema{Type: "object"},
 		})
@@ -1810,7 +1817,7 @@ func TestElicitationDefaultValues(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			res, err := ss.Elicit(ctx, &ElicitParams{
+			res, err := ss.Elicit(clientRequestCtx(ctx), &ElicitParams{
 				Message:         "Test schema with defaults: " + tc.name,
 				RequestedSchema: tc.schema,
 			})
@@ -2013,7 +2020,7 @@ func TestSynchronousNotifications(t *testing.T) {
 			}
 
 			time.Sleep(notificationDelay * 2) // Wait for delayed notification.
-			if _, err := ss.CreateMessage(context.Background(), new(CreateMessageParams)); err != nil {
+			if _, err := ss.CreateMessage(clientRequestCtx(context.Background()), new(CreateMessageParams)); err != nil {
 				t.Errorf("CreateMessage failed: %v", err)
 			}
 		}
@@ -2058,6 +2065,140 @@ func TestNoDistributedDeadlock(t *testing.T) {
 		if _, err := cs.CallTool(context.Background(), &CallToolParams{Name: "tool1"}); err != nil {
 			// should not deadlock
 			t.Fatalf("CallTool failed: %v", err)
+		}
+	})
+}
+
+func TestServerToClientRequestScoping(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		ct, st := NewInMemoryTransports()
+
+		server := NewServer(testImpl, nil)
+		ss, err := server.Connect(ctx, st, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ss.Close()
+
+		client := NewClient(testImpl, &ClientOptions{
+			CreateMessageHandler: func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error) {
+				return &CreateMessageResult{Content: &TextContent{}}, nil
+			},
+			ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
+				return &ElicitResult{Action: "accept"}, nil
+			},
+		})
+		cs, err := client.Connect(ctx, ct, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cs.Close()
+
+		// Server-to-client requests on a bare context must fail.
+		if _, err := ss.ListRoots(ctx, nil); err == nil {
+			t.Error("ListRoots on bare context: got nil error, want error")
+		}
+		if _, err := ss.CreateMessage(ctx, &CreateMessageParams{}); err == nil {
+			t.Error("CreateMessage on bare context: got nil error, want error")
+		}
+		if _, err := ss.CreateMessageWithTools(ctx, &CreateMessageWithToolsParams{}); err == nil {
+			t.Error("CreateMessageWithTools on bare context: got nil error, want error")
+		}
+		if _, err := ss.Elicit(ctx, &ElicitParams{Message: "test"}); err == nil {
+			t.Error("Elicit on bare context: got nil error, want error")
+		}
+
+		// Ping is exempt from this restriction.
+		if err := ss.Ping(ctx, nil); err != nil {
+			t.Errorf("Ping on bare context: got error %v, want nil", err)
+		}
+
+		// Server-to-client requests from within a tool handler must succeed.
+		var toolErr error
+		AddTool(server, &Tool{Name: "test_scoping"}, func(ctx context.Context, req *CallToolRequest, args any) (*CallToolResult, any, error) {
+			if _, err := req.Session.ListRoots(ctx, nil); err != nil {
+				toolErr = fmt.Errorf("ListRoots in tool handler: %v", err)
+				return &CallToolResult{}, nil, nil
+			}
+			if _, err := req.Session.CreateMessage(ctx, &CreateMessageParams{}); err != nil {
+				toolErr = fmt.Errorf("CreateMessage in tool handler: %v", err)
+				return &CallToolResult{}, nil, nil
+			}
+			if _, err := req.Session.CreateMessageWithTools(ctx, &CreateMessageWithToolsParams{}); err != nil {
+				toolErr = fmt.Errorf("CreateMessageWithTools in tool handler: %v", err)
+				return &CallToolResult{}, nil, nil
+			}
+			if _, err := req.Session.Elicit(ctx, &ElicitParams{Message: "test"}); err != nil {
+				toolErr = fmt.Errorf("Elicit in tool handler: %v", err)
+				return &CallToolResult{}, nil, nil
+			}
+			return &CallToolResult{}, nil, nil
+		})
+
+		if _, err := cs.CallTool(ctx, &CallToolParams{Name: "test_scoping"}); err != nil {
+			t.Fatalf("CallTool failed: %v", err)
+		}
+		if toolErr != nil {
+			t.Error(toolErr)
+		}
+
+		// Server-to-client requests from within a resource handler must succeed.
+		var resourceErr error
+		server.AddResource(&Resource{URI: "file:///test_scoping"}, func(ctx context.Context, req *ReadResourceRequest) (*ReadResourceResult, error) {
+			if _, err := req.Session.ListRoots(ctx, nil); err != nil {
+				resourceErr = fmt.Errorf("ListRoots in resource handler: %v", err)
+				return nil, nil
+			}
+			if _, err := req.Session.CreateMessage(ctx, &CreateMessageParams{}); err != nil {
+				resourceErr = fmt.Errorf("CreateMessage in resource handler: %v", err)
+				return nil, nil
+			}
+			if _, err := req.Session.CreateMessageWithTools(ctx, &CreateMessageWithToolsParams{}); err != nil {
+				resourceErr = fmt.Errorf("CreateMessageWithTools in resource handler: %v", err)
+				return nil, nil
+			}
+			if _, err := req.Session.Elicit(ctx, &ElicitParams{Message: "test"}); err != nil {
+				resourceErr = fmt.Errorf("Elicit in resource handler: %v", err)
+				return nil, nil
+			}
+			return &ReadResourceResult{Contents: []*ResourceContents{{URI: "file:///test_scoping", Text: "ok"}}}, nil
+		})
+
+		if _, err := cs.ReadResource(ctx, &ReadResourceParams{URI: "file:///test_scoping"}); err != nil {
+			t.Fatalf("ReadResource failed: %v", err)
+		}
+		if resourceErr != nil {
+			t.Error(resourceErr)
+		}
+
+		// Server-to-client requests from within a prompt handler must succeed.
+		var promptErr error
+		server.AddPrompt(&Prompt{Name: "test_scoping"}, func(ctx context.Context, req *GetPromptRequest) (*GetPromptResult, error) {
+			if _, err := req.Session.ListRoots(ctx, nil); err != nil {
+				promptErr = fmt.Errorf("ListRoots in prompt handler: %v", err)
+				return nil, nil
+			}
+			if _, err := req.Session.CreateMessage(ctx, &CreateMessageParams{}); err != nil {
+				promptErr = fmt.Errorf("CreateMessage in prompt handler: %v", err)
+				return nil, nil
+			}
+			if _, err := req.Session.CreateMessageWithTools(ctx, &CreateMessageWithToolsParams{}); err != nil {
+				promptErr = fmt.Errorf("CreateMessageWithTools in prompt handler: %v", err)
+				return nil, nil
+			}
+			if _, err := req.Session.Elicit(ctx, &ElicitParams{Message: "test"}); err != nil {
+				promptErr = fmt.Errorf("Elicit in prompt handler: %v", err)
+				return nil, nil
+			}
+			return &GetPromptResult{Messages: []*PromptMessage{}}, nil
+		})
+
+		if _, err := cs.GetPrompt(ctx, &GetPromptParams{Name: "test_scoping"}); err != nil {
+			t.Fatalf("GetPrompt failed: %v", err)
+		}
+		if promptErr != nil {
+			t.Error(promptErr)
 		}
 	})
 }

--- a/mcp/sampling_test.go
+++ b/mcp/sampling_test.go
@@ -78,7 +78,7 @@ func TestSamplingWithTools_ToolUse(t *testing.T) {
 		},
 		ToolChoice: &ToolChoice{Mode: "auto"},
 	}
-	gotResult, err := ss.CreateMessageWithTools(ctx, params)
+	gotResult, err := ss.CreateMessageWithTools(clientRequestCtx(ctx), params)
 	if err != nil {
 		t.Fatalf("CreateMessageWithTools() error = %v", err)
 	}
@@ -143,7 +143,7 @@ func TestSamplingWithTools_ToolResult(t *testing.T) {
 			}},
 		},
 	}
-	_, err = ss.CreateMessage(ctx, params)
+	_, err = ss.CreateMessage(clientRequestCtx(ctx), params)
 	if err != nil {
 		t.Fatalf("CreateMessage() error = %v", err)
 	}
@@ -308,7 +308,7 @@ func TestSamplingWithTools_ToolResultWithError(t *testing.T) {
 			}},
 		},
 	}
-	_, err = ss.CreateMessage(ctx, params)
+	_, err = ss.CreateMessage(clientRequestCtx(ctx), params)
 	if err != nil {
 		t.Fatalf("CreateMessage() error = %v", err)
 	}
@@ -354,7 +354,7 @@ func TestSamplingWithTools_ParallelToolCalls(t *testing.T) {
 	}
 	defer cs.Close()
 
-	gotResult, err := ss.CreateMessageWithTools(ctx, &CreateMessageWithToolsParams{
+	gotResult, err := ss.CreateMessageWithTools(clientRequestCtx(ctx), &CreateMessageWithToolsParams{
 		MaxTokens: 1000,
 		Messages: []*SamplingMessageV2{
 			{Role: "user", Content: []Content{&TextContent{Text: "Weather in SF and NY"}}},
@@ -425,7 +425,7 @@ func TestCreateMessage_MultipleContentError(t *testing.T) {
 	defer cs.Close()
 
 	// Server calls CreateMessage (singular), should get error
-	_, err = ss.CreateMessage(ctx, &CreateMessageParams{
+	_, err = ss.CreateMessage(clientRequestCtx(ctx), &CreateMessageParams{
 		MaxTokens: 100,
 		Messages:  []*SamplingMessage{{Role: "user", Content: &TextContent{Text: "hi"}}},
 	})

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1172,6 +1172,9 @@ func (ss *ServerSession) Ping(ctx context.Context, params *PingParams) error {
 
 // ListRoots lists the client roots.
 func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams) (*ListRootsResult, error) {
+	if err := checkClientRequestContext(ctx); err != nil {
+		return nil, err
+	}
 	if err := ss.checkInitialized(methodListRoots); err != nil {
 		return nil, err
 	}
@@ -1184,6 +1187,9 @@ func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams)
 // CreateMessage returns an error. Use [ServerSession.CreateMessageWithTools]
 // for tool-enabled sampling.
 func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessageParams) (*CreateMessageResult, error) {
+	if err := checkClientRequestContext(ctx); err != nil {
+		return nil, err
+	}
 	if err := ss.checkInitialized(methodCreateMessage); err != nil {
 		return nil, err
 	}
@@ -1221,6 +1227,9 @@ func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessag
 // (for parallel tool calls). Use this instead of [ServerSession.CreateMessage]
 // when the request includes tools.
 func (ss *ServerSession) CreateMessageWithTools(ctx context.Context, params *CreateMessageWithToolsParams) (*CreateMessageWithToolsResult, error) {
+	if err := checkClientRequestContext(ctx); err != nil {
+		return nil, err
+	}
 	if err := ss.checkInitialized(methodCreateMessage); err != nil {
 		return nil, err
 	}
@@ -1237,6 +1246,9 @@ func (ss *ServerSession) CreateMessageWithTools(ctx context.Context, params *Cre
 
 // Elicit sends an elicitation request to the client asking for user input.
 func (ss *ServerSession) Elicit(ctx context.Context, params *ElicitParams) (*ElicitResult, error) {
+	if err := checkClientRequestContext(ctx); err != nil {
+		return nil, err
+	}
 	if err := ss.checkInitialized(methodElicit); err != nil {
 		return nil, err
 	}
@@ -1445,10 +1457,9 @@ func (ss *ServerSession) handle(ctx context.Context, req *jsonrpc.Request) (any,
 		jsonrpc2.Async(ctx)
 	}
 
-	// For the streamable transport, we need the request ID to correlate
-	// server->client calls and notifications to the incoming request from which
-	// they originated. See [idContextKey] for details.
-	ctx = context.WithValue(ctx, idContextKey{}, req.ID)
+	// Store the originating client request ID in the context. See
+	// [clientRequestIDKey] for details.
+	ctx = context.WithValue(ctx, clientRequestIDKey{}, req.ID)
 	return handleReceive(ctx, ss, req)
 }
 
@@ -1608,4 +1619,28 @@ func paginateList[P listParams, R listResult[T], T any](fs *featureSet[T], pageS
 	}
 	*res.nextCursorPtr() = nextCursor
 	return res, nil
+}
+
+// clientRequestIDKey stores the originating client request ID in the context.
+//
+// This serves two purposes:
+//  1. Transport routing: the streamable HTTP transport uses this to correlate
+//     server-to-client calls and notifications with the incoming request that
+//     caused them, so they can be dispatched on the correct SSE stream.
+//  2. SEP-2260 enforcement: server-to-client requests (roots/list,
+//     sampling/createMessage, elicitation/create) MUST be associated with an
+//     originating client request. Ping is exempt.
+//
+// The value is set in [ServerSession.handle] for every incoming client message.
+type clientRequestIDKey struct{}
+
+// checkClientRequestContext verifies that ctx carries a client request ID,
+// indicating that the call is being made within the scope of handling a client
+// request. Per SEP-2260, server-to-client requests (except ping) must not be
+// sent outside this scope.
+func checkClientRequestContext(ctx context.Context) error {
+	if ctx.Value(clientRequestIDKey{}) == nil {
+		return fmt.Errorf("server-to-client request must be made within the scope of a client request")
+	}
+	return nil
 }

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -880,29 +880,6 @@ func (c *streamableServerConn) newStream(ctx context.Context, requests map[jsonr
 	}, nil
 }
 
-// We track the incoming request ID inside the handler context using
-// idContextValue, so that notifications and server->client calls that occur in
-// the course of handling incoming requests are correlated with the incoming
-// request that caused them, and can be dispatched as server-sent events to the
-// correct HTTP request.
-//
-// Currently, this is implemented in [ServerSession.handle]. This is not ideal,
-// because it means that a user of the MCP package couldn't implement the
-// streamable transport, as they'd lack this privileged access.
-//
-// If we ever wanted to expose this mechanism, we have a few options:
-//  1. Make ServerSession an interface, and provide an implementation of
-//     ServerSession to handlers that closes over the incoming request ID.
-//  2. Expose a 'HandlerTransport' interface that allows transports to provide
-//     a handler middleware, so that we don't hard-code this behavior in
-//     ServerSession.handle.
-//  3. Add a `func ForRequest(context.Context) jsonrpc.ID` accessor that lets
-//     any transport access the incoming request ID.
-//
-// For now, by giving only the StreamableServerTransport access to the request
-// ID, we avoid having to make this API decision.
-type idContextKey struct{}
-
 // ServeHTTP handles a single HTTP request for the session.
 func (t *StreamableServerTransport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if t.connection == nil {
@@ -1382,7 +1359,7 @@ func (c *streamableServerConn) Write(ctx context.Context, msg jsonrpc.Message) e
 		// Otherwise, we check to see if it request was made in the context of an
 		// ongoing request. This may not be the case if the request was made with
 		// an unrelated context.
-		if v := ctx.Value(idContextKey{}); v != nil {
+		if v := ctx.Value(clientRequestIDKey{}); v != nil {
 			relatedRequest = v.(jsonrpc.ID)
 		}
 	}

--- a/mcp/streamable_server.go
+++ b/mcp/streamable_server.go
@@ -93,7 +93,7 @@ When the server writes a message, it must be routed to the correct [stream]:
 
 This routing is implemented using:
   - [streamableServerConn.requestStreams] maps request IDs to stream IDs
-  - [idContextKey] is used to store the originating request ID in Context
+  - [clientRequestIDKey] is used to store the originating request ID in Context
   - [streamableServerConn.streams] maps stream IDs to [stream] objects
 
 # Stream Resumption

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -98,11 +98,11 @@ func TestStreamableTransports(t *testing.T) {
 				}
 				// Test that we can make sampling requests during tool handling.
 				//
-				// Try this on both the request context and a background context, so
-				// that messages may be delivered on either the POST or GET connection.
+				// server-to-client requests must be made within the
+				// scope of a client request, so only the request context succeeds.
 				for _, test := range []testCase{
 					{"request context", ctx, true},
-					{"background context", context.Background(), true},
+					{"background context", context.Background(), false},
 				} {
 					testSample(test)
 				}
@@ -110,11 +110,12 @@ func TestStreamableTransports(t *testing.T) {
 				// check behavior when the client request has completed.
 				sampleWG.Go(func() {
 					<-sampleDone
-					// Test that sampling requests in the tool context fail outside of
-					// tool handling, but succeed on the background context.
+					// After the tool handler returns, both contexts should fail:
+					// the request context because the request is done, and the
+					// background context because it lacks a client request ID.
 					for _, test := range []testCase{
 						{"request context", ctx, false},
-						{"background context", context.Background(), true},
+						{"background context", context.Background(), false},
 					} {
 						testSample(test)
 					}
@@ -1069,47 +1070,32 @@ func TestStreamableServerTransport(t *testing.T) {
 		},
 		{
 			name: "background",
-			// Enabling replay is necessary here because the standalone "GET" request
-			// is fully asynchronous. Replay is needed to guarantee message delivery.
-			//
-			// TODO(rfindley): this should no longer be necessary.
+			// server-to-client requests (like ListRoots) must be
+			// made within the scope of a client request, so using a background
+			// context is prohibited. Notifications are allowed.
 			replay: true,
 			tool: func(t *testing.T, _ context.Context, req *CallToolRequest) {
-				// Perform operations on a background context, and ensure the client
-				// receives it.
 				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 				defer cancel()
 
 				if err := req.Session.NotifyProgress(ctx, &ProgressNotificationParams{}); err != nil {
 					t.Errorf("Notify failed: %v", err)
 				}
-				// TODO(rfindley): finish implementing logging.
-				// if err := ss.LoggingMessage(ctx, &LoggingMessageParams{}); err != nil {
-				// 	t.Errorf("Logging failed: %v", err)
-				// }
-				if _, err := req.Session.ListRoots(ctx, &ListRootsParams{}); err != nil {
-					t.Errorf("ListRoots failed: %v", err)
+				// ListRoots on a background context should fail.
+				if _, err := req.Session.ListRoots(ctx, &ListRootsParams{}); err == nil {
+					t.Errorf("ListRoots on background context: got nil error, want error")
 				}
 			},
 			requests: []streamableRequest{
 				initialize,
 				initialized,
 				{
-					method:    "POST",
-					onRequest: 1,
-					messages: []jsonrpc.Message{
-						resp(1, &ListRootsResult{}, nil),
-					},
-					wantStatusCode: http.StatusAccepted,
-				},
-				{
 					method:         "GET",
 					async:          true,
 					wantStatusCode: http.StatusOK,
-					closeAfter:     2,
+					closeAfter:     1,
 					wantMessages: []jsonrpc.Message{
 						req(0, "notifications/progress", &ProgressNotificationParams{}),
-						req(1, "roots/list", &ListRootsParams{}),
 					},
 				},
 				{
@@ -1131,6 +1117,30 @@ func TestStreamableServerTransport(t *testing.T) {
 				},
 			},
 			wantSessions: 0, // session deleted
+		},
+		{
+			name: "notification in post",
+			tool: func(t *testing.T, ctx context.Context, req *CallToolRequest) {
+				if err := req.Session.NotifyProgress(ctx, &ProgressNotificationParams{}); err != nil {
+					t.Errorf("Notify failed: %v", err)
+				}
+			},
+			requests: []streamableRequest{
+				initialize,
+				initialized,
+				{
+					method: "POST",
+					messages: []jsonrpc.Message{
+						req(2, "tools/call", &CallToolParams{Name: "tool"}),
+					},
+					wantStatusCode: http.StatusOK,
+					wantMessages: []jsonrpc.Message{
+						req(0, "notifications/progress", &ProgressNotificationParams{}),
+						resp(2, &CallToolResult{Content: []Content{}}, nil),
+					},
+				},
+			},
+			wantSessions: 1,
 		},
 		{
 			name:   "no priming message on old protocol",


### PR DESCRIPTION
## Description 

Implements [SEP-2260](https://modelcontextprotocol.io/seps/2260-Require-Server-requests-to-be-associated-with-Client-requests)

Fixes #914 
