### PR TITLE
fix: add panic recovery to goroutines that execute user code

### DIFF
--- a/internal/jsonrpc2/conn.go
+++ b/internal/jsonrpc2/conn.go
@@ -639,6 +639,11 @@ func (c *Connection) handleAsync() {
 		ctx := context.WithValue(req.ctx, asyncKey, releaser)
 		go func() {
 			defer releaser.release(true)
+			defer func() {
+				if r := recover(); r != nil {
+					c.processResult(c.handler, req, nil, fmt.Errorf("%w: panic in handler: %v", ErrInternal, r))
+				}
+			}()
 			result, err := c.handler.Handle(ctx, req.Request)
 			c.processResult(c.handler, req, result, err)
 		}()

--- a/mcp/panic_recovery_test.go
+++ b/mcp/panic_recovery_test.go
@@ -1,0 +1,106 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// TestToolHandler_PanicRecovery verifies that a panicking tool handler does
+// not crash the server process. The panic should be recovered and returned
+// as a JSON-RPC internal error to the client.
+func TestToolHandler_PanicRecovery(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ct, st := NewInMemoryTransports()
+
+	s := NewServer(testImpl, nil)
+	AddTool(s, &Tool{
+		Name:        "panic-tool",
+		Description: "a tool that panics",
+		InputSchema: &jsonschema.Schema{Type: "object"},
+	}, func(_ context.Context, _ *CallToolRequest, _ map[string]any) (*CallToolResult, any, error) {
+		panic("deliberate panic in tool handler")
+	})
+
+	ss, err := s.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	c := NewClient(testImpl, nil)
+	cs, err := c.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	// Call the panicking tool. Without recovery, this crashes the process.
+	// With recovery, we get an error response.
+	_, err = cs.CallTool(ctx, &CallToolParams{Name: "panic-tool"})
+
+	// We expect an error (the panic is caught and returned as internal error).
+	if err == nil {
+		t.Fatal("expected error from panicking tool handler, got success")
+	}
+	// The important thing is we reached this line: the process didn't crash.
+}
+
+// TestToolHandler_PanicDoesNotAffectSubsequentCalls verifies that after a
+// panic in one tool handler, the server continues to serve other requests.
+func TestToolHandler_PanicDoesNotAffectSubsequentCalls(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ct, st := NewInMemoryTransports()
+
+	s := NewServer(testImpl, nil)
+	AddTool(s, &Tool{
+		Name:        "panic-tool",
+		Description: "a tool that panics",
+		InputSchema: &jsonschema.Schema{Type: "object"},
+	}, func(_ context.Context, _ *CallToolRequest, _ map[string]any) (*CallToolResult, any, error) {
+		panic("deliberate panic")
+	})
+	AddTool(s, &Tool{
+		Name:        "safe-tool",
+		Description: "a tool that works",
+		InputSchema: &jsonschema.Schema{Type: "object"},
+	}, func(_ context.Context, _ *CallToolRequest, _ map[string]any) (*CallToolResult, any, error) {
+		return &CallToolResult{Content: []Content{&TextContent{Text: "ok"}}}, nil, nil
+	})
+
+	ss, err := s.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	c := NewClient(testImpl, nil)
+	cs, err := c.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	// First: call the panicking tool.
+	_, _ = cs.CallTool(ctx, &CallToolParams{Name: "panic-tool"})
+
+	// Second: call the safe tool. This should succeed, proving the server
+	// is still alive after the panic.
+	result, err := cs.CallTool(ctx, &CallToolParams{Name: "safe-tool"})
+	if err != nil {
+		t.Fatalf("safe tool call failed after panic: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result from safe tool, got nil")
+	}
+}

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -606,6 +606,11 @@ func startKeepalive(session keepaliveSession, interval time.Duration, cancelPtr 
 	*cancelPtr = cancel
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error("panic in keepalive goroutine", "error", r)
+			}
+		}()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 

--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net"
 	"net/http"
@@ -420,6 +421,11 @@ func (c *SSEClientTransport) Connect(ctx context.Context) (Connection, error) {
 
 	go func() {
 		defer s.Close() // close the transport when the GET exits
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Default().Error("panic in SSE reader goroutine", "error", r)
+			}
+		}()
 
 		for evt, err := range scanEvents(resp.Body) {
 			if err != nil {

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -2058,6 +2058,11 @@ func (c *streamableClientConn) setMCPHeaders(req *http.Request) error {
 }
 
 func (c *streamableClientConn) handleJSON(requestSummary string, resp *http.Response) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.fail(fmt.Errorf("%s: panic in handleJSON: %v", requestSummary, r))
+		}
+	}()
 	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
@@ -2083,6 +2088,11 @@ func (c *streamableClientConn) handleJSON(requestSummary string, resp *http.Resp
 // stream is complete when we receive its response. Otherwise, this is the
 // standalone stream.
 func (c *streamableClientConn) handleSSE(ctx context.Context, requestSummary string, resp *http.Response, forCall *jsonrpc2.Request) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.fail(fmt.Errorf("%s: panic in handleSSE: %v", requestSummary, r))
+		}
+	}()
 	// Track the last event ID to detect progress.
 	// The retry counter is only reset when progress is made (lastEventID advances).
 	// This prevents infinite retry loops when a server repeatedly terminates

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -403,6 +403,14 @@ func newIOConn(rwc io.ReadWriteCloser) *ioConn {
 	// but that is unavoidable since AFAIK there is no (easy and portable) way to
 	// guarantee that reads of stdin are unblocked when closed.
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				select {
+				case incoming <- msgOrErr{err: fmt.Errorf("panic in reader: %v", r)}:
+				case <-closed:
+				}
+			}
+		}()
 		dec := json.NewDecoder(rwc)
 		for {
 			var raw json.RawMessage


### PR DESCRIPTION
Implementation for #958.

## Problem

Library goroutines that dispatch user-provided handlers (tool handlers, middleware, etc.) lack `defer recover()`. A panic in user code crashes the entire host process.

As a library, the SDK doesn't own the process, doesn't control the supervisor, and doesn't know what else runs in the same address space. A panicking goroutine takes down the consumer's HTTP server, metrics exporters, graceful shutdown hooks, and any other in-flight work.

## Fix

Add recovery to 5 goroutine sites:

| File | Goroutine | Recovery behavior |
|------|-----------|-------------------|
| `internal/jsonrpc2/conn.go` | `handleAsync` handler dispatch | Sends INTERNAL_ERROR JSON-RPC response to client |
| `mcp/shared.go` | keepalive goroutine | Logs via structured logger, goroutine exits |
| `mcp/sse.go` | SSE reader goroutine | Logs via `slog.Default()`, `defer Close()` still fires |
| `mcp/streamable.go` | `handleJSON` response processor | Calls `c.fail()` to signal connection error |
| `mcp/streamable.go` | `handleSSE` stream processor | Calls `c.fail()` to signal connection error |
| `mcp/transport.go` | stdio reader goroutine | Sends error on incoming channel |

The critical path is `handleAsync` in `internal/jsonrpc2/conn.go`: this is where ALL tool, prompt, and resource handlers execute. A panicking tool handler currently kills the process; with this fix it returns an error response to the client and the server continues serving other sessions.

## Tests

- `TestToolHandler_PanicRecovery`: registers a tool that panics, calls it, verifies process survives and error is returned
- `TestToolHandler_PanicDoesNotAffectSubsequentCalls`: panics one tool, then calls a different tool successfully, proving the server continues operating

Both tests crash without the fix (verified by reverting and running).

## Notes

- Defer order is verified correct in all sites (LIFO semantics)
- `go vet`, `-race`, and full test suite pass
- Happy to adjust the approach based on feedback from #958