### PR TITLE
streamable: validate Mcp-Protocol-Version header matches body protocolVersion on initialize

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -1322,6 +1322,27 @@ func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Reques
 		}
 	}
 
+	// If the client sent both a Mcp-Protocol-Version header and an initialize
+	// request with a protocolVersion field, verify they match.
+	if isInitialize && initializeProtocolVersion != "" && protocolVersion != "" && initializeProtocolVersion != protocolVersion {
+		resp := &jsonrpc.Response{
+			Error: jsonrpc2.NewError(CodeHeaderMismatch, fmt.Sprintf("protocol version mismatch: Mcp-Protocol-Version header '%s' does not match body protocolVersion '%s'", protocolVersion, initializeProtocolVersion)),
+		}
+		// Find the initialize request to get its ID.
+		for _, msg := range incoming {
+			if jreq, ok := msg.(*jsonrpc.Request); ok && jreq.Method == methodInitialize {
+				resp.ID = jreq.ID
+				break
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		if data, err := jsonrpc2.EncodeMessage(resp); err == nil {
+			w.Write(data)
+		}
+		return
+	}
+
 	// Validate MCP standard headers (Mcp-Method, Mcp-Name, Mcp-Param-*)
 	if !isBatch && len(incoming) == 1 {
 		if err := validateMcpHeaders(req.Header, incoming[0], c.toolLookup); err != nil {

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -1256,6 +1256,20 @@ func TestStreamableServerTransport(t *testing.T) {
 			},
 			wantSessions: 0,
 		},
+		{
+			name: "protocol version mismatch",
+			requests: []streamableRequest{
+				{
+					method: "POST",
+					headers: http.Header{protocolVersionHeader: {protocolVersion20251125}},
+					messages: []jsonrpc.Message{req(1, methodInitialize, &InitializeParams{ProtocolVersion: protocolVersion20250618})},
+					wantStatusCode: http.StatusBadRequest,
+					wantBodyContaining: "protocol version mismatch",
+					wantSessionID: false,
+				},
+			},
+			wantSessions: 0,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Fix #963

The Streamable HTTP server now validates that the Mcp-Protocol-Version header matches the protocolVersion field in the initialize request body. Previously, mismatched versions were silently accepted.

## Changes

- mcp/streamable.go: In servePOST, after extracting protocolVersion from both the HTTP header and the initialize body params, compare them. If both are present and differ, return a CodeHeaderMismatch (-32001) error with a 400 status.
- mcp/streamable_test.go: Add test case "protocol version mismatch" that sends an initialize request with header 2025-11-25 but body 2025-06-18, verifying a 400 Bad Request response.

## Testing

go test ./mcp/ -run TestStreamableServerTransport/protocol_version_mismatch -v
# PASS