### PR TITLE
fix: preserve empty-method requests during decode

### DIFF
--- a/internal/jsonrpc2/messages.go
+++ b/internal/jsonrpc2/messages.go
@@ -183,7 +183,11 @@ func DecodeMessage(data []byte) (Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	if msg.Method != "" {
+	var fields map[string]json.RawMessage
+	if err := internaljson.Unmarshal(data, &fields); err != nil {
+		return nil, fmt.Errorf("unmarshaling jsonrpc message fields: %w", err)
+	}
+	if _, hasMethod := fields["method"]; hasMethod {
 		// has a method, must be a call
 		return &Request{
 			Method: msg.Method,

--- a/internal/jsonrpc2/wire_test.go
+++ b/internal/jsonrpc2/wire_test.go
@@ -63,6 +63,23 @@ func TestWireMessage(t *testing.T) {
 	}
 }
 
+func TestDecodeMessageWithEmptyMethodIsRequest(t *testing.T) {
+	msg, err := jsonrpc2.DecodeMessage([]byte(`{"jsonrpc":"2.0","id":5,"method":"","params":{}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, ok := msg.(*jsonrpc2.Request)
+	if !ok {
+		t.Fatalf("DecodeMessage returned %T, want *jsonrpc2.Request", msg)
+	}
+	if req.Method != "" {
+		t.Fatalf("Request.Method = %q, want empty string", req.Method)
+	}
+	if got := req.ID.Raw(); got != int64(5) {
+		t.Fatalf("Request.ID = %v, want 5", got)
+	}
+}
+
 func newNotification(method string, params any) jsonrpc2.Message {
 	msg, err := jsonrpc2.NewNotification(method, params)
 	if err != nil {


### PR DESCRIPTION
﻿## Summary

Fixes #976.

`DecodeMessage` used `msg.Method != ""` to distinguish requests from responses. That means a wire payload with a present but empty `method` field, such as:

```json
{"jsonrpc":"2.0","id":5,"method":"","params":{}}
```

was decoded as a response instead of a request. Since there was no matching outgoing call, the server ignored it and did not send a correlated JSON-RPC error, even though the session stayed alive.

This PR checks whether the wire payload contains the `method` field instead of checking whether the decoded string is non-empty. An empty method now reaches the normal request dispatch path and receives the existing method-not-found handling.

## Tests

```text
go test ./internal/jsonrpc2
go test ./mcp
go test ./...
git diff --check
```
