### PR TITLE
fix: add implementation description metadata

### DIFF
--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -1935,16 +1935,18 @@ type ElicitationCompleteParams struct {
 func (x *ElicitationCompleteParams) isParams()   {}
 func (x *ElicitationCompleteParams) isNil() bool { return x == nil }
 
-// An Implementation describes the name and version of an MCP implementation, with an optional
-// title for UI representation.
+// An Implementation describes the name and version of an MCP implementation, with
+// optional display metadata.
 type Implementation struct {
 	// Intended for programmatic or logical use, but used as a display name in past
 	// specs or fallback (if title isn't present).
 	Name string `json:"name"`
 	// Intended for UI and end-user contexts — optimized to be human-readable and
 	// easily understood, even by those unfamiliar with domain-specific terminology.
-	Title   string `json:"title,omitempty"`
-	Version string `json:"version"`
+	Title string `json:"title,omitempty"`
+	// A human-readable description of the implementation.
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version"`
 	// WebsiteURL for the server, if any.
 	WebsiteURL string `json:"websiteUrl,omitempty"`
 	// Icons for the Server, if any.

--- a/mcp/shared_test.go
+++ b/mcp/shared_test.go
@@ -245,6 +245,39 @@ func TestServerRequest_PerRequestAccessors_Empty(t *testing.T) {
 	}
 }
 
+func TestImplementationDescriptionJSON(t *testing.T) {
+	impl := &Implementation{
+		Name:        "greeter",
+		Title:       "Greeter",
+		Description: "Example server for greeting tools",
+		Version:     "v1.0.0",
+	}
+	got, err := json.Marshal(impl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"name":"greeter","title":"Greeter","description":"Example server for greeting tools","version":"v1.0.0"}`
+	if string(got) != want {
+		t.Fatalf("Implementation JSON = %s, want %s", got, want)
+	}
+
+	var roundTrip Implementation
+	if err := json.Unmarshal(got, &roundTrip); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(impl, &roundTrip); diff != "" {
+		t.Fatalf("Implementation round trip mismatch (-want +got):\n%s", diff)
+	}
+
+	got, err = json.Marshal(&Implementation{Name: "greeter", Version: "v1.0.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "description") {
+		t.Fatalf("empty description should be omitted, got %s", got)
+	}
+}
+
 // TODO(v0.3.0): rewrite this test.
 // func TestToolValidate(t *testing.T) {
 // 	// Check that the tool returned from NewServerTool properly validates its input schema.


### PR DESCRIPTION
## Summary
- add the optional `description` field to `mcp.Implementation`
- keep the field omitted when empty
- cover JSON marshal/unmarshal behavior with a focused regression test

Fixes #977.

## To verify
- `go test ./mcp -run TestImplementationDescriptionJSON -count=1`
- `go test ./mcp -run TestServerRequest_PerRequestAccessors -count=1`
- `go test ./mcp -count=1`
- `go test ./...`
- `git diff --check`
