### PR TITLE
fix: decode empty jsonrpc methods as requests

### DIFF
--- a/internal/jsonrpc2/messages.go
+++ b/internal/jsonrpc2/messages.go
@@ -109,7 +109,7 @@ func (msg *Request) IsCall() bool { return msg.ID.IsValid() }
 
 func (msg *Request) marshal(to *wireCombined) {
 	to.ID = msg.ID.value
-	to.Method = msg.Method
+	to.Method = &msg.Method
 	to.Params = msg.Params
 }
 
@@ -183,10 +183,10 @@ func DecodeMessage(data []byte) (Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	if msg.Method != "" {
+	if msg.Method != nil {
 		// has a method, must be a call
 		return &Request{
-			Method: msg.Method,
+			Method: *msg.Method,
 			ID:     id,
 			Params: msg.Params,
 		}, nil

--- a/internal/jsonrpc2/wire.go
+++ b/internal/jsonrpc2/wire.go
@@ -54,7 +54,7 @@ const wireVersion = "2.0"
 type wireCombined struct {
 	VersionTag string          `json:"jsonrpc"`
 	ID         any             `json:"id,omitempty"`
-	Method     string          `json:"method,omitempty"`
+	Method     *string         `json:"method,omitempty"`
 	Params     json.RawMessage `json:"params,omitempty"`
 	Result     json.RawMessage `json:"result,omitempty"`
 	Error      *WireError      `json:"error,omitempty"`

--- a/internal/jsonrpc2/wire_test.go
+++ b/internal/jsonrpc2/wire_test.go
@@ -63,6 +63,24 @@ func TestWireMessage(t *testing.T) {
 	}
 }
 
+func TestDecodeEmptyMethodAsRequest(t *testing.T) {
+	msg, err := jsonrpc2.DecodeMessage([]byte(`{"jsonrpc":"2.0","id":5,"method":"","params":{}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, ok := msg.(*jsonrpc2.Request)
+	if !ok {
+		t.Fatalf("decoded message is %T, want *jsonrpc2.Request", msg)
+	}
+	if req.ID.Raw() != int64(5) {
+		t.Fatalf("request id = %v, want 5", req.ID.Raw())
+	}
+	if req.Method != "" {
+		t.Fatalf("request method = %q, want empty string", req.Method)
+	}
+}
+
 func newNotification(method string, params any) jsonrpc2.Message {
 	msg, err := jsonrpc2.NewNotification(method, params)
 	if err != nil {


### PR DESCRIPTION
﻿Fixes #976.

An incoming JSON-RPC message with an explicit empty method field was decoded as a response because the wire struct could not distinguish a missing method from an empty method. That meant stdio servers silently ignored requests like id=5/method="" instead of routing them through request handling and returning a correlated JSON-RPC error.

This keeps method presence during decode by storing the wire method as a pointer, then decodes method="" as a Request. The existing dispatch path can then return method-not-found for the request id while leaving the session alive.

Validation:
- go test ./internal/jsonrpc2
- go test ./mcp -run "TestIOConnRead|TestServerSessionHandle|TestKeepAliveMethodNotFound"
- go test ./...
