### PR TITLE
mcp: add MCPGPDEBUG for opt-in Content-Type check

### DIFF
--- a/docs/mcpgodebug.md
+++ b/docs/mcpgodebug.md
@@ -50,6 +50,15 @@ Options listed below were added and will be removed in the 1.9.0 version of the 
   restoring the previous behavior. The default behavior was changed so that
   the client always attempts to surface the underlying JSON-RPC error.
 
+### 1.6.1
+
+Options listed below were added and will be removed in the 1.8.0 version of the SDK.
+
+- `disablecontenttypecheck` added. If set to `1`, Content-Type validation on
+  HTTP POST requests will be disabled, allowing requests with non-JSON or missing
+  Content-Type headers. The default behavior is to validate that HTTP POST
+  requests have Content-Type: application/json.
+
 ### 1.6.0
 
 Options listed below were added and will be removed in the 1.8.0 version of the SDK.

--- a/internal/docs/mcpgodebug.src.md
+++ b/internal/docs/mcpgodebug.src.md
@@ -49,6 +49,15 @@ Options listed below were added and will be removed in the 1.9.0 version of the 
   restoring the previous behavior. The default behavior was changed so that
   the client always attempts to surface the underlying JSON-RPC error.
 
+### 1.6.1
+
+Options listed below were added and will be removed in the 1.8.0 version of the SDK.
+
+- `disablecontenttypecheck` added. If set to `1`, Content-Type validation on
+  HTTP POST requests will be disabled, allowing requests with non-JSON or missing
+  Content-Type headers. The default behavior is to validate that HTTP POST
+  requests have Content-Type: application/json.
+
 ### 1.6.0
 
 Options listed below were added and will be removed in the 1.8.0 version of the SDK.

--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -202,7 +202,7 @@ func (h *SSEHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Validate 'Content-Type' header.
-	if req.Method == http.MethodPost {
+	if disablecontenttypecheck != "1" && req.Method == http.MethodPost {
 		mediaType, _, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
 		if err != nil || mediaType != "application/json" {
 			http.Error(w, "Content-Type must be 'application/json'", http.StatusUnsupportedMediaType)

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -271,6 +271,12 @@ var allowsessionsinstateless = mcpgodebug.Value("allowsessionsinstateless")
 // the client always attempts to surface the underlying JSON-RPC error.
 var noprotocolerrorbody = mcpgodebug.Value("noprotocolerrorbody")
 
+// disablecontenttypecheck is a compatibility parameter that allows to disable
+// Content-Type validation on POST requests.
+// See the documentation for the mcpgodebug package for instructions how to enable it.
+// The option will be removed in the 1.8.0 version of the SDK.
+var disablecontenttypecheck = mcpgodebug.Value("disablecontenttypecheck")
+
 // writeJSONRPCError writes a JSON-RPC error response with the given HTTP
 // status code, request ID (may be a zero ID for errors that occur before the
 // request body has been parsed), and JSON-RPC error.
@@ -342,7 +348,7 @@ func (h *StreamableHTTPHandler) serveStateless(w http.ResponseWriter, req *http.
 		return
 	}
 
-	if baseMediaType(req.Header.Get("Content-Type")) != "application/json" {
+	if disablecontenttypecheck != "1" && baseMediaType(req.Header.Get("Content-Type")) != "application/json" {
 		http.Error(w, "Content-Type must be 'application/json'", http.StatusUnsupportedMediaType)
 		return
 	}
@@ -560,7 +566,7 @@ func (h *StreamableHTTPHandler) serveStatefulDELETE(w http.ResponseWriter, req *
 // ID, a new session is created (this is the normal path for the first
 // initialize request).
 func (h *StreamableHTTPHandler) serveStatefulPOST(w http.ResponseWriter, req *http.Request) {
-	if baseMediaType(req.Header.Get("Content-Type")) != "application/json" {
+	if disablecontenttypecheck != "1" && baseMediaType(req.Header.Get("Content-Type")) != "application/json" {
 		http.Error(w, "Content-Type must be 'application/json'", http.StatusUnsupportedMediaType)
 		return
 	}


### PR DESCRIPTION
Copy of existing [PR](https://github.com/modelcontextprotocol/go-sdk/pull/972) patching 1.6.0 version
