### PR TITLE
mcp: deprecate roots, sampling, and logging (SEP-2577)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The following table shows which versions of the Go SDK support which versions of
 
 \*\* Partial support for 2025-11-25 (client side OAuth and Sampling with tools not available).
 
+The roots, sampling, and logging features are deprecated by
+[SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+The SDK continues to support them for compatibility.
+
 New releases of the SDK target only supported versions of Go. See
 https://go.dev/doc/devel/release#policy for more information.
 

--- a/conformance/everything-server/main.go
+++ b/conformance/everything-server/main.go
@@ -5,6 +5,8 @@
 // The conformance server implements features required for MCP conformance testing.
 // It mirrors the functionality of the TypeScript conformance server at
 // https://github.com/modelcontextprotocol/conformance/blob/main/examples/servers/typescript/everything-server.ts
+//
+//lint:file-ignore SA1019 conformance server exercises deprecated SEP-2577 APIs
 package main
 
 import (

--- a/docs/client.md
+++ b/docs/client.md
@@ -10,6 +10,9 @@
 
 ## Roots
 
+> **Note:** The roots feature is deprecated by [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+> The SDK continues to support roots for compatibility.
+
 MCP allows clients to specify a set of filesystem
 ["roots"](https://modelcontextprotocol.io/specification/2025-06-18/client/roots).
 The SDK supports this as follows:
@@ -76,6 +79,9 @@ func Example_roots() {
 ```
 
 ## Sampling
+
+> **Note:** The sampling feature is deprecated by [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+> The SDK continues to support sampling for compatibility.
 
 [Sampling](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling)
 is a way for servers to leverage the client's AI capabilities. It is

--- a/docs/server.md
+++ b/docs/server.md
@@ -474,6 +474,9 @@ _ = mcp.NewServer(&mcp.Implementation{Name: "server"}, &mcp.ServerOptions{
 
 ### Logging
 
+> **Note:** The logging feature is deprecated by [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+> The SDK continues to support logging for compatibility.
+
 MCP servers can send logging messages to MCP clients.
 (This form of logging is distinct from server-side logging, where the
 server produces logs that remain server-side, for use by server maintainers.)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,9 @@ SDK, as well as inspecting MCP traffic.
 
 ## Collecting MCP logs
 
+> **Note:** `LoggingTransport` is deprecated by [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+> It remains available for debugging.
+
 For [stdio](protocol.md#stdio-transport) transport connections, you can also
 inspect MCP traffic using a `LoggingTransport`:
 

--- a/examples/server/distributed/main.go
+++ b/examples/server/distributed/main.go
@@ -16,6 +16,8 @@
 // Example:
 //
 //	./distributed -http=localhost:8080 -child_ports=8081,8082
+//
+//lint:file-ignore SA1019 example server exercises deprecated SEP-2577 APIs
 package main
 
 import (

--- a/examples/server/everything/main.go
+++ b/examples/server/everything/main.go
@@ -3,6 +3,8 @@
 // license that can be found in the LICENSE file.
 
 // The everything server implements all supported features of an MCP server.
+//
+//lint:file-ignore SA1019 example server exercises deprecated SEP-2577 APIs
 package main
 
 import (

--- a/examples/server/memory/main.go
+++ b/examples/server/memory/main.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//lint:file-ignore SA1019 example server exercises deprecated SEP-2577 APIs
 package main
 
 import (

--- a/examples/server/sequentialthinking/main.go
+++ b/examples/server/sequentialthinking/main.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//lint:file-ignore SA1019 example server exercises deprecated SEP-2577 APIs
 package main
 
 import (

--- a/internal/docs/client.src.md
+++ b/internal/docs/client.src.md
@@ -4,6 +4,9 @@
 
 ## Roots
 
+> **Note:** The roots feature is deprecated by [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+> The SDK continues to support roots for compatibility.
+
 MCP allows clients to specify a set of filesystem
 ["roots"](https://modelcontextprotocol.io/specification/2025-06-18/client/roots).
 The SDK supports this as follows:
@@ -25,6 +28,9 @@ method. To receive notifications about root changes, set
 %include ../../mcp/client_example_test.go roots -
 
 ## Sampling
+
+> **Note:** The sampling feature is deprecated by [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+> The SDK continues to support sampling for compatibility.
 
 [Sampling](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling)
 is a way for servers to leverage the client's AI capabilities. It is

--- a/internal/docs/server.src.md
+++ b/internal/docs/server.src.md
@@ -236,6 +236,9 @@ requests.
 
 ### Logging
 
+> **Note:** The logging feature is deprecated by [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+> The SDK continues to support logging for compatibility.
+
 MCP servers can send logging messages to MCP clients.
 (This form of logging is distinct from server-side logging, where the
 server produces logs that remain server-side, for use by server maintainers.)

--- a/internal/docs/troubleshooting.src.md
+++ b/internal/docs/troubleshooting.src.md
@@ -20,6 +20,9 @@ SDK, as well as inspecting MCP traffic.
 
 ## Collecting MCP logs
 
+> **Note:** `LoggingTransport` is deprecated by [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+> It remains available for debugging.
+
 For [stdio](protocol.md#stdio-transport) transport connections, you can also
 inspect MCP traffic using a `LoggingTransport`:
 

--- a/internal/readme/README.src.md
+++ b/internal/readme/README.src.md
@@ -43,6 +43,10 @@ The following table shows which versions of the Go SDK support which versions of
 
 \*\* Partial support for 2025-11-25 (client side OAuth and Sampling with tools not available).
 
+The roots, sampling, and logging features are deprecated by
+[SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+The SDK continues to support them for compatibility.
+
 New releases of the SDK target only supported versions of Go. See
 https://go.dev/doc/devel/release#policy for more information.
 

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -83,8 +83,7 @@ type ClientOptions struct {
 	// non nil value for [ClientCapabilities.Sampling], that value overrides the
 	// inferred capability.
 	//
-	// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-	// This API may be removed in a future release of this SDK.
+	// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 	CreateMessageHandler func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error)
 	// CreateMessageWithToolsHandler handles incoming sampling/createMessage
 	// requests that may involve tool use. It returns
@@ -99,8 +98,7 @@ type ClientOptions struct {
 	// It is a panic to set both CreateMessageHandler and
 	// CreateMessageWithToolsHandler.
 	//
-	// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-	// This API may be removed in a future release of this SDK.
+	// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 	CreateMessageWithToolsHandler func(context.Context, *CreateMessageWithToolsRequest) (*CreateMessageWithToolsResult, error)
 	// ElicitationHandler handles incoming requests for elicitation/create.
 	//
@@ -162,8 +160,7 @@ type ClientOptions struct {
 	PromptListChangedHandler   func(context.Context, *PromptListChangedRequest)
 	ResourceListChangedHandler func(context.Context, *ResourceListChangedRequest)
 	ResourceUpdatedHandler     func(context.Context, *ResourceUpdatedNotificationRequest)
-	// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-	// This API may be removed in a future release of this SDK.
+	// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 	LoggingMessageHandler       func(context.Context, *LoggingMessageRequest)
 	ProgressNotificationHandler func(context.Context, *ProgressNotificationClientRequest)
 	// MultiRoundTrip configures the automatic MultiRoundTrip (Multi Round-Trip Requests) middleware.
@@ -585,8 +582,7 @@ func (cs *ClientSession) startKeepalive(interval time.Duration) {
 // replacing any with the same URIs,
 // and notifies any connected servers.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 func (c *Client) AddRoots(roots ...*Root) {
 	// Only notify if something could change.
 	if len(roots) == 0 {
@@ -600,8 +596,7 @@ func (c *Client) AddRoots(roots ...*Root) {
 // and notifies any connected servers if the list has changed.
 // It is not an error to remove a nonexistent root.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 func (c *Client) RemoveRoots(uris ...string) {
 	changeAndNotify(c, notificationRootsListChanged, &RootsListChangedParams{},
 		func() bool { return c.roots.remove(uris...) })
@@ -1200,8 +1195,7 @@ func (cs *ClientSession) CallTool(ctx context.Context, params *CallToolParams) (
 
 // SetLoggingLevel sets the minimum log level for the server session.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 func (cs *ClientSession) SetLoggingLevel(ctx context.Context, params *SetLoggingLevelParams) error {
 	_, err := handleSend[*emptyResult](ctx, methodSetLevel, newClientRequest(cs, orZero[Params](params)))
 	return err

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -82,6 +82,9 @@ type ClientOptions struct {
 	// &SamplingCapabilities{}. If [ClientOptions.Capabilities] is set and has a
 	// non nil value for [ClientCapabilities.Sampling], that value overrides the
 	// inferred capability.
+	//
+	// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+	// This API may be removed in a future release of this SDK.
 	CreateMessageHandler func(context.Context, *CreateMessageRequest) (*CreateMessageResult, error)
 	// CreateMessageWithToolsHandler handles incoming sampling/createMessage
 	// requests that may involve tool use. It returns
@@ -95,6 +98,9 @@ type ClientOptions struct {
 	//
 	// It is a panic to set both CreateMessageHandler and
 	// CreateMessageWithToolsHandler.
+	//
+	// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+	// This API may be removed in a future release of this SDK.
 	CreateMessageWithToolsHandler func(context.Context, *CreateMessageWithToolsRequest) (*CreateMessageWithToolsResult, error)
 	// ElicitationHandler handles incoming requests for elicitation/create.
 	//
@@ -152,10 +158,12 @@ type ClientOptions struct {
 	// ElicitationCompleteHandler handles incoming notifications for notifications/elicitation/complete.
 	ElicitationCompleteHandler func(context.Context, *ElicitationCompleteNotificationRequest)
 	// Handlers for notifications from the server.
-	ToolListChangedHandler      func(context.Context, *ToolListChangedRequest)
-	PromptListChangedHandler    func(context.Context, *PromptListChangedRequest)
-	ResourceListChangedHandler  func(context.Context, *ResourceListChangedRequest)
-	ResourceUpdatedHandler      func(context.Context, *ResourceUpdatedNotificationRequest)
+	ToolListChangedHandler     func(context.Context, *ToolListChangedRequest)
+	PromptListChangedHandler   func(context.Context, *PromptListChangedRequest)
+	ResourceListChangedHandler func(context.Context, *ResourceListChangedRequest)
+	ResourceUpdatedHandler     func(context.Context, *ResourceUpdatedNotificationRequest)
+	// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+	// This API may be removed in a future release of this SDK.
 	LoggingMessageHandler       func(context.Context, *LoggingMessageRequest)
 	ProgressNotificationHandler func(context.Context, *ProgressNotificationClientRequest)
 	// MultiRoundTrip configures the automatic MultiRoundTrip (Multi Round-Trip Requests) middleware.
@@ -576,6 +584,9 @@ func (cs *ClientSession) startKeepalive(interval time.Duration) {
 // AddRoots adds the given roots to the client,
 // replacing any with the same URIs,
 // and notifies any connected servers.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 func (c *Client) AddRoots(roots ...*Root) {
 	// Only notify if something could change.
 	if len(roots) == 0 {
@@ -588,6 +599,9 @@ func (c *Client) AddRoots(roots ...*Root) {
 // RemoveRoots removes the roots with the given URIs,
 // and notifies any connected servers if the list has changed.
 // It is not an error to remove a nonexistent root.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 func (c *Client) RemoveRoots(uris ...string) {
 	changeAndNotify(c, notificationRootsListChanged, &RootsListChangedParams{},
 		func() bool { return c.roots.remove(uris...) })
@@ -1184,6 +1198,10 @@ func (cs *ClientSession) CallTool(ctx context.Context, params *CallToolParams) (
 	return handleSend[*CallToolResult](ctx, methodCallTool, newClientRequest(cs, orZero[Params](params)))
 }
 
+// SetLoggingLevel sets the minimum log level for the server session.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 func (cs *ClientSession) SetLoggingLevel(ctx context.Context, params *SetLoggingLevelParams) error {
 	_, err := handleSend[*emptyResult](ctx, methodSetLevel, newClientRequest(cs, orZero[Params](params)))
 	return err

--- a/mcp/logging.go
+++ b/mcp/logging.go
@@ -69,6 +69,9 @@ func compareLevels(l1, l2 LoggingLevel) int {
 }
 
 // LoggingHandlerOptions are options for a LoggingHandler.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 type LoggingHandlerOptions struct {
 	// The value for the "logger" field of logging notifications.
 	LoggerName string
@@ -79,6 +82,9 @@ type LoggingHandlerOptions struct {
 }
 
 // A LoggingHandler is a [slog.Handler] for MCP.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 type LoggingHandler struct {
 	opts LoggingHandlerOptions
 	ss   *ServerSession
@@ -101,6 +107,9 @@ func ensureLogger(l *slog.Logger) *slog.Logger {
 
 // NewLoggingHandler creates a [LoggingHandler] that logs to the given [ServerSession] using a
 // [slog.JSONHandler].
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 func NewLoggingHandler(ss *ServerSession, opts *LoggingHandlerOptions) *LoggingHandler {
 	var buf bytes.Buffer
 	jsonHandler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
@@ -194,5 +203,5 @@ func (h *LoggingHandler) handle(ctx context.Context, r slog.Record) error {
 	// documentation says not to.
 	// In this case logging is a service to clients, not a means for debugging the
 	// server, so we want to cancel the log message.
-	return h.ss.Log(ctx, params)
+	return h.ss.log(ctx, params)
 }

--- a/mcp/logging.go
+++ b/mcp/logging.go
@@ -70,8 +70,7 @@ func compareLevels(l1, l2 LoggingLevel) int {
 
 // LoggingHandlerOptions are options for a LoggingHandler.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 type LoggingHandlerOptions struct {
 	// The value for the "logger" field of logging notifications.
 	LoggerName string
@@ -83,8 +82,7 @@ type LoggingHandlerOptions struct {
 
 // A LoggingHandler is a [slog.Handler] for MCP.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 type LoggingHandler struct {
 	opts LoggingHandlerOptions
 	ss   *ServerSession
@@ -108,8 +106,7 @@ func ensureLogger(l *slog.Logger) *slog.Logger {
 // NewLoggingHandler creates a [LoggingHandler] that logs to the given [ServerSession] using a
 // [slog.JSONHandler].
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 func NewLoggingHandler(ss *ServerSession, opts *LoggingHandlerOptions) *LoggingHandler {
 	var buf bytes.Buffer
 	jsonHandler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{

--- a/mcp/mrtr.go
+++ b/mcp/mrtr.go
@@ -185,11 +185,11 @@ func fulfillServerInputRequest(ctx context.Context, ss *ServerSession, ir InputR
 	case *ElicitParams:
 		return ss.Elicit(ctx, p)
 	case *CreateMessageParams:
-		return ss.CreateMessageWithTools(ctx, createMessageParamsToWithTools(p))
+		return ss.createMessageWithTools(ctx, createMessageParamsToWithTools(p))
 	case *CreateMessageWithToolsParams:
-		return ss.CreateMessageWithTools(ctx, p)
+		return ss.createMessageWithTools(ctx, p)
 	case *ListRootsParams:
-		return ss.ListRoots(ctx, p)
+		return ss.listRoots(ctx, p)
 	default:
 		return nil, fmt.Errorf("unknown input request type: %T", ir)
 	}

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -439,6 +439,8 @@ func (x *CancelledParams) GetProgressToken() any  { return getProgressToken(x) }
 func (x *CancelledParams) SetProgressToken(t any) { setProgressToken(x, t) }
 
 // RootCapabilities describes a client's support for roots.
+//
+// Part of the deprecated roots feature (SEP-2577). Remains on the wire for compatibility.
 type RootCapabilities struct {
 	// ListChanged reports whether the client supports notifications for
 	// changes to the roots list.
@@ -466,6 +468,8 @@ type ClientCapabilities struct {
 	// Deprecated: use RootsV2. As described in #607, Roots should have been a
 	// pointer to a RootCapabilities value. Roots will be continue to be
 	// populated, but any new fields will only be added in the RootsV2 field.
+	//
+	// Part of the deprecated roots feature (SEP-2577). Remains on the wire for compatibility.
 	Roots struct {
 		// ListChanged reports whether the client supports notifications for
 		// changes to the roots list.
@@ -474,6 +478,8 @@ type ClientCapabilities struct {
 	// RootsV2 is present if the client supports roots. When capabilities are explicitly configured via [ClientOptions.Capabilities]
 	RootsV2 *RootCapabilities `json:"-"`
 	// Sampling is present if the client supports sampling from an LLM.
+	//
+	// Part of the deprecated sampling feature (SEP-2577). Remains on the wire for compatibility.
 	Sampling *SamplingCapabilities `json:"sampling,omitempty"`
 	// Elicitation is present if the client supports elicitation from the server.
 	Elicitation *ElicitationCapabilities `json:"elicitation,omitempty"`
@@ -641,6 +647,9 @@ type CompleteResult struct {
 
 func (*CompleteResult) isResult() {}
 
+// CreateMessageParams holds parameters for a sampling/create_message request.
+//
+// Part of the deprecated sampling feature (SEP-2577). Remains on the wire for compatibility.
 type CreateMessageParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -681,6 +690,8 @@ func (x *CreateMessageParams) SetProgressToken(t any) { setProgressToken(x, t) }
 // and messages that support array content (for parallel tool calls).
 //
 // Use with [ServerSession.CreateMessageWithTools].
+//
+// Part of the deprecated sampling feature (SEP-2577). Remains on the wire for compatibility.
 type CreateMessageWithToolsParams struct {
 	Meta           `json:"_meta,omitempty"`
 	IncludeContext string `json:"includeContext,omitempty"`
@@ -782,6 +793,8 @@ func (m *SamplingMessageV2) UnmarshalJSON(data []byte) error {
 // The client should inform the user before returning the sampled message, to
 // allow them to inspect the response (human in the loop) and decide whether to
 // allow the server to see it.
+//
+// Part of the deprecated sampling feature (SEP-2577). Remains on the wire for compatibility.
 type CreateMessageResult struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -828,6 +841,8 @@ func (r *CreateMessageResult) UnmarshalJSON(data []byte) error {
 //
 // When unmarshaling, a single JSON content object is accepted and wrapped in a
 // one-element slice, for compatibility with clients that return a single block.
+//
+// Part of the deprecated sampling feature (SEP-2577). Remains on the wire for compatibility.
 type CreateMessageWithToolsResult struct {
 	Meta    `json:"_meta,omitempty"`
 	Content []Content `json:"content"`
@@ -1174,6 +1189,9 @@ type ListResourcesResult struct {
 func (x *ListResourcesResult) isResult()              {}
 func (x *ListResourcesResult) nextCursorPtr() *string { return &x.NextCursor }
 
+// ListRootsParams holds parameters for a roots/list request.
+//
+// Part of the deprecated roots feature (SEP-2577). Remains on the wire for compatibility.
 type ListRootsParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -1189,6 +1207,8 @@ func (x *ListRootsParams) SetProgressToken(t any) { setProgressToken(x, t) }
 // The client's response to a roots/list request from the server. This result
 // contains an array of Root objects, each representing a root directory or file
 // that the server can operate on.
+//
+// Part of the deprecated roots feature (SEP-2577). Remains on the wire for compatibility.
 type ListRootsResult struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -1232,8 +1252,13 @@ func (x *ListToolsResult) nextCursorPtr() *string { return &x.NextCursor }
 //
 // These map to syslog message severities, as specified in RFC-5424:
 // https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1
+//
+// Part of the deprecated logging feature (SEP-2577). Remains on the wire for compatibility.
 type LoggingLevel string
 
+// LoggingMessageParams holds parameters for a logging notification.
+//
+// Part of the deprecated logging feature (SEP-2577). Remains on the wire for compatibility.
 type LoggingMessageParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -1606,6 +1631,8 @@ type ResourceTemplate struct {
 type Role string
 
 // Represents a root directory or file that the server can operate on.
+//
+// Part of the deprecated roots feature (SEP-2577). Remains on the wire for compatibility.
 type Root struct {
 	// See [specification/2025-06-18/basic/index#general-fields] for notes on _meta
 	// usage.
@@ -1620,6 +1647,9 @@ type Root struct {
 	URI string `json:"uri"`
 }
 
+// RootsListChangedParams holds parameters for a roots/list_changed notification.
+//
+// Part of the deprecated roots feature (SEP-2577). Remains on the wire for compatibility.
 type RootsListChangedParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -1635,6 +1665,8 @@ func (x *RootsListChangedParams) SetProgressToken(t any) { setProgressToken(x, t
 // below directly above ClientCapabilities.
 
 // SamplingCapabilities describes the client's support for sampling.
+//
+// Part of the deprecated sampling feature (SEP-2577). Remains on the wire for compatibility.
 type SamplingCapabilities struct {
 	// Context indicates the client supports includeContext values other than "none".
 	Context *SamplingContextCapabilities `json:"context,omitempty"`
@@ -1700,6 +1732,9 @@ func (m *SamplingMessage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// SetLoggingLevelParams holds parameters for a logging/setLevel request.
+//
+// Part of the deprecated logging feature (SEP-2577). Remains on the wire for compatibility.
 type SetLoggingLevelParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -1982,6 +2017,8 @@ type Implementation struct {
 type CompletionCapabilities struct{}
 
 // LoggingCapabilities describes the server's support for sending log messages to the client.
+//
+// Part of the deprecated logging feature (SEP-2577). Remains on the wire for compatibility.
 type LoggingCapabilities struct{}
 
 // PromptCapabilities describes the server's support for prompts.
@@ -2025,6 +2062,8 @@ type ServerCapabilities struct {
 	// suggestions.
 	Completions *CompletionCapabilities `json:"completions,omitempty"`
 	// Logging is present if the server supports log messages.
+	//
+	// Part of the deprecated logging feature (SEP-2577). Remains on the wire for compatibility.
 	Logging *LoggingCapabilities `json:"logging,omitempty"`
 	// Prompts is present if the server supports prompts.
 	Prompts *PromptCapabilities `json:"prompts,omitempty"`

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -1189,9 +1189,6 @@ type ListResourcesResult struct {
 func (x *ListResourcesResult) isResult()              {}
 func (x *ListResourcesResult) nextCursorPtr() *string { return &x.NextCursor }
 
-// ListRootsParams holds parameters for a roots/list request.
-//
-// Part of the deprecated roots feature (SEP-2577). Remains on the wire for compatibility.
 type ListRootsParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -1647,9 +1644,6 @@ type Root struct {
 	URI string `json:"uri"`
 }
 
-// RootsListChangedParams holds parameters for a roots/list_changed notification.
-//
-// Part of the deprecated roots feature (SEP-2577). Remains on the wire for compatibility.
 type RootsListChangedParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.
@@ -1732,9 +1726,6 @@ func (m *SamplingMessage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// SetLoggingLevelParams holds parameters for a logging/setLevel request.
-//
-// Part of the deprecated logging feature (SEP-2577). Remains on the wire for compatibility.
 type SetLoggingLevelParams struct {
 	// This property is reserved by the protocol to allow clients and servers to
 	// attach additional metadata to their responses.

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -71,8 +71,7 @@ type ServerOptions struct {
 	PageSize int
 	// If non-nil, called when "notifications/roots/list_changed" is received.
 	//
-	// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-	// This API may be removed in a future release of this SDK.
+	// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 	RootsListChangedHandler func(context.Context, *RootsListChangedRequest)
 	// If non-nil, called when "notifications/progress" is received.
 	ProgressNotificationHandler func(context.Context, *ProgressNotificationServerRequest)
@@ -1294,8 +1293,7 @@ func (ss *ServerSession) listRoots(ctx context.Context, params *ListRootsParams)
 
 // ListRoots lists the client roots.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams) (*ListRootsResult, error) {
 	return ss.listRoots(ctx, params)
 }
@@ -1306,8 +1304,7 @@ func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams)
 // CreateMessage returns an error. Use [ServerSession.CreateMessageWithTools]
 // for tool-enabled sampling.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessageParams) (*CreateMessageResult, error) {
 	return ss.createMessage(ctx, params)
 }
@@ -1350,8 +1347,7 @@ func (ss *ServerSession) createMessage(ctx context.Context, params *CreateMessag
 // (for parallel tool calls). Use this instead of [ServerSession.CreateMessage]
 // when the request includes tools.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 func (ss *ServerSession) CreateMessageWithTools(ctx context.Context, params *CreateMessageWithToolsParams) (*CreateMessageWithToolsResult, error) {
 	return ss.createMessageWithTools(ctx, params)
 }
@@ -1458,8 +1454,7 @@ type logLevelContextKey struct{}
 // suppresses the message per spec. For old-protocol requests, the level is
 // taken from the session state set via `logging/setLevel`.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 func (ss *ServerSession) Log(ctx context.Context, params *LoggingMessageParams) error {
 	return ss.log(ctx, params)
 }

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -70,6 +70,9 @@ type ServerOptions struct {
 	// If zero, defaults to [DefaultPageSize].
 	PageSize int
 	// If non-nil, called when "notifications/roots/list_changed" is received.
+	//
+	// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+	// This API may be removed in a future release of this SDK.
 	RootsListChangedHandler func(context.Context, *RootsListChangedRequest)
 	// If non-nil, called when "notifications/progress" is received.
 	ProgressNotificationHandler func(context.Context, *ProgressNotificationServerRequest)
@@ -958,7 +961,7 @@ func fileResourceHandler(dir string) ResourceHandler {
 		defer util.Wrapf(&err, "reading resource %s", req.Params.URI)
 
 		// TODO(#25): use a memoizing API here.
-		rootRes, err := req.Session.ListRoots(ctx, nil)
+		rootRes, err := req.Session.listRoots(ctx, nil)
 		if err != nil {
 			return nil, fmt.Errorf("listing roots: %w", err)
 		}
@@ -1282,12 +1285,19 @@ func (ss *ServerSession) Ping(ctx context.Context, params *PingParams) error {
 	return err
 }
 
-// ListRoots lists the client roots.
-func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams) (*ListRootsResult, error) {
+func (ss *ServerSession) listRoots(ctx context.Context, params *ListRootsParams) (*ListRootsResult, error) {
 	if err := ss.checkInitialized(methodListRoots); err != nil {
 		return nil, err
 	}
 	return handleSend[*ListRootsResult](ctx, methodListRoots, newServerRequest(ss, orZero[Params](params)))
+}
+
+// ListRoots lists the client roots.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
+func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams) (*ListRootsResult, error) {
+	return ss.listRoots(ctx, params)
 }
 
 // CreateMessage sends a sampling request to the client.
@@ -1295,7 +1305,14 @@ func (ss *ServerSession) ListRoots(ctx context.Context, params *ListRootsParams)
 // If the client returns multiple content blocks (e.g. parallel tool calls),
 // CreateMessage returns an error. Use [ServerSession.CreateMessageWithTools]
 // for tool-enabled sampling.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessageParams) (*CreateMessageResult, error) {
+	return ss.createMessage(ctx, params)
+}
+
+func (ss *ServerSession) createMessage(ctx context.Context, params *CreateMessageParams) (*CreateMessageResult, error) {
 	if err := ss.checkInitialized(methodCreateMessage); err != nil {
 		return nil, err
 	}
@@ -1332,7 +1349,14 @@ func (ss *ServerSession) CreateMessage(ctx context.Context, params *CreateMessag
 // returning a [CreateMessageWithToolsResult] that supports array content
 // (for parallel tool calls). Use this instead of [ServerSession.CreateMessage]
 // when the request includes tools.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 func (ss *ServerSession) CreateMessageWithTools(ctx context.Context, params *CreateMessageWithToolsParams) (*CreateMessageWithToolsResult, error) {
+	return ss.createMessageWithTools(ctx, params)
+}
+
+func (ss *ServerSession) createMessageWithTools(ctx context.Context, params *CreateMessageWithToolsParams) (*CreateMessageWithToolsResult, error) {
 	if err := ss.checkInitialized(methodCreateMessage); err != nil {
 		return nil, err
 	}
@@ -1433,7 +1457,14 @@ type logLevelContextKey struct{}
 // originating request's `_meta` field (SEP-2575); an absent or empty value
 // suppresses the message per spec. For old-protocol requests, the level is
 // taken from the session state set via `logging/setLevel`.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 func (ss *ServerSession) Log(ctx context.Context, params *LoggingMessageParams) error {
+	return ss.log(ctx, params)
+}
+
+func (ss *ServerSession) log(ctx context.Context, params *LoggingMessageParams) error {
 	logLevel, ok := ctx.Value(logLevelContextKey{}).(LoggingLevel)
 	if !ok {
 		ss.mu.Lock()

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -267,6 +267,9 @@ func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params 
 
 // A LoggingTransport is a [Transport] that delegates to another transport,
 // writing RPC logs to an io.Writer.
+//
+// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+// This API may be removed in a future release of this SDK.
 type LoggingTransport struct {
 	Transport Transport
 	Writer    io.Writer

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -268,8 +268,7 @@ func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params 
 // A LoggingTransport is a [Transport] that delegates to another transport,
 // writing RPC logs to an io.Writer.
 //
-// Deprecated: Deprecated by SEP-2577 (https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
-// This API may be removed in a future release of this SDK.
+// Deprecated: SEP-2577 deprecates this API. It may be removed in a future release of this SDK.
 type LoggingTransport struct {
 	Transport Transport
 	Writer    io.Writer


### PR DESCRIPTION
## Summary

Implements [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577) by marking user-facing roots, sampling, and logging APIs as deprecated. The deprecation is advisory: wire format and runtime behavior are unchanged.

- Add `Deprecated:` comments on client/server session methods, option handlers, and logging helpers (`AddRoots`, `CreateMessage`, `NewLoggingHandler`, `LoggingTransport`, and related APIs).
- Document deprecated capability and wire types in `protocol.go` without changing their behavior.
- Route internal SDK call sites through unexported helpers so production code stays staticcheck-clean.
- Add `//lint:file-ignore SA1019` to conformance and example servers that intentionally exercise deprecated APIs for coverage.
- Update generated README and docs with SEP-2577 notes.

Fixes #995

## Test plan

- [x] `gofmt` (clean)
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
