### PR TITLE
mcp: retry transient errors on SSE reconnect

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -2432,21 +2432,36 @@ func (c *streamableClientConn) handleSSE(ctx context.Context, requestSummary str
 		}
 
 		// The stream was interrupted or ended by the server. Attempt to reconnect.
-		newResp, err := c.connectSSE(ctx, lastEventID, reconnectDelay, false)
-		if err != nil {
-			// If the client didn't cancel this request, any failure to execute it
-			// breaks the logical MCP session.
-			if ctx.Err() == nil {
-				// All reconnection attempts failed: fail the connection.
-				c.fail(fmt.Errorf("%s: failed to reconnect (session ID: %v): %v", requestSummary, c.sessionID, err))
+		for {
+			newResp, err := c.connectSSE(ctx, lastEventID, reconnectDelay, false)
+			if err != nil {
+				// If the client didn't cancel this request, any failure to execute it
+				// breaks the logical MCP session.
+				if ctx.Err() == nil {
+					// All reconnection attempts failed: fail the connection.
+					c.fail(fmt.Errorf("%s: failed to reconnect (session ID: %v): %v", requestSummary, c.sessionID, err))
+				}
+				return
 			}
-			return
-		}
 
-		resp = newResp
-		if err := c.checkResponse(ctx, requestSummary, resp); err != nil {
-			c.fail(err)
-			return
+			if err := c.checkResponse(ctx, requestSummary, newResp); err != nil {
+				if errors.Is(err, jsonrpc2.ErrRejected) {
+					retriesWithoutProgress++
+					if retriesWithoutProgress > c.maxRetries {
+						if ctx.Err() == nil {
+							c.fail(fmt.Errorf("%s: exceeded %d retries without progress (session ID: %v)", requestSummary, c.maxRetries, c.sessionID))
+						}
+						return
+					}
+					reconnectDelay = 0
+					continue
+				}
+				c.fail(err)
+				return
+			}
+
+			resp = newResp
+			break
 		}
 	}
 }

--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -2490,7 +2490,6 @@ func (c *streamableClientConn) handleSSE(ctx context.Context, requestSummary str
 						}
 						return
 					}
-					reconnectDelay = 0
 					continue
 				}
 				c.fail(err)

--- a/mcp/streamable_client_test.go
+++ b/mcp/streamable_client_test.go
@@ -740,6 +740,83 @@ func TestStreamableClientTransientErrors(t *testing.T) {
 	}
 }
 
+// TestStreamableClientReconnectTransientErrors verifies that a transient HTTP
+// error on an SSE reconnect is retried rather than breaking the session (#683).
+func TestStreamableClientReconnectTransientErrors(t *testing.T) {
+	const tick = 10 * time.Millisecond
+	defer func(delay int64) {
+		reconnectInitialDelay.Store(delay)
+	}(reconnectInitialDelay.Load())
+	reconnectInitialDelay.Store(int64(tick))
+
+	ctx := context.Background()
+
+	var callID atomic.Int64
+	var sentTransient atomic.Bool
+
+	fake := &fakeStreamableServer{
+		t: t,
+		responses: fakeResponses{
+			{"POST", "", methodInitialize, ""}: {
+				header: header{
+					"Content-Type":  "application/json",
+					sessionIDHeader: "123",
+				},
+				body: jsonBody(t, initResp),
+			},
+			{"POST", "123", notificationInitialized, ""}: {
+				status:              http.StatusAccepted,
+				wantProtocolVersion: protocolVersion20251125,
+			},
+			{"GET", "123", "", ""}: {
+				status: http.StatusMethodNotAllowed,
+			},
+			{"POST", "123", methodCallTool, ""}: {
+				header: header{
+					"Content-Type": "text/event-stream",
+				},
+				responseFunc: func(r *jsonrpc.Request) (string, int) {
+					callID.Store(r.ID.Raw().(int64))
+					return "id: evt_1\n" +
+						`data: {"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"progress"}}` +
+						"\n\n", http.StatusOK
+				},
+			},
+			{"GET", "123", "", "evt_1"}: {
+				header: header{
+					"Content-Type": "text/event-stream",
+				},
+				responseFunc: func(r *jsonrpc.Request) (string, int) {
+					if !sentTransient.Swap(true) {
+						return "", http.StatusServiceUnavailable
+					}
+					body := jsonBody(t, resp(callID.Load(), &CallToolResult{Content: []Content{}}, nil))
+					return "id: evt_2\ndata: " + body + "\n\n", http.StatusOK
+				},
+			},
+			{"DELETE", "123", "", ""}: {optional: true},
+		},
+	}
+
+	httpServer := httptest.NewServer(fake)
+	defer httpServer.Close()
+
+	transport := &StreamableClientTransport{Endpoint: httpServer.URL}
+	client := NewClient(testImpl, nil)
+	session, err := client.Connect(ctx, transport, &ClientSessionOptions{protocolVersion: protocolVersion20251125})
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer session.Close()
+
+	if _, err := session.CallTool(ctx, &CallToolParams{Name: "test"}); err != nil {
+		t.Fatalf("CallTool failed after transient reconnect error: %v (session should survive)", err)
+	}
+	if !sentTransient.Load() {
+		t.Error("expected a transient error to be exercised on reconnect")
+	}
+}
+
 // TestStreamableClientRetryWithoutProgress verifies that the client fails after
 // exceeding the retry limit when no progress is made (Last-Event-ID does not advance).
 // This tests the fix for issue #679.

--- a/mcp/streamable_client_test.go
+++ b/mcp/streamable_client_test.go
@@ -744,6 +744,7 @@ func TestStreamableClientTransientErrors(t *testing.T) {
 // error on an SSE reconnect is retried rather than breaking the session (#683).
 func TestStreamableClientReconnectTransientErrors(t *testing.T) {
 	const tick = 10 * time.Millisecond
+	const serverReconnectDelay = 50 * time.Millisecond
 	defer func(delay int64) {
 		reconnectInitialDelay.Store(delay)
 	}(reconnectInitialDelay.Load())
@@ -753,6 +754,8 @@ func TestStreamableClientReconnectTransientErrors(t *testing.T) {
 
 	var callID atomic.Int64
 	var sentTransient atomic.Bool
+	var transientResponseAt atomic.Int64
+	var successfulReconnectAt atomic.Int64
 
 	fake := &fakeStreamableServer{
 		t: t,
@@ -777,7 +780,8 @@ func TestStreamableClientReconnectTransientErrors(t *testing.T) {
 				},
 				responseFunc: func(r *jsonrpc.Request) (string, int) {
 					callID.Store(r.ID.Raw().(int64))
-					return "id: evt_1\n" +
+					return fmt.Sprintf("retry: %d\n", serverReconnectDelay.Milliseconds()) +
+						"id: evt_1\n" +
 						`data: {"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"progress"}}` +
 						"\n\n", http.StatusOK
 				},
@@ -788,8 +792,10 @@ func TestStreamableClientReconnectTransientErrors(t *testing.T) {
 				},
 				responseFunc: func(r *jsonrpc.Request) (string, int) {
 					if !sentTransient.Swap(true) {
+						transientResponseAt.Store(time.Now().UnixNano())
 						return "", http.StatusServiceUnavailable
 					}
+					successfulReconnectAt.Store(time.Now().UnixNano())
 					body := jsonBody(t, resp(callID.Load(), &CallToolResult{Content: []Content{}}, nil))
 					return "id: evt_2\ndata: " + body + "\n\n", http.StatusOK
 				},
@@ -814,6 +820,9 @@ func TestStreamableClientReconnectTransientErrors(t *testing.T) {
 	}
 	if !sentTransient.Load() {
 		t.Error("expected a transient error to be exercised on reconnect")
+	}
+	if got := time.Duration(successfulReconnectAt.Load() - transientResponseAt.Load()); got < serverReconnectDelay {
+		t.Errorf("retry after transient error took %v, want at least the server-requested %v", got, serverReconnectDelay)
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes the remaining work for #683 that #723 called out: "we should also retry transient errors in handleSSE."

When an SSE stream is interrupted and the client reconnects, `streamableClientConn.handleSSE` passed any `checkResponse` error to `c.fail`, permanently breaking the session. But `checkResponse` intentionally wraps transient HTTP statuses (429, 502, 503, 504) in `jsonrpc2.ErrRejected` so they should *not* break the connection — the POST path already honors this (`if !errors.Is(err, jsonrpc2.ErrRejected) { c.fail(err) }`), while the SSE reconnect path did not. As a result a transient 503 during a reconnect (server restart, load-balancer hiccup, load spike) poisoned the whole session — the failure mode reported in #683.

## Change

In the reconnect loop, when `checkResponse` returns an `ErrRejected`-wrapped (transient) error, retry the reconnect instead of failing. Each retry counts against the existing no-progress retry budget (#679), so a persistently unavailable server still eventually gives up rather than looping forever. Non-transient errors are unchanged.

## Test

`TestStreamableClientReconnectTransientErrors` reproduces the bug with the existing `fakeStreamableServer` harness: a POST tool call returns an SSE stream that emits a resumable event then ends without the response (forcing a reconnect); the reconnect returns 503 once, then the real response. The test fails before this change (`... Service Unavailable (session should survive)`) and passes after.

Verified locally: `go test ./...`, `go test -race ./...`, `go vet ./...`, `gofmt -l`, and `staticcheck` all clean.

## Scope note

`connectStandaloneSSE` has the same unconditional `c.fail` on a transient status. The standalone GET stream is optional (§2.2.3), so I scoped this PR to `handleSSE` (the case #723 named). Happy to also fix the standalone path here or in a follow-up — whichever you prefer.

For #683
