### PR TITLE
mcp: avoid panic for new-protocol null IDs

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1812,7 +1812,7 @@ func (ss *ServerSession) handle(ctx context.Context, req *jsonrpc.Request) (any,
 		return nil, perRequestErr
 	}
 
-	if validatedMeta.usesNewProtocol &&
+	if validatedMeta.usesNewProtocol && validatedMeta.initializeParams != nil &&
 		!slices.Contains(supportedProtocolVersions, validatedMeta.initializeParams.ProtocolVersion) {
 		data, _ := json.Marshal(UnsupportedProtocolVersionData{
 			Supported: supportedProtocolVersions,

--- a/mcp/shared_test.go
+++ b/mcp/shared_test.go
@@ -5,12 +5,14 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
@@ -180,6 +182,42 @@ func TestValidateRequestMeta(t *testing.T) {
 				t.Errorf("error message %q does not contain %q", jerr.Message, tc.wantErrContains)
 			}
 		})
+	}
+}
+
+func TestServerHandleNewProtocolNullID(t *testing.T) {
+	msg, err := jsonrpc.DecodeMessage([]byte(`{
+		"jsonrpc": "2.0",
+		"id": null,
+		"method": "completion/complete",
+		"params": {
+			"_meta": {
+				"io.modelcontextprotocol/protocolVersion": "2026-07-28",
+				"io.modelcontextprotocol/clientInfo": {"name": "repro", "version": "0.1.0"},
+				"io.modelcontextprotocol/clientCapabilities": {}
+			},
+			"ref": {"type": "ref/prompt", "name": "test"},
+			"argument": {"name": "arg", "value": "x"}
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, ok := msg.(*jsonrpc.Request)
+	if !ok {
+		t.Fatalf("message type = %T, want *jsonrpc.Request", msg)
+	}
+
+	ss := &ServerSession{server: NewServer(testImpl, nil)}
+	_, err = ss.handle(context.Background(), req)
+	if err == nil {
+		t.Fatal("handle returned nil error, want invalid request")
+	}
+	if !errors.Is(err, jsonrpc2.ErrInvalidRequest) {
+		t.Fatalf("handle error = %v, want invalid request", err)
+	}
+	if !strings.Contains(err.Error(), "missing id") {
+		t.Fatalf("handle error = %v, want missing id", err)
 	}
 }
 


### PR DESCRIPTION
This fixes a panic in the server-side per-request protocol metadata path when an inbound message has `id: null` and new-protocol `_meta`.

The request decodes as notification-shaped, so `validateRequestMeta` returns new-protocol metadata without initialize params. Guard the protocol-version check before reading initialize params, allowing the existing request validation path to reject the malformed call instead of dereferencing nil.

Tests:
- `go test ./mcp -run 'Test(ServerHandleNewProtocolNullID|ValidateRequestMeta)$' -count=1`
- `go test ./mcp -count=1`
- `git diff --check HEAD~1..HEAD`

Fixes #1043
