### PR TITLE
fix(mcp): guard nil initializeParams on new-protocol notifications

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1813,6 +1813,7 @@ func (ss *ServerSession) handle(ctx context.Context, req *jsonrpc.Request) (any,
 	}
 
 	if validatedMeta.usesNewProtocol &&
+		validatedMeta.initializeParams != nil &&
 		!slices.Contains(supportedProtocolVersions, validatedMeta.initializeParams.ProtocolVersion) {
 		data, _ := json.Marshal(UnsupportedProtocolVersionData{
 			Supported: supportedProtocolVersions,

--- a/mcp/server_test.go
+++ b/mcp/server_test.go
@@ -1451,3 +1451,27 @@ func TestServerSessionHandle_RejectsRemovedMethodsOnNewProtocol(t *testing.T) {
 		})
 	}
 }
+
+// TestServerSessionHandle_NewProtocolNotificationWithoutParams verifies that
+// a notification carrying new-protocol _meta (id: null) does not panic when
+// the server dereferences initializeParams, which is nil for notifications.
+// Fixes https://github.com/modelcontextprotocol/go-sdk/issues/1043 and #1046.
+func TestServerSessionHandle_NewProtocolNotificationWithoutParams(t *testing.T) {
+	ss := &ServerSession{server: NewServer(testImpl, nil)}
+	req := &jsonrpc.Request{
+		Method: notificationCancelled,
+		Params: mustMarshal(map[string]any{
+			"_meta": map[string]any{
+				MetaKeyProtocolVersion: protocolVersion20260728,
+			},
+			"requestId": "r1",
+		}),
+	}
+	// A notification with new-protocol _meta must not panic.
+	// The expected behavior is that it returns without error
+	// (notifications are fire-and-forget).
+	_, err := ss.handle(context.Background(), req)
+	if err != nil {
+		t.Fatalf("notification with new-protocol _meta: unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Fixes a panic in the server-side per-request protocol metadata path when a JSON-RPC notification (`id: null`) carries new-protocol `_meta` (`protocolVersion >= 2026-07-28`).

## Root cause

`validateRequestMeta` (§2.3 step 3) returns `usesNewProtocol=true` with `initializeParams=nil` for notifications — notifications do not carry client identity per SEP-2575. The protocol version check at `server.go:1816` then dereferenced `initializeParams.ProtocolVersion` without a nil guard.

## Fix

Add `validatedMeta.initializeParams != nil` guard before accessing `.ProtocolVersion`. Notifications skip the version check entirely — the same guard pattern already used at line 1846 for initialization state.

## Regression test

`TestServerSessionHandle_NewProtocolNotificationWithoutParams` sends a `notifications/cancelled` notification with new-protocol `_meta` and verifies it returns without error (no panic).

## Related

Fixes #1043
Fixes #1046