### PR TITLE
mcp: do not exclude Notifications from carrying InitializeParams in Meta

### DIFF
--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -515,11 +515,10 @@ type validatedMeta struct {
 // the >= 2026-07-28 protocol via the `_meta` field.
 // If the request has no _meta, or no protocolVersion in _meta, it returns a non-nil
 // validatedMeta with usesNewProtocol set to false, and a nil error.
-// If the request has a protocolVersion in _meta:
-//   - For notifications, it returns usesNewProtocol set to true and a nil initializeParams.
-//   - For call requests, it validates the presence of clientInfo and clientCapabilities in _meta.
-//     If either is missing or invalid, it returns nil and a non-nil error. Otherwise, it returns
-//     usesNewProtocol set to true and the populated initializeParams.
+// If the request has a protocolVersion in _meta it validates the presence of clientInfo
+// and clientCapabilities in _meta. If either is missing or invalid, it returns nil and
+// a non-nil error. Otherwise, it returns usesNewProtocol set to true and the populated
+// initializeParams.
 func validateRequestMeta(req *jsonrpc.Request) (*validatedMeta, error) {
 	meta := extractRequestMeta(req.Params)
 	if meta == nil {
@@ -528,10 +527,6 @@ func validateRequestMeta(req *jsonrpc.Request) (*validatedMeta, error) {
 	protocolVersion, ok := meta[MetaKeyProtocolVersion].(string)
 	if !ok || protocolVersion < protocolVersion20260728 {
 		return &validatedMeta{usesNewProtocol: false, initializeParams: nil}, nil
-	}
-	// Notifications do not carry full client identity.
-	if !req.IsCall() {
-		return &validatedMeta{usesNewProtocol: true, initializeParams: nil}, nil
 	}
 	clientInfo, ok := decodeMetaValue[*Implementation](meta, MetaKeyClientInfo)
 	if !ok {

--- a/mcp/shared_test.go
+++ b/mcp/shared_test.go
@@ -18,7 +18,6 @@ func TestValidateRequestMeta(t *testing.T) {
 	tests := []struct {
 		name            string
 		method          string
-		isNotification  bool
 		params          any
 		wantUsesNew     bool
 		wantLogLevel    LoggingLevel
@@ -85,18 +84,6 @@ func TestValidateRequestMeta(t *testing.T) {
 			wantErrContains: MetaKeyClientCapabilities,
 		},
 		{
-			name:           "notifications exempt from required fields",
-			method:         notificationCancelled,
-			isNotification: true,
-			params: map[string]any{
-				"_meta": map[string]any{
-					MetaKeyProtocolVersion: protocolVersion20260728,
-				},
-				"requestId": "r1",
-			},
-			wantUsesNew: true,
-		},
-		{
 			name:        "malformed _meta is ignored",
 			method:      methodCallTool,
 			params:      json.RawMessage(`{"_meta": "not an object", "name": "x"}`),
@@ -141,16 +128,11 @@ func TestValidateRequestMeta(t *testing.T) {
 			default:
 				raw = mustMarshal(tc.params)
 			}
-			req := &jsonrpc.Request{Method: tc.method, Params: raw}
-			if !tc.isNotification {
-				req.ID = jsonrpc.ID{}
-				// Give the request an ID by parsing one.
-				id, err := jsonrpc.MakeID("test")
-				if err != nil {
-					t.Fatal(err)
-				}
-				req.ID = id
+			id, err := jsonrpc.MakeID("test")
+			if err != nil {
+				t.Fatal(err)
 			}
+			req := &jsonrpc.Request{Method: tc.method, Params: raw, ID: id}
 
 			vmeta, err := validateRequestMeta(req)
 			usesNew := vmeta != nil && vmeta.usesNewProtocol


### PR DESCRIPTION
Fixes #1043
