### PR TITLE
mcp: do not enforce TTL on cached tool

### DIFF
--- a/mcp/cache.go
+++ b/mcp/cache.go
@@ -54,14 +54,10 @@ func (mc *methodCache[R]) put(key string, result R) {
 	}
 }
 
-func (mc *methodCache[R]) forEachValid(f func(R)) {
+func (mc *methodCache[R]) forEach(f func(R)) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
-	for key, entry := range mc.cachedValues {
-		if !entry.isValid() {
-			delete(mc.cachedValues, key)
-			continue
-		}
+	for _, entry := range mc.cachedValues {
 		f(entry.result)
 	}
 }

--- a/mcp/cache.go
+++ b/mcp/cache.go
@@ -54,14 +54,6 @@ func (mc *methodCache[R]) put(key string, result R) {
 	}
 }
 
-func (mc *methodCache[R]) forEach(f func(R)) {
-	mc.mu.Lock()
-	defer mc.mu.Unlock()
-	for _, entry := range mc.cachedValues {
-		f(entry.result)
-	}
-}
-
 func (mc *methodCache[R]) invalidate() {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -584,19 +584,16 @@ func (cs *ClientSession) Wait() error {
 // outgoing request context for transport-layer features (e.g. x-mcp-header
 // param annotations).
 func (cs *ClientSession) lookupTool(name string) *Tool {
-	var found *Tool
-	cs.toolsCache.forEach(func(r *ListToolsResult) {
-		if found != nil {
-			return
-		}
-		for _, t := range r.Tools {
+	cs.toolsCache.mu.Lock()
+	defer cs.toolsCache.mu.Unlock()
+	for _, entry := range cs.toolsCache.cachedValues {
+		for _, t := range entry.result.Tools {
 			if t.Name == name {
-				found = t
-				return
+				return t
 			}
 		}
-	})
-	return found
+	}
+	return nil
 }
 
 // registerElicitationWaiter registers a waiter for an elicitation complete

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -585,7 +585,7 @@ func (cs *ClientSession) Wait() error {
 // param annotations).
 func (cs *ClientSession) lookupTool(name string) *Tool {
 	var found *Tool
-	cs.toolsCache.forEachValid(func(r *ListToolsResult) {
+	cs.toolsCache.forEach(func(r *ListToolsResult) {
 		if found != nil {
 			return
 		}


### PR DESCRIPTION
This PR removes the TTL enforcing on the cached tools, when used to generate the http-parameters for CallTool, according to updated [spec](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2972) 

> Clients **MUST** construct `Mcp-Param-*` headers using the most recently obtained `inputSchema` for the tool.
