### PR TITLE
mcp: handle nil elicitation content with defaults

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -877,7 +877,10 @@ func (c *Client) elicit(ctx context.Context, req *ElicitRequest) (*ElicitResult,
 			return nil, err
 		}
 		// Validate elicitation result content against requested schema.
-		if res.Action == "accept" && schema != nil && res.Content != nil {
+		if res.Action == "accept" && schema != nil {
+			if res.Content == nil {
+				res.Content = map[string]any{}
+			}
 			resolved, err := schema.Resolve(nil)
 			if err != nil {
 				return nil, &jsonrpc.Error{Code: jsonrpc.CodeInvalidParams, Message: fmt.Sprintf("failed to resolve requested schema: %v", err)}

--- a/mcp/elicitation_test.go
+++ b/mcp/elicitation_test.go
@@ -6,6 +6,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -207,6 +208,45 @@ func TestElicitationCompleteNotification(t *testing.T) {
 			t.Errorf("elicitationComplete notification ID mismatch: got %q, want %q", gotParams.ElicitationID, elicitID)
 		}
 	})
+}
+
+func TestElicitationAcceptNilContentAppliesDefaults(t *testing.T) {
+	ctx := context.Background()
+
+	ct, st := NewInMemoryTransports()
+	s := NewServer(testImpl, nil)
+	ss, err := s.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	c := NewClient(testImpl, &ClientOptions{
+		ElicitationHandler: func(context.Context, *ElicitRequest) (*ElicitResult, error) {
+			return &ElicitResult{Action: "accept"}, nil
+		},
+	})
+	cs, err := c.Connect(ctx, ct, &ClientSessionOptions{protocolVersion: protocolVersion20251125})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	res, err := ss.Elicit(ctx, &ElicitParams{
+		Message: "Test defaults",
+		RequestedSchema: &jsonschema.Schema{
+			Type: "object",
+			Properties: map[string]*jsonschema.Schema{
+				"ok": {Type: "boolean", Default: json.RawMessage(`true`)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Elicit failed: %v", err)
+	}
+	if got := res.Content["ok"]; got != true {
+		t.Fatalf("Elicit content default: got %v, want true", got)
+	}
 }
 
 func TestElicitationNoValidationWithoutAccept(t *testing.T) {

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1685,6 +1685,9 @@ func (ss *ServerSession) Elicit(ctx context.Context, params *ElicitParams) (*Eli
 	if schema == nil {
 		return res, nil
 	}
+	if res.Content == nil {
+		res.Content = map[string]any{}
+	}
 
 	resolved, err := schema.Resolve(nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Treat accepted elicitation responses with omitted `content` as an empty object before validation.
- Apply that normalization on both client and server elicitation paths.
- Add a regression test for schema defaults with nil content.

## Why

Fixes #1062. `jsonschema-go` can panic when applying defaults into a nil map, so a loose client response could crash the server during `ServerSession.Elicit`.

## Validation

- `go test ./mcp -run TestElicitationAcceptNilContentAppliesDefaults -count=1` — failed before the fix with `panic: assignment to entry in nil map`; passed after
- `go test ./mcp -run 'TestElicitation|TestClientElicitation|TestServerRequestElicit|TestInputRequired' -count=1` — passed\n- `go test ./mcp -count=1` — passed\n- `go test ./...` — passed\n- `go vet ./...` — passed\n- `gofmt` — passed\n- `git diff --check` — passed