### PR TITLE
fix: omit empty Mode from ElicitParams JSON serialization

### DIFF
--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -2092,7 +2092,7 @@ type ElicitParams struct {
 	// The mode of elicitation to use.
 	//
 	// If unset, will be inferred from the other fields.
-	Mode string `json:"mode"`
+	Mode string `json:"mode,omitempty"`
 	// The message to present to the user.
 	Message string `json:"message"`
 	// A JSON schema object defining the requested elicitation schema.

--- a/mcp/protocol_elicitation_test.go
+++ b/mcp/protocol_elicitation_test.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestElicitParamsModeOmitempty(t *testing.T) {
+	// When Mode is empty, it should be omitted from JSON serialization
+	params := ElicitParams{
+		Message: "Please provide your name",
+		RequestedSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("failed to marshal ElicitParams: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Mode should be omitted from the JSON output when empty
+	if _, exists := m["mode"]; exists {
+		t.Errorf("expected 'mode' to be omitted when empty, but got %q", m["mode"])
+	}
+
+	// Message should still be present
+	if msg, ok := m["message"].(string); !ok || msg != "Please provide your name" {
+		t.Errorf("expected message to be 'Please provide your name', got %v", m["message"])
+	}
+}
+
+func TestElicitParamsModePresentWhenSet(t *testing.T) {
+	// When Mode is set, it should appear in JSON serialization
+	params := ElicitParams{
+		Mode:    "form",
+		Message: "Please provide your name",
+	}
+
+	data, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("failed to marshal ElicitParams: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Mode should be present in the JSON output
+	if mode, ok := m["mode"].(string); !ok || mode != "form" {
+		t.Errorf("expected mode to be 'form', got %v", m["mode"])
+	}
+}


### PR DESCRIPTION
## Summary

When ElicitParams.Mode is an empty string, it was being serialized as "mode":"" which does not match the MCP schema. The draft schema permits form-mode elicitation to either omit mode or set it to "form". An empty string matches neither the form nor the URL branch of ElicitRequestParams, so the nested ElicitRequest fails schema validation.

## Root Cause

The Mode field in ElicitParams (protocol.go:2095) had the JSON tag `json:"mode"` without omitempty. This means an empty string was always included in the serialized JSON output as "mode":"".

## Fix

Added omitempty to the Mode field's JSON tag so that an unset Mode is omitted from the JSON output. This preserves the spec's backward-compatible form-mode default: when mode is absent, the client infers it from the other fields.

## Changes

- mcp/protocol.go: Changed Mode field JSON tag from `json:"mode"` to `json:"mode,omitempty"` on ElicitParams struct
- mcp/protocol_elicitation_test.go: Added tests verifying that Mode is omitted from JSON when empty, and present when set to a valid value

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./mcp/ -run TestElicitParams -v` passes (2/2 tests)
- [x] All existing tests continue to pass

Fixes #1072