### PR TITLE
fix: validate LoggingLevel in setLevel handler

### DIFF
--- a/mcp/logging.go
+++ b/mcp/logging.go
@@ -63,6 +63,11 @@ func mcpLevelToSlog(ll LoggingLevel) slog.Level {
 	return LevelDebug
 }
 
+func isValidLoggingLevel(level LoggingLevel) bool {
+	_, ok := mcpToSlog[level]
+	return ok
+}
+
 // compareLevels behaves like [cmp.Compare] for [LoggingLevel]s.
 func compareLevels(l1, l2 LoggingLevel) int {
 	return cmp.Compare(mcpLevelToSlog(l1), mcpLevelToSlog(l2))

--- a/mcp/logging_validation_test.go
+++ b/mcp/logging_validation_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSetLevelValidLoggingLevels(t *testing.T) {
+	ss := &ServerSession{server: NewServer(testImpl, nil)}
+	for _, level := range []LoggingLevel{
+		"debug",
+		"info",
+		"notice",
+		"warning",
+		"error",
+		"critical",
+		"alert",
+		"emergency",
+	} {
+		if _, err := ss.setLevel(context.Background(), &SetLoggingLevelParams{Level: level}); err != nil {
+			t.Errorf("setLevel(%q) returned error: %v", level, err)
+		}
+		if got := ss.state.LogLevel; got != level {
+			t.Errorf("LogLevel after setLevel(%q) = %q, want %q", level, got, level)
+		}
+	}
+}
+
+func TestSetLevelInvalidLoggingLevel(t *testing.T) {
+	ss := &ServerSession{server: NewServer(testImpl, nil)}
+	ss.state.LogLevel = "info"
+
+	_, err := ss.setLevel(context.Background(), &SetLoggingLevelParams{Level: "verbose"})
+	if err == nil {
+		t.Fatal("setLevel(\"verbose\") returned nil error")
+	}
+	if !strings.Contains(err.Error(), `invalid logging level "verbose"`) {
+		t.Errorf("error = %q, want invalid level message", err)
+	}
+	if got := ss.state.LogLevel; got != "info" {
+		t.Errorf("LogLevel after invalid setLevel = %q, want %q", got, "info")
+	}
+}
+
+func TestSetLevelEmptyLoggingLevel(t *testing.T) {
+	ss := &ServerSession{server: NewServer(testImpl, nil)}
+
+	_, err := ss.setLevel(context.Background(), &SetLoggingLevelParams{Level: ""})
+	if err == nil {
+		t.Fatal("setLevel(\"\") returned nil error")
+	}
+	if !strings.Contains(err.Error(), `invalid logging level ""`) {
+		t.Errorf("error = %q, want invalid level message", err)
+	}
+	if got := ss.state.LogLevel; got != "" {
+		t.Errorf("LogLevel after empty setLevel = %q, want empty", got)
+	}
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1953,6 +1953,9 @@ func (ss *ServerSession) cancel(context.Context, *CancelledParams) (Result, erro
 }
 
 func (ss *ServerSession) setLevel(_ context.Context, params *SetLoggingLevelParams) (*emptyResult, error) {
+	if !isValidLoggingLevel(params.Level) {
+		return nil, fmt.Errorf("invalid logging level %q: must be one of debug, info, notice, warning, error, critical, alert, emergency", params.Level)
+	}
 	ss.updateState(func(state *ServerSessionState) {
 		state.LogLevel = params.Level
 	})


### PR DESCRIPTION
## Summary

The `setLevel` handler accepted any string value for the `Level` field in `SetLoggingLevelParams`. Invalid values were stored without validation, and when used in severity comparisons, unknown levels silently mapped to `debug` (via the fallback in `mcpLevelToSlog`). The MCP spec defines `LoggingLevel` as a closed enum with values: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`.

## Root Cause

The `setLevel` method in `mcp/server.go` called `ss.updateState` to store `params.Level` without checking whether the value was a valid `LoggingLevel`. The `mcpToSlog` map (built in `mcp/logging.go` `init()`) only contains the 8 valid enum values, but any other string would pass through unchecked.

## Fix

Added an `isValidLoggingLevel` function in `mcp/logging.go` that checks whether the given level exists in the `mcpToSlog` map. Modified the `setLevel` handler in `mcp/server.go` to call this validation before storing the level, returning a descriptive error if the value is invalid.

## Changes

- `mcp/logging.go`: Added `isValidLoggingLevel(level LoggingLevel) bool` function
- `mcp/server.go`: Added validation call at the start of `setLevel` handler
- `mcp/logging_validation_test.go`: Added 3 test cases:
  - `TestSetLevelValidLoggingLevels`: Verifies all 8 valid levels are accepted
  - `TestSetLevelInvalidLoggingLevel`: Verifies invalid level ("verbose") is rejected
  - `TestSetLevelEmptyLoggingLevel`: Verifies empty string is rejected

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./mcp/ -run TestSetLevel -v` passes (3/3 tests)
- [x] All existing tests continue to pass

Fixes #1070