### PR TITLE
Disable scheduled nightly runs on forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   vulncheck:
+    # Don't run scheduled builds on forks.
+    if: github.event_name != 'schedule' || github.repository == 'modelcontextprotocol/go-sdk'
     runs-on: ubuntu-latest
     steps:
     - name: Run govulncheck
@@ -20,6 +22,8 @@ jobs:
            go-package: ./...
 
   conformance:
+    # Don't run scheduled builds on forks.
+    if: github.event_name != 'schedule' || github.repository == 'modelcontextprotocol/go-sdk'
     runs-on: ubuntu-latest
     steps:
     - name: Check out code


### PR DESCRIPTION
.github/workflows/nightly.yml: disable scheduled nightly runs on the forked repos

User will still be able to run the workflow manually

Fixes #1082