### PR TITLE
mcp: reject calls to methodDiscover for `<20260728` requests

### DIFF
--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1879,10 +1879,16 @@ func (ss *ServerSession) handle(ctx context.Context, req *jsonrpc.Request) (any,
 				Message: fmt.Sprintf("%q is not supported in the new protocol", req.Method),
 			}
 		}
-	case methodDiscover:
+	case methodDiscover, methodSubscriptionsListen:
 		// In case of methodDiscover call the state.initializeParams is populated
 		// within the discover handle function to make sure the method is supported
 		// when the user is probing a pre-2026-07-28 server.
+		if !validatedMeta.usesNewProtocol {
+			return nil, &jsonrpc.Error{
+				Code:    jsonrpc.CodeMethodNotFound,
+				Message: fmt.Sprintf("%q is only supported in protocol version >= %s", req.Method, protocolVersion20260728),
+			}
+		}
 	default:
 		if !initialized && !validatedMeta.usesNewProtocol {
 			ss.server.opts.Logger.Error("method invalid during initialization", "method", req.Method)

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1879,7 +1879,7 @@ func (ss *ServerSession) handle(ctx context.Context, req *jsonrpc.Request) (any,
 				Message: fmt.Sprintf("%q is not supported in the new protocol", req.Method),
 			}
 		}
-	case methodDiscover, methodSubscriptionsListen:
+	case methodDiscover:
 		// In case of methodDiscover call the state.initializeParams is populated
 		// within the discover handle function to make sure the method is supported
 		// when the user is probing a pre-2026-07-28 server.


### PR DESCRIPTION
This PR adds a gate for requests towards methodDiscover if it is coming from a client that does not support the 20260728 protocol version
