### PR TITLE
Expose ServerSession.NotifyElicitationComplete

### DIFF
--- a/mcp/elicitation_test.go
+++ b/mcp/elicitation_test.go
@@ -194,9 +194,9 @@ func TestElicitationCompleteNotification(t *testing.T) {
 		}
 
 		// 2. Server sends elicitation complete notification (simulating out-of-band completion)
-		err = handleNotify(ctx, notificationElicitationComplete, newServerRequest(ss, &ElicitationCompleteParams{
+		err = ss.NotifyElicitationComplete(ctx, &ElicitationCompleteParams{
 			ElicitationID: elicitID,
-		}))
+		})
 		if err != nil {
 			t.Fatalf("failed to send elicitation complete notification: %v", err)
 		}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1448,6 +1448,18 @@ func (ss *ServerSession) NotifyProgress(ctx context.Context, params *ProgressNot
 	return handleNotify(ctx, notificationProgress, newServerRequest(ss, orZero[Params](params)))
 }
 
+// NotifyElicitationComplete informs the client that an out-of-band URL-mode
+// elicitation interaction has completed. The ElicitationID must match the one
+// originally sent in the elicitation/create request or the
+// URLElicitationRequiredError that started the flow.
+//
+// Per the MCP spec, this MUST only be sent to the client that initiated the
+// corresponding elicitation — it is the caller's responsibility to ensure ss
+// is the correct session for the given ElicitationID.
+func (ss *ServerSession) NotifyElicitationComplete(ctx context.Context, params *ElicitationCompleteParams) error {
+	return handleNotify(ctx, notificationElicitationComplete, newServerRequest(ss, orZero[Params](params)))
+}
+
 // notifySubscriptionAcked sends a "notifications/subscriptions/acknowledged"
 // notification on the listen stream represented by this session, indicating
 // the subscription filter the server accepted (SEP-2575).


### PR DESCRIPTION
Servers have no public way to send `notifications/elicitation/complete`, even though the spec defines it ([2025-11-25 revision, "Elicitation" page, "Completion Notifications for URL Mode Elicitation"](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#completion-notifications-for-url-mode-elicitation)) and the client-receiving side is already fully implemented (`ElicitationCompleteHandler`, `client.go`). `ServerSession` only exposes `NotifyProgress` and `Log` as outbound push notifications — nothing lets server code trigger this one. The gap is real enough that even this package's own test for the behavior, `TestElicitationCompleteNotification`, had to reach into unexported internals (`handleNotify`, `newServerRequest`) to simulate it, since there was no public entry point to call instead.

This adds `ServerSession.NotifyElicitationComplete`, mirroring `NotifyProgress`'s exact shape over the same `handleNotify`/ `newServerRequest` plumbing already used (and already tested) internally. `TestElicitationCompleteNotification` is updated to call the new public method instead of the internal calls it used before, proving identical wire behavior to what was already tested.