### PR TITLE
feat: add ServerSession.NotifyElicitationComplete for url-mode elicitation

### DIFF
--- a/mcp/elicitation_test.go
+++ b/mcp/elicitation_test.go
@@ -194,9 +194,9 @@ func TestElicitationCompleteNotification(t *testing.T) {
 		}
 
 		// 2. Server sends elicitation complete notification (simulating out-of-band completion)
-		err = handleNotify(ctx, notificationElicitationComplete, newServerRequest(ss, &ElicitationCompleteParams{
+		err = ss.NotifyElicitationComplete(ctx, &ElicitationCompleteParams{
 			ElicitationID: elicitID,
-		}))
+		})
 		if err != nil {
 			t.Fatalf("failed to send elicitation complete notification: %v", err)
 		}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1448,6 +1448,12 @@ func (ss *ServerSession) NotifyProgress(ctx context.Context, params *ProgressNot
 	return handleNotify(ctx, notificationProgress, newServerRequest(ss, orZero[Params](params)))
 }
 
+// NotifyElicitationComplete signals that an out-of-band (url-mode)
+// elicitation identified by params.ElicitationID has completed.
+func (ss *ServerSession) NotifyElicitationComplete(ctx context.Context, params *ElicitationCompleteParams) error {
+	return handleNotify(ctx, notificationElicitationComplete, newServerRequest(ss, orZero[Params](params)))
+}
+
 // notifySubscriptionAcked sends a "notifications/subscriptions/acknowledged"
 // notification on the listen stream represented by this session, indicating
 // the subscription filter the server accepted (SEP-2575).


### PR DESCRIPTION
## Summary

Add an exported `ServerSession.NotifyElicitationComplete` method so MCP servers can notify clients when an out-of-band URL-mode elicitation has completed.

Fixes #1091.

## Background

The client side of the URL-mode elicitation flow already handles `notifications/elicitation/complete` through `ClientOptions.ElicitationCompleteHandler` and the URL elicitation middleware. However, servers had no exported API for sending that notification. The only available path required using unexported SDK internals, which prevented external server implementations from completing the flow.

## Changes

- Add `ServerSession.NotifyElicitationComplete` with the same notification helper pattern used by `ServerSession.NotifyProgress`.
- Send `ElicitationCompleteParams` using the existing `notificationElicitationComplete` method constant and shared `handleNotify` dispatch path.
- Update the elicitation completion integration test to exercise the exported server API and verify that the client receives the matching elicitation ID.
- Preserve all existing notification behavior and protocol handling.

## Test Plan

- `go build ./...`
- `go test ./...`
- `go vet ./...`
