### PR TITLE
mcp: avoid double-copy of payload in writeEvent

### DIFF
--- a/mcp/event.go
+++ b/mcp/event.go
@@ -52,7 +52,12 @@ func writeEvent(w http.ResponseWriter, evt Event) (int, error) {
 	if evt.Retry != "" {
 		fmt.Fprintf(&b, "retry: %s\n", evt.Retry)
 	}
-	fmt.Fprintf(&b, "data: %s\n\n", string(evt.Data))
+	// Write the payload directly into a pre-grown buffer to avoid the extra
+	// copy from string(evt.Data) and repeated buffer regrowths.
+	b.Grow(len("data: \n\n") + len(evt.Data))
+	b.WriteString("data: ")
+	b.Write(evt.Data)
+	b.WriteString("\n\n")
 	n, err := w.Write(b.Bytes())
 	rc := http.NewResponseController(w)
 	// Ignore returned error as flushing is best-effort.


### PR DESCRIPTION
`writeEvent` built the SSE frame with `fmt.Fprintf(&b, "data: %s\n\n", string(evt.Data))`, which copies the payload into a fresh string and then again into the buffer, growing it via repeated `bytes.growSlice` doublings. For large MCP responses (e.g. ~162KB `tools/list`) under a burst of concurrent writes this ~3x amplifies allocations and peak heap.

Write the payload directly into a pre-grown buffer instead. Output framing is byte-identical. Benchmarks (162KB payload): 517KB->172KB per op, 9->4 allocs/op, ~3x faster.