### PR TITLE
mcp: emit UnsupportedProtocolVersionError for stateful servers rejecting SEP-2575 requests

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -1514,10 +1514,25 @@ func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Reques
 				// rejection as it should learn about the supported protocols from the
 				// DiscoverResult response.
 				if !c.stateless && jreq.Method != methodDiscover {
-					http.Error(w, fmt.Sprintf(
-						"Bad Request: protocol version %q is only supported on stateless HTTP servers (set StreamableHTTPOptions.Stateless = true)",
-						protocolVersion),
-						http.StatusBadRequest)
+					// This server has chosen not to serve >= 2026-07-28 requests
+					// unless configured as stateless (see StreamableHTTPOptions.Stateless).
+					c.logger.Warn("rejecting request for unsupported protocol version; set StreamableHTTPOptions.Stateless = true to serve it",
+						"protocolVersion", protocolVersion)
+					legacyVersions := make([]string, 0, len(supportedProtocolVersions))
+					for _, v := range supportedProtocolVersions {
+						if v < protocolVersion20260728 {
+							legacyVersions = append(legacyVersions, v)
+						}
+					}
+					data, _ := json.Marshal(UnsupportedProtocolVersionData{
+						Supported: legacyVersions,
+						Requested: protocolVersion,
+					})
+					writeJSONRPCError(w, http.StatusBadRequest, jreq.ID, &jsonrpc.Error{
+						Code:    CodeUnsupportedProtocolVersion,
+						Message: fmt.Sprintf("protocol version %q is not supported by this server", protocolVersion),
+						Data:    data,
+					})
 					return
 				}
 				if headerVersion == "" {

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -3504,8 +3504,30 @@ func TestStreamableStateful_RejectsNewProtocol(t *testing.T) {
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body = %s", resp.StatusCode, respBody)
 	}
-	if !strings.Contains(string(respBody), "stateless") {
-		t.Errorf("body = %q, want a message mentioning 'stateless'", respBody)
+	msg, err := jsonrpc2.DecodeMessage(respBody)
+	if err != nil {
+		t.Fatalf("failed to decode message: %v; body = %s", err, respBody)
+	}
+	wireResp, ok := msg.(*jsonrpc2.Response)
+	if !ok {
+		t.Fatalf("expected *jsonrpc2.Response, got %T", msg)
+	}
+	var wireErr *jsonrpc2.WireError
+	if !errors.As(wireResp.Error, &wireErr) {
+		t.Fatalf("expected *jsonrpc2.WireError, got %T", wireResp.Error)
+	}
+	if wireErr.Code != CodeUnsupportedProtocolVersion {
+		t.Errorf("error code = %d, want %d", wireErr.Code, CodeUnsupportedProtocolVersion)
+	}
+	var data UnsupportedProtocolVersionData
+	if err := json.Unmarshal(wireErr.Data, &data); err != nil {
+		t.Fatalf("error.Data is not UnsupportedProtocolVersionData: %v", err)
+	}
+	if data.Requested != protocolVersion20260728 {
+		t.Errorf("data.Requested = %q, want %q", data.Requested, protocolVersion20260728)
+	}
+	if slices.Contains(data.Supported, protocolVersion20260728) {
+		t.Errorf("data.Supported = %v, must not contain %q for a stateful server", data.Supported, protocolVersion20260728)
 	}
 }
 


### PR DESCRIPTION
## Summary

A stateful (`Stateless == false`) Streamable HTTP server rejected requests carrying `_meta."io.modelcontextprotocol/protocolVersion"` for MCP `2026-07-28` with a plain-text `http.Error` body, instead of the JSON-RPC error the draft spec requires. Per the draft's Protocol Version Header section, a server that won't serve a known-but-unsupported version MUST respond `400 Bad Request` with an `UnsupportedProtocolVersionError` listing its supported versions — this is exactly that case (a stateful server that hasn't opted into `Stateless`).

Two things made this clearly a bug rather than a design choice:
- The very next branch in the same function already calls `writeJSONRPCError` with `CodeHeaderMismatch` for an adjacent condition — this branch used `http.Error` instead, inconsistently.
- The body text (`"set StreamableHTTPOptions.Stateless = true"`) is a Go-API hint for whoever wrote the server, not something a remote client can act on.

- Reuse the existing `CodeUnsupportedProtocolVersion` (-32022) and `UnsupportedProtocolVersionData{Supported, Requested}` shape already used by the `discover`/`initialize` paths, so `Client.Connect`'s existing renegotiation logic can recognize this response and fall back cleanly, instead of hitting an unrecognized `text/plain` body.
- `Supported` lists only the server's legacy-era versions (excludes `2026-07-28`), since that's the whole point of the rejection.
- The developer-facing hint moves to a server-side log line instead of the wire body.
- `server/discover` stays exempt, as before — it's how a client is meant to learn a stateful server's restricted version set in the first place.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./mcp/...` (full package)
- [x] Updated `TestStreamableStateful_RejectsNewProtocol` to assert the JSON-RPC error shape (code `-32022`, `Requested`, `Supported` excluding `2026-07-28`) instead of the old text-contains-"stateless" check
- [x] `TestStreamableStateless_AcceptsNewProtocol`, `TestStreamableClientUnsupportedVersionFallback`, `TestStreamableStateful_AcceptsDiscover` all still pass unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)