### PR TITLE
docs: quick start `go get` leaves the module unbuildable

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -7,8 +7,13 @@
 ## Installation
 
 ```
-go get github.com/modelcontextprotocol/go-sdk
+go get github.com/modelcontextprotocol/go-sdk/mcp
 ```
+
+The module root holds no importable package, so `go get` on the module path
+alone records the requirement without the `go.sum` entries the `mcp` package
+needs, and the first `go build` fails. Ask for the package instead, as above
+(or run `go mod tidy` after writing the code below).
 
 ## Getting started
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -10,11 +10,6 @@
 go get github.com/modelcontextprotocol/go-sdk/mcp
 ```
 
-The module root holds no importable package, so `go get` on the module path
-alone records the requirement without the `go.sum` entries the `mcp` package
-needs, and the first `go build` fails. Ask for the package instead, as above
-(or run `go mod tidy` after writing the code below).
-
 ## Getting started
 
 To get started creating an MCP server, create an `mcp.Server` instance, add

--- a/internal/docs/quick_start.src.md
+++ b/internal/docs/quick_start.src.md
@@ -8,11 +8,6 @@
 go get github.com/modelcontextprotocol/go-sdk/mcp
 ```
 
-The module root holds no importable package, so `go get` on the module path
-alone records the requirement without the `go.sum` entries the `mcp` package
-needs, and the first `go build` fails. Ask for the package instead, as above
-(or run `go mod tidy` after writing the code below).
-
 ## Getting started
 
 To get started creating an MCP server, create an `mcp.Server` instance, add

--- a/internal/docs/quick_start.src.md
+++ b/internal/docs/quick_start.src.md
@@ -5,8 +5,13 @@
 ## Installation
 
 ```
-go get github.com/modelcontextprotocol/go-sdk
+go get github.com/modelcontextprotocol/go-sdk/mcp
 ```
+
+The module root holds no importable package, so `go get` on the module path
+alone records the requirement without the `go.sum` entries the `mcp` package
+needs, and the first `go build` fails. Ask for the package instead, as above
+(or run `go mod tidy` after writing the code below).
 
 ## Getting started
 


### PR DESCRIPTION
### What was broken

`docs/quick_start.md` → *Installation* says:

```
go get github.com/modelcontextprotocol/go-sdk
```

The module root holds no importable package (only `copyright_test.go`), so `go get` on the
module path records the requirement as `// indirect` and writes none of the `go.sum` entries
the `mcp` package needs. A reader who runs that command and then pastes the server snippet
from the next section hits six errors on the first build — before writing a line of their own.

### How I checked

Followed the page verbatim on Go 1.26.4, in an empty directory:

```
$ go mod init example.com/qs
$ go get github.com/modelcontextprotocol/go-sdk
go: added github.com/modelcontextprotocol/go-sdk v1.7.0
```

`go.mod` now reads `require github.com/modelcontextprotocol/go-sdk v1.7.0 // indirect`.
Then the two snippets from *Getting started*, saved as `server/main.go` and `client/main.go`:

```
$ go build ./...
missing go.sum entry for module providing package github.com/google/jsonschema-go/jsonschema (imported by github.com/modelcontextprotocol/go-sdk/mcp)
missing go.sum entry for module providing package golang.org/x/oauth2 (imported by github.com/modelcontextprotocol/go-sdk/mcp)
missing go.sum entry for module providing package github.com/segmentio/encoding/json (imported by github.com/modelcontextprotocol/go-sdk/internal/json)
missing go.sum entry for module providing package github.com/yosida95/uritemplate/v3 (imported by github.com/modelcontextprotocol/go-sdk/mcp)
missing go.sum entry for module providing package golang.org/x/sync/errgroup (imported by github.com/modelcontextprotocol/go-sdk/mcp)
missing go.sum entry for module providing package golang.org/x/time/rate (imported by github.com/modelcontextprotocol/go-sdk/mcp)
```

Same directory, same snippets, asking for the package instead:

```
$ go get github.com/modelcontextprotocol/go-sdk/mcp
$ go build -o myserver ./server && go build -o myclient ./client
$ ./myclient
{"greeting":"Hi you"}
```

`go mod tidy` after the fact fixes it too — that is the escape hatch the note mentions,
but it is not what the page tells you to do.

### What it is now

```
go get github.com/modelcontextprotocol/go-sdk/mcp
```

plus four lines saying why the module path alone is not enough, so the next person who
copies the module path from `go.mod` or from a search result knows what they are looking at.

Change is in `internal/docs/quick_start.src.md`; `docs/quick_start.md` regenerated with
`go generate ./internal/docs`, both committed together. Docs-only, no code paths touched.

---
Assisted-by: Claude Opus 5 — this PR was drafted and verified by Anton's AI cofounder running
on his account; every command and output above is from a real run on this machine, not a
reconstruction.
