### PR TITLE
mcp: preserve required text field when marshaling empty ResourceContents

### DIFF
--- a/mcp/content.go
+++ b/mcp/content.go
@@ -307,6 +307,39 @@ type ResourceContents struct {
 	Meta     Meta   `json:"_meta,omitempty"`
 }
 
+func (r *ResourceContents) MarshalJSON() ([]byte, error) {
+	// Custom wire format to ensure the required "text" or "blob" field is
+	// always included, even when empty, so a text resource with empty
+	// content still matches the TextResourceContents branch of the spec's
+	// anyOf union instead of matching neither branch.
+	if r.Blob != nil {
+		wire := struct {
+			URI      string `json:"uri"`
+			MIMEType string `json:"mimeType,omitempty"`
+			Blob     []byte `json:"blob"`
+			Meta     Meta   `json:"_meta,omitempty"`
+		}{
+			URI:      r.URI,
+			MIMEType: r.MIMEType,
+			Blob:     r.Blob,
+			Meta:     r.Meta,
+		}
+		return json.Marshal(wire)
+	}
+	wire := struct {
+		URI      string `json:"uri"`
+		MIMEType string `json:"mimeType,omitempty"`
+		Text     string `json:"text"`
+		Meta     Meta   `json:"_meta,omitempty"`
+	}{
+		URI:      r.URI,
+		MIMEType: r.MIMEType,
+		Text:     r.Text,
+		Meta:     r.Meta,
+	}
+	return json.Marshal(wire)
+}
+
 // wireContent is the wire format for content.
 // It represents the protocol types TextContent, ImageContent, AudioContent,
 // ResourceLink, EmbeddedResource, ToolUseContent, and ToolResultContent.

--- a/mcp/content_test.go
+++ b/mcp/content_test.go
@@ -160,8 +160,10 @@ func TestEmbeddedResource(t *testing.T) {
 			`{"uri":"u","mimeType":"m","text":"t","_meta":{"key":"value"}}`,
 		},
 		{
+			// Text is required by TextResourceContents in the spec, so it must
+			// always be present, even when empty.
 			&mcp.ResourceContents{URI: "u"},
-			`{"uri":"u"}`,
+			`{"uri":"u","text":""}`,
 		},
 		{
 			&mcp.ResourceContents{URI: "u", Blob: []byte{}},


### PR DESCRIPTION
## The bug

`ResourceContents` (`mcp/content.go`) carries `Text string \`json:"text,omitempty"\``. One
struct backs both branches of the spec's `anyOf[TextResourceContents, BlobResourceContents]`,
and `text` is **required** on `TextResourceContents`. A text resource with empty content (e.g.
`&ResourceContents{URI: "u"}`) therefore marshals to `{"uri":"u"}` — no `text` key at all — which
matches *neither* branch of the union. Strict clients validating against the schema reject the
response outright.

This doesn't show up in Go↔Go round-trips because the Go unmarshaler is lenient about the
missing field, so nothing caught it until now.

## The fix

Added `MarshalJSON` on `ResourceContents`, mirroring the existing `TextContent.MarshalJSON`
(same mechanism, no new pattern introduced). It branches on `Blob`:

- `Blob == nil` → text resource: `text` is always emitted, even when empty; `blob` is omitted.
- `Blob != nil` (including `[]byte{}`) → blob resource: `blob` is emitted; `text` is omitted
  entirely.

`_meta` is carried through on **both** branches — flagging this explicitly because #96 previously
had to go back and repair a dropped `Meta` field after #95, so it's an easy thing to miss when
splitting a marshal method into two wire structs.

Struct tags on the fields are left untouched, since they're still what `UnmarshalJSON` relies on
(there's no custom unmarshaler for `ResourceContents`).

This finishes the series the TODO at the top of `content.go` asks for
(`// TODO(findleyr): update JSON marshalling of all content types to preserve required fields.`):
`TextContent` landed in #91, `ImageContent`/`AudioContent` in #95, and `ResourceContents` was the
one left.

## Test change — please look closely here

`mcp/content_test.go`'s `TestEmbeddedResource` pinned `{"uri":"u"}` as the expected output for
`&ResourceContents{URI: "u"}` (empty text, nil blob) — that expectation *was* the bug. Updated it
to `{"uri":"u","text":""}` with a comment explaining why. Calling this out explicitly since
changing a test to make your own fix pass is exactly the kind of diff that deserves a second set
of eyes.

The existing `&ResourceContents{URI: "u", Blob: []byte{}}` → `{"uri":"u","blob":""}` case is
unchanged and still passes, confirming the blob branch wasn't touched.

## Verification

- `gofmt -l ./` — clean
- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all packages pass

Discrimination check: reverted only the source change (kept the new test expectation) and ran
`go test ./mcp/ -run TestEmbeddedResource -v`. It failed exactly as expected:

```
got  {"uri":"u"}
want {"uri":"u","text":""}
```

Restored the fix and reran the full suite — passes again.

## Dedupe check

Searched open/closed issues and PRs for `ResourceContents`/`MarshalJSON`/`text`. #781 and #782
moved `Blob` to `json:"blob,omitzero"` (Go 1.24) — already landed, which is why `Blob` has that
tag today — but neither touched `Text`. No open PR currently touches `content.go`. This isn't a
duplicate of prior work; it's the same series continued.

---

### AI assistance disclosure

Per the [modelcontextprotocol AI policy](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/AI_POLICY.md): **this change was made in conjunction with my pair programmer, Claude Code.**

Extent, so you know how much scrutiny to apply: the defect was surfaced by an automated sweep I run across MCP-ecosystem repos, and the patch was written with Claude Code working alongside me. I reviewed it before filing — the before/after test output, the baseline test counts, and the lint/format runs quoted above were executed on my machine, not pasted from a model. I understand what the change does and why, and replies on this PR are mine.
