### PR TITLE
mcp: drain SSE messages when closing

### DIFF
--- a/mcp/sse.go
+++ b/mcp/sse.go
@@ -140,10 +140,9 @@ type SSEServerTransport struct {
 	// the transport is connected.
 	incoming chan jsonrpc.Message
 
-	// We must guard both pushes to the incoming queue and writes to the response
-	// writer, because incoming POST requests are arbitrarily concurrent and we
-	// need to ensure we don't write push to the queue, or write to the
-	// ResponseWriter, after the session GET request exits.
+	// Incoming POST requests are arbitrarily concurrent. The mutex guards writes
+	// to the ResponseWriter and the closed state, which is checked around queue
+	// pushes so messages are not accepted after the session GET request exits.
 	mu     sync.Mutex    // also guards writes to Response
 	closed bool          // set when the stream is closed
 	done   chan struct{} // closed when the connection is closed
@@ -189,8 +188,25 @@ func (t *SSEServerTransport) ServeHTTP(w http.ResponseWriter, req *http.Request)
 			return
 		}
 	}
+	t.mu.Lock()
+	closed := t.closed
+	t.mu.Unlock()
+	if closed {
+		http.Error(w, "session closed", http.StatusBadRequest)
+		return
+	}
 	select {
 	case t.incoming <- msg:
+		t.mu.Lock()
+		closed = t.closed
+		if closed {
+			t.drainIncoming()
+		}
+		t.mu.Unlock()
+		if closed {
+			http.Error(w, "session closed", http.StatusBadRequest)
+			return
+		}
 		w.WriteHeader(http.StatusAccepted)
 	case <-t.done:
 		http.Error(w, "session closed", http.StatusBadRequest)
@@ -335,10 +351,22 @@ func (s *sseServerConn) SessionID() string { return "" }
 
 // Read implements jsonrpc2.Reader.
 func (s *sseServerConn) Read(ctx context.Context) (jsonrpc.Message, error) {
+	s.t.mu.Lock()
+	closed := s.t.closed
+	s.t.mu.Unlock()
+	if closed {
+		return nil, io.EOF
+	}
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case msg := <-s.t.incoming:
+		s.t.mu.Lock()
+		closed := s.t.closed
+		s.t.mu.Unlock()
+		if closed {
+			return nil, io.EOF
+		}
 		return msg, nil
 	case <-s.t.done:
 		return nil, io.EOF
@@ -370,6 +398,17 @@ func (s *sseServerConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 	return err
 }
 
+// drainIncoming must be called with t.mu held.
+func (t *SSEServerTransport) drainIncoming() {
+	for {
+		select {
+		case <-t.incoming:
+		default:
+			return
+		}
+	}
+}
+
 // Close implements io.Closer, and closes the session.
 //
 // It must be safe to call Close more than once, as the close may
@@ -377,11 +416,12 @@ func (s *sseServerConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 // by the hanging GET exiting.
 func (s *sseServerConn) Close() error {
 	s.t.mu.Lock()
-	defer s.t.mu.Unlock()
 	if !s.t.closed {
 		s.t.closed = true
 		close(s.t.done)
+		s.t.drainIncoming()
 	}
+	s.t.mu.Unlock()
 	return nil
 }
 

--- a/mcp/sse_test.go
+++ b/mcp/sse_test.go
@@ -7,16 +7,20 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
 // TestSSEServerTransport_SupportedVersions verifies that the deprecated
@@ -187,6 +191,45 @@ func TestSSEServer(t *testing.T) {
 				cs.Wait()
 			}
 		})
+	}
+}
+
+func TestSSEServerConnCloseDrainsIncoming(t *testing.T) {
+	transport := &SSEServerTransport{Response: httptest.NewRecorder()}
+	connection, err := transport.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	transport.incoming <- &jsonrpc.Request{Method: "ping"}
+	if err := connection.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := connection.Read(ctx); !errors.Is(err, io.EOF) {
+		t.Fatalf("Read after Close error = %v, want io.EOF", err)
+	}
+}
+
+func TestSSEServerTransportServeHTTPAfterClose(t *testing.T) {
+	transport := &SSEServerTransport{Response: httptest.NewRecorder()}
+	connection, err := transport.Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/messages", strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}`,
+	))
+	recorder := httptest.NewRecorder()
+	transport.ServeHTTP(recorder, req)
+	if got, want := recorder.Code, http.StatusBadRequest; got != want {
+		t.Fatalf("POST after Close status = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
mcp: drain SSE messages when closing

`SSEServerTransport.Close` previously closed the session signal without draining buffered client messages. Because `Read` and `ServeHTTP` select between the message queue and the closed signal, a closed session could deliver stale messages or acknowledge a POST with `202 Accepted` even though the message would never be processed.

This change drains buffered incoming messages when the server connection closes and checks the closed state around queue operations, so close races return `io.EOF` or `400 session closed`. It adds regression tests for stale post-close reads and POST responses after close.

Tests:

- `go test -race ./mcp -run '^(TestSSEServerConnCloseDrainsIncoming|TestSSEServerTransportServeHTTPAfterClose)$' -count=50` — passed.
- `go test ./...` — passed on the rebased head.
- `go vet ./...` — passed.
- `gofmt -d mcp/sse.go mcp/sse_test.go` — no changes reported.

Hosted checks for rebased head `fd3a248297cd62389764587e2949a3cb988c6611` passed, including Test on Go 1.25 and 1.26, race-test, lint, client and server conformance, Analyze, and CodeQL.

Fixes #1191