### PR TITLE
mcp: add ServerSession.NotifyElicitationComplete

### DIFF
--- a/mcp/elicitation_test.go
+++ b/mcp/elicitation_test.go
@@ -12,6 +12,7 @@ import (
 	"testing/synctest"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
@@ -194,9 +195,9 @@ func TestElicitationCompleteNotification(t *testing.T) {
 		}
 
 		// 2. Server sends elicitation complete notification (simulating out-of-band completion)
-		err = handleNotify(ctx, notificationElicitationComplete, newServerRequest(ss, &ElicitationCompleteParams{
+		err = ss.NotifyElicitationComplete(ctx, &ElicitationCompleteParams{
 			ElicitationID: elicitID,
-		}))
+		})
 		if err != nil {
 			t.Fatalf("failed to send elicitation complete notification: %v", err)
 		}
@@ -207,6 +208,41 @@ func TestElicitationCompleteNotification(t *testing.T) {
 			t.Errorf("elicitationComplete notification ID mismatch: got %q, want %q", gotParams.ElicitationID, elicitID)
 		}
 	})
+}
+
+func TestNotifyElicitationCompleteInvalidParams(t *testing.T) {
+	ctx := context.Background()
+
+	ct, st := NewInMemoryTransports()
+	s := NewServer(testImpl, nil)
+	ss, err := s.Connect(ctx, st, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+	c := NewClient(testImpl, nil)
+	cs, err := c.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	// An empty elicitation ID cannot be matched to a pending elicitation by the
+	// client, so it is rejected rather than sent.
+	for _, tc := range []struct {
+		name   string
+		params *ElicitationCompleteParams
+	}{
+		{"nil params", nil},
+		{"empty ID", &ElicitationCompleteParams{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ss.NotifyElicitationComplete(ctx, tc.params)
+			if !errors.Is(err, jsonrpc2.ErrInvalidParams) {
+				t.Errorf("NotifyElicitationComplete(%v) = %v, want %v", tc.params, err, jsonrpc2.ErrInvalidParams)
+			}
+		})
+	}
 }
 
 func TestElicitationNoValidationWithoutAccept(t *testing.T) {

--- a/mcp/error_test.go
+++ b/mcp/error_test.go
@@ -300,10 +300,9 @@ func TestURLElicitationRequired(t *testing.T) {
 				// In a real scenario, this would happen out-of-band after the user
 				// completes the form submission.
 				go func() {
-					err := handleNotify(ctx, notificationElicitationComplete,
-						newServerRequest(ss, &ElicitationCompleteParams{
-							ElicitationID: elicitID,
-						}))
+					err := ss.NotifyElicitationComplete(ctx, &ElicitationCompleteParams{
+						ElicitationID: elicitID,
+					})
 					if err != nil {
 						t.Errorf("failed to send elicitation complete notification: %v", err)
 					}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1734,14 +1734,7 @@ func (ss *ServerSession) Elicit(ctx context.Context, params *ElicitParams) (*Eli
 }
 
 // NotifyElicitationComplete tells the client that the out-of-band ("url" mode)
-// elicitation identified by params.ElicitationID has finished, so that the
-// client can dismiss any pending UI for it.
-//
-// A server that rejects a request with [URLElicitationRequiredError] must call
-// this once the user has completed the interaction: the client blocks the
-// originating request until the notification arrives, then retries it.
-// ElicitationID must match the one in the [ElicitParams] that requested the
-// elicitation.
+// elicitation identified by params.ElicitationID has finished.
 func (ss *ServerSession) NotifyElicitationComplete(ctx context.Context, params *ElicitationCompleteParams) error {
 	if params == nil {
 		return fmt.Errorf("%w: params cannot be nil", jsonrpc2.ErrInvalidParams)

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1733,6 +1733,25 @@ func (ss *ServerSession) Elicit(ctx context.Context, params *ElicitParams) (*Eli
 	return res, nil
 }
 
+// NotifyElicitationComplete tells the client that the out-of-band ("url" mode)
+// elicitation identified by params.ElicitationID has finished, so that the
+// client can dismiss any pending UI for it.
+//
+// A server that rejects a request with [URLElicitationRequiredError] must call
+// this once the user has completed the interaction: the client blocks the
+// originating request until the notification arrives, then retries it.
+// ElicitationID must match the one in the [ElicitParams] that requested the
+// elicitation.
+func (ss *ServerSession) NotifyElicitationComplete(ctx context.Context, params *ElicitationCompleteParams) error {
+	if params == nil {
+		return fmt.Errorf("%w: params cannot be nil", jsonrpc2.ErrInvalidParams)
+	}
+	if params.ElicitationID == "" {
+		return fmt.Errorf("%w: ElicitationID cannot be empty", jsonrpc2.ErrInvalidParams)
+	}
+	return handleNotify(ctx, notificationElicitationComplete, newServerRequest(ss, orZero[Params](params)))
+}
+
 // Log sends a log message to the client.
 //
 // For new-protocol (>= 2026-07-28) requests, the level is taken from the


### PR DESCRIPTION
Adds:

```go
func (ss *ServerSession) NotifyElicitationComplete(ctx context.Context, params *ElicitationCompleteParams) error
```

As according to [spec](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts#L2493-L2501) 