### PR TITLE
mcp: support per-resource cache policy for resources/read

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -996,6 +996,30 @@ server.AddSendingMiddleware(func(next mcp.MethodHandler) mcp.MethodHandler {
 })
 ```
 
+**Per-resource cache hints.** For `resources/read`, a resource or resource
+template can declare its caching policy at registration through
+`CacheHint`, without central URI matching in middleware. The matched
+resource's hint applies only to its `resources/read` result, takes precedence
+over the server default, and is never emitted in `resources/list` or
+`resources/templates/list`. A value the handler sets on the result still wins
+over the hint.
+
+```go
+// Public static documentation, cacheable by any intermediary.
+server.AddResource(&mcp.Resource{
+    URI:       "docs://style-guide",
+    Name:      "style-guide",
+    CacheHint: &mcp.CacheHint{TTLMs: 60_000, CacheScope: "public"},
+}, docHandler)
+
+// Tenant-specific data, cacheable only by the requesting client.
+server.AddResourceTemplate(&mcp.ResourceTemplate{
+    URITemplate: "tenant://{id}/profile",
+    Name:        "tenant-profile",
+    CacheHint:   &mcp.CacheHint{TTLMs: 5_000, CacheScope: "private"},
+}, tenantHandler)
+```
+
 ## Utilities
 
 ### Completion

--- a/internal/docs/server.src.md
+++ b/internal/docs/server.src.md
@@ -395,6 +395,30 @@ server.AddSendingMiddleware(func(next mcp.MethodHandler) mcp.MethodHandler {
 })
 ```
 
+**Per-resource cache hints.** For `resources/read`, a resource or resource
+template can declare its caching policy at registration through
+`CacheHint`, without central URI matching in middleware. The matched
+resource's hint applies only to its `resources/read` result, takes precedence
+over the server default, and is never emitted in `resources/list` or
+`resources/templates/list`. A value the handler sets on the result still wins
+over the hint.
+
+```go
+// Public static documentation, cacheable by any intermediary.
+server.AddResource(&mcp.Resource{
+    URI:       "docs://style-guide",
+    Name:      "style-guide",
+    CacheHint: &mcp.CacheHint{TTLMs: 60_000, CacheScope: "public"},
+}, docHandler)
+
+// Tenant-specific data, cacheable only by the requesting client.
+server.AddResourceTemplate(&mcp.ResourceTemplate{
+    URITemplate: "tenant://{id}/profile",
+    Name:        "tenant-profile",
+    CacheHint:   &mcp.CacheHint{TTLMs: 5_000, CacheScope: "private"},
+}, tenantHandler)
+```
+
 ## Utilities
 
 ### Completion

--- a/mcp/protocol.go
+++ b/mcp/protocol.go
@@ -1196,6 +1196,37 @@ func (c *Cacheable) setDefaultCacheableValues() {
 	c.CacheScope = "public"
 }
 
+// CacheHint declares a caching policy for a single resource or resource
+// template, applied to its resources/read result at registration time. See
+// [Resource.CacheHint] and [ResourceTemplate.CacheHint].
+type CacheHint struct {
+	// TTLMs is the freshness hint in milliseconds, with the same semantics
+	// as [Cacheable.TTLMs].
+	TTLMs int
+	// CacheScope is the intended cache scope ("public" or "private"), with
+	// the same semantics as [Cacheable.CacheScope]. If empty, the server
+	// default ("public") applies.
+	CacheScope string
+}
+
+// applyCacheHint fills the cacheable fields from a registration-level hint,
+// falling back to the server default ("public", TTL 0) when the hint is nil.
+// Values already set on the result by the handler take precedence over the
+// hint, and the hint takes precedence over the default.
+func (c *Cacheable) applyCacheHint(hint *CacheHint) {
+	if c.CacheScope == "" {
+		switch {
+		case hint != nil && hint.CacheScope != "":
+			c.CacheScope = hint.CacheScope
+		default:
+			c.CacheScope = "public"
+		}
+	}
+	if c.TTLMs == 0 && hint != nil {
+		c.TTLMs = hint.TTLMs
+	}
+}
+
 // The server's response to a prompts/list request from the client.
 type ListPromptsResult struct {
 	completeResultWithType
@@ -1693,6 +1724,10 @@ type Resource struct {
 	URI string `json:"uri"`
 	// Icons for the resource, if any.
 	Icons []Icon `json:"icons,omitempty"`
+	// CacheHint declares a caching policy applied to this resource's
+	// resources/read result (SEP-2549). When set, it takes precedence over
+	// the server default and is not emitted in resources/list.
+	CacheHint *CacheHint `json:"-"`
 }
 
 type ResourceListChangedParams struct {
@@ -1736,6 +1771,11 @@ type ResourceTemplate struct {
 	URITemplate string `json:"uriTemplate"`
 	// Icons for the resource template, if any.
 	Icons []Icon `json:"icons,omitempty"`
+	// CacheHint declares a caching policy applied to the resources/read
+	// result of resources matched by this template (SEP-2549). When set, it
+	// takes precedence over the server default and is not emitted in
+	// resources/templates/list.
+	CacheHint *CacheHint `json:"-"`
 }
 
 // The sender or recipient of messages and data in a conversation.

--- a/mcp/resource_cachehint_test.go
+++ b/mcp/resource_cachehint_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 The Go MCP SDK Authors. All rights reserved.
+// Use of this source code is governed by the license
+// that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestReadResourceCacheHint(t *testing.T) {
+	handler := func(_ context.Context, req *ReadResourceRequest) (*ReadResourceResult, error) {
+		return &ReadResourceResult{
+			Contents: []*ResourceContents{{URI: req.Params.URI, Text: "data"}},
+		}, nil
+	}
+
+	tests := []struct {
+		name           string
+		uri            string
+		wantTTLMs      int
+		wantCacheScope string
+	}{
+		{
+			name:           "resource private hint",
+			uri:            "test://private",
+			wantTTLMs:      5000,
+			wantCacheScope: "private",
+		},
+		{
+			name:           "resource public ttl-only hint",
+			uri:            "test://public",
+			wantTTLMs:      1000,
+			wantCacheScope: "public",
+		},
+		{
+			name:           "resource without hint uses server default",
+			uri:            "test://none",
+			wantTTLMs:      0,
+			wantCacheScope: "public",
+		},
+		{
+			name:           "template hint applies to matched uri",
+			uri:            "tmpl://tenant/42",
+			wantTTLMs:      2000,
+			wantCacheScope: "private",
+		},
+	}
+
+	ctx := context.Background()
+	srv := NewServer(testImpl, nil)
+	srv.AddResource(&Resource{URI: "test://private", Name: "private", CacheHint: &CacheHint{TTLMs: 5000, CacheScope: "private"}}, handler)
+	srv.AddResource(&Resource{URI: "test://public", Name: "public", CacheHint: &CacheHint{TTLMs: 1000}}, handler)
+	srv.AddResource(&Resource{URI: "test://none", Name: "none"}, handler)
+	srv.AddResourceTemplate(&ResourceTemplate{URITemplate: "tmpl://tenant/{id}", Name: "tenant", CacheHint: &CacheHint{TTLMs: 2000, CacheScope: "private"}}, handler)
+
+	conn := mustConnect(t, srv, nil)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := conn.ReadResource(ctx, &ReadResourceParams{URI: tt.uri})
+			if err != nil {
+				t.Fatalf("ReadResource(%q) error = %v", tt.uri, err)
+			}
+			if res.TTLMs != tt.wantTTLMs {
+				t.Errorf("TTLMs = %d, want %d", res.TTLMs, tt.wantTTLMs)
+			}
+			if res.CacheScope != tt.wantCacheScope {
+				t.Errorf("CacheScope = %q, want %q", res.CacheScope, tt.wantCacheScope)
+			}
+		})
+	}
+}
+
+func TestReadResourceHandlerOverridesCacheHint(t *testing.T) {
+	handler := func(_ context.Context, req *ReadResourceRequest) (*ReadResourceResult, error) {
+		return &ReadResourceResult{
+			Cacheable: Cacheable{TTLMs: 9000, CacheScope: "public"},
+			Contents:  []*ResourceContents{{URI: req.Params.URI, Text: "data"}},
+		}, nil
+	}
+
+	ctx := context.Background()
+	srv := NewServer(testImpl, nil)
+	srv.AddResource(&Resource{URI: "test://override", Name: "override", CacheHint: &CacheHint{TTLMs: 5000, CacheScope: "private"}}, handler)
+
+	conn := mustConnect(t, srv, nil)
+
+	res, err := conn.ReadResource(ctx, &ReadResourceParams{URI: "test://override"})
+	if err != nil {
+		t.Fatalf("ReadResource() error = %v", err)
+	}
+	if res.TTLMs != 9000 {
+		t.Errorf("TTLMs = %d, want 9000 (handler value should win over hint)", res.TTLMs)
+	}
+	if res.CacheScope != "public" {
+		t.Errorf("CacheScope = %q, want \"public\" (handler value should win over hint)", res.CacheScope)
+	}
+}
+
+func TestCacheHintNotSerializedInListings(t *testing.T) {
+	r := &Resource{URI: "file:///a", Name: "a", CacheHint: &CacheHint{TTLMs: 5000, CacheScope: "private"}}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("Marshal(Resource) error = %v", err)
+	}
+	if got := string(b); containsAny(got, "cacheHint", "CacheHint", "ttlMs", "cacheScope") {
+		t.Errorf("Resource JSON unexpectedly contains cache hint fields: %s", got)
+	}
+
+	rt := &ResourceTemplate{URITemplate: "file:///{x}", Name: "t", CacheHint: &CacheHint{TTLMs: 1000}}
+	b2, err := json.Marshal(rt)
+	if err != nil {
+		t.Fatalf("Marshal(ResourceTemplate) error = %v", err)
+	}
+	if got := string(b2); containsAny(got, "cacheHint", "CacheHint", "ttlMs", "cacheScope") {
+		t.Errorf("ResourceTemplate JSON unexpectedly contains cache hint fields: %s", got)
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1025,7 +1025,7 @@ func (s *Server) readResource(ctx context.Context, req *ReadResourceRequest) (*R
 	uri := req.Params.URI
 	// Look up the resource URI in the lists of resources and resource templates.
 	// This is a security check as well as an information lookup.
-	handler, mimeType, ok := s.lookupResourceHandler(uri)
+	handler, mimeType, hint, ok := s.lookupResourceHandler(uri)
 	if !ok {
 		// Don't expose the server configuration to the client.
 		// Treat an unregistered resource the same as a registered one that couldn't be found.
@@ -1041,7 +1041,7 @@ func (s *Server) readResource(ctx context.Context, req *ReadResourceRequest) (*R
 	if err := handleMultiRoundTripResult(req.Session, s.opts.Logger, res); err != nil {
 		return nil, err
 	}
-	res.setDefaultCacheableValues()
+	res.applyCacheHint(hint)
 	if res.resultType == resultTypeInputRequired {
 		return res, nil
 	}
@@ -1060,22 +1060,23 @@ func (s *Server) readResource(ctx context.Context, req *ReadResourceRequest) (*R
 	return res, nil
 }
 
-// lookupResourceHandler returns the resource handler and MIME type for the resource or
-// resource template matching uri. If none, the last return value is false.
-func (s *Server) lookupResourceHandler(uri string) (ResourceHandler, string, bool) {
+// lookupResourceHandler returns the resource handler, MIME type, and cache
+// hint for the resource or resource template matching uri. If none, the last
+// return value is false.
+func (s *Server) lookupResourceHandler(uri string) (ResourceHandler, string, *CacheHint, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// Try resources first.
 	if r, ok := s.resources.get(uri); ok {
-		return r.handler, r.resource.MIMEType, true
+		return r.handler, r.resource.MIMEType, r.resource.CacheHint, true
 	}
 	// Look for matching template.
 	for rt := range s.resourceTemplates.all() {
 		if rt.Matches(uri) {
-			return rt.handler, rt.resourceTemplate.MIMEType, true
+			return rt.handler, rt.resourceTemplate.MIMEType, rt.resourceTemplate.CacheHint, true
 		}
 	}
-	return nil, "", false
+	return nil, "", nil, false
 }
 
 // fileResourceHandler returns a ReadResourceHandler that reads paths using dir as


### PR DESCRIPTION
Fixes #1185

Desc: support per-resource cache policy for resources/read

Changes:
- Add exported CacheHint{ TTLMs int, CacheScope string } type.
- Add a CacheHint *CacheHint field to Resource and ResourceTemplate, tagged json:"-" so it never appears in resources/list or resources/templates/list.
- readResource now applies the matched resource's/template's hint to the resources/read result via a new (*Cacheable).applyCacheHint.
- Add UnitTest and passed.
- Update docs/server.md.