### PR TITLE
mcp: carry the SEP-2575 _meta envelope on notifications/cancelled

### DIFF
--- a/mcp/mcp_test.go
+++ b/mcp/mcp_test.go
@@ -2632,6 +2632,132 @@ func TestSubscriptionsListen_Streamable(t *testing.T) {
 		&StreamableClientTransport{Endpoint: httpServer.URL}, events)
 }
 
+// TestSubscriptionsListen_CancellationCarriesMeta verifies that the
+// notifications/cancelled a new-protocol client emits — on Unsubscribe and on
+// a canceled in-flight call — carries the SEP-2575 _meta envelope, so a
+// stateless server accepts it (202) instead of rejecting it with
+// CodeInvalidParams, a rejection that permanently failed the connection.
+func TestSubscriptionsListen_CancellationCarriesMeta(t *testing.T) {
+	ctx := context.Background()
+
+	server := NewServer(testImpl, &ServerOptions{
+		SubscribeHandler:   func(context.Context, *SubscribeRequest) error { return nil },
+		UnsubscribeHandler: func(context.Context, *UnsubscribeRequest) error { return nil },
+	})
+	started := make(chan struct{}, 1)
+	AddTool(server, &Tool{Name: "slow", InputSchema: &jsonschema.Schema{Type: "object"}},
+		func(ctx context.Context, req *CallToolRequest, args any) (*CallToolResult, any, error) {
+			started <- struct{}{}
+			<-ctx.Done() // unblocked by the aborted POST (PropagateRequestCancellation)
+			return nil, nil, ctx.Err()
+		})
+
+	handler := NewStreamableHTTPHandler(
+		func(*http.Request) *Server { return server },
+		&StreamableHTTPOptions{Stateless: true, PropagateRequestCancellation: true},
+	)
+
+	type cancelledPost struct {
+		metaVersion string
+		status      int
+	}
+	posts := make(chan cancelledPost, 4)
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		var msg struct {
+			Method string `json:"method"`
+			Params struct {
+				Meta map[string]any `json:"_meta"`
+			} `json:"params"`
+		}
+		isCancelled := json.Unmarshal(body, &msg) == nil && msg.Method == notificationCancelled
+		sw := &statusCapturingWriter{ResponseWriter: w, code: http.StatusOK}
+		handler.ServeHTTP(sw, r)
+		if isCancelled {
+			version, _ := msg.Params.Meta[MetaKeyProtocolVersion].(string)
+			posts <- cancelledPost{metaVersion: version, status: sw.code}
+		}
+	})
+
+	httpServer := httptest.NewServer(mustNotPanic(t, wrapped))
+	defer httpServer.Close()
+
+	client := NewClient(testImpl, nil)
+	cs, err := client.Connect(ctx, &StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer cs.Close()
+	if v := cs.InitializeResult().ProtocolVersion; v < protocolVersion20260728 {
+		t.Fatalf("negotiated %q, want >= %q", v, protocolVersion20260728)
+	}
+
+	expectCancelled := func(what string) {
+		t.Helper()
+		select {
+		case p := <-posts:
+			if p.metaVersion == "" {
+				t.Errorf("%s: notifications/cancelled missing _meta %q", what, MetaKeyProtocolVersion)
+			}
+			if p.status != http.StatusAccepted {
+				t.Errorf("%s: notifications/cancelled got HTTP %d, want %d", what, p.status, http.StatusAccepted)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("%s: no notifications/cancelled observed", what)
+		}
+	}
+
+	// Trigger 1: Unsubscribe cancels the per-URI listen call.
+	const uri = "test://resource"
+	if err := cs.Subscribe(ctx, &SubscribeParams{URI: uri}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if err := cs.Unsubscribe(ctx, &UnsubscribeParams{URI: uri}); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+	expectCancelled("unsubscribe")
+
+	// Trigger 2: canceling an in-flight call.
+	callCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = cs.CallTool(callCtx, &CallToolParams{Name: "slow"})
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("slow tool never started — session unusable after Unsubscribe")
+	}
+	cancel()
+	<-done
+	expectCancelled("canceled call")
+
+	// A rejected cancellation used to fail the connection; the session must
+	// remain usable.
+	if _, err := cs.ListTools(ctx, nil); err != nil {
+		t.Errorf("ListTools after cancellations: %v", err)
+	}
+}
+
+// statusCapturingWriter records the response status, passing SSE flushes through.
+type statusCapturingWriter struct {
+	http.ResponseWriter
+	code int
+}
+
+func (w *statusCapturingWriter) WriteHeader(code int) {
+	w.code = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusCapturingWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // TestSubscriptionsListen_NoHandlersNoListen verifies that a new-protocol
 // client without any list-changed handlers registered does not open an
 // auto-listen on connect, and therefore does not receive any acknowledgment

--- a/mcp/shared.go
+++ b/mcp/shared.go
@@ -157,14 +157,26 @@ func defaultSendingMethodHandler(ctx context.Context, method string, req Request
 	// Create the result to unmarshal into.
 	// The concrete type of the result is the return type of the receiving function.
 	res := info.newResult()
+	cancelMeta := cancellationMeta(req.GetSession())
 	if method == methodSubscriptionsListen {
-		callSubscriptionsListen(ctx, req.GetSession().getConn(), method, params)
+		callSubscriptionsListen(ctx, req.GetSession().getConn(), method, params, cancelMeta)
 	} else {
-		if err := call(ctx, req.GetSession().getConn(), method, params, res); err != nil {
+		if err := call(ctx, req.GetSession().getConn(), method, params, res, cancelMeta); err != nil {
 			return nil, err
 		}
 	}
 	return res, nil
+}
+
+// cancellationMeta returns the SEP-2575 per-request _meta envelope for the
+// "notifications/cancelled" the transport may send on sess's behalf, or nil
+// when the session's protocol does not require one. Without it, a
+// >= 2026-07-28 server rejects the cancellation (CodeInvalidParams).
+func cancellationMeta(sess Session) Meta {
+	if cs, ok := sess.(*ClientSession); ok && cs.usesNewProtocol() {
+		return injectRequestMeta(cs, &CancelledParams{}).GetMeta()
+	}
+	return nil
 }
 
 // Helper method to avoid typed nil.

--- a/mcp/transport.go
+++ b/mcp/transport.go
@@ -267,18 +267,18 @@ func (c *canceller) Preempt(ctx context.Context, req *jsonrpc.Request) (result a
 // Cancellation is driven by ctx: when it is cancelled, a background goroutine
 // sends a "notifications/cancelled" notification referencing the listen's
 // request ID and retires the call from the connection's outgoing-calls map.
-func callSubscriptionsListen(ctx context.Context, conn *jsonrpc2.Connection, method string, params Params) {
+func callSubscriptionsListen(ctx context.Context, conn *jsonrpc2.Connection, method string, params Params, cancelMeta Meta) {
 	call := conn.Call(ctx, method, params)
 
 	go func() {
 		<-ctx.Done()
-		_ = cancelCall(ctx, conn, call)
+		_ = cancelCall(ctx, conn, call, cancelMeta)
 	}()
 }
 
 // call executes and awaits a jsonrpc2 call on the given connection,
 // translating errors into the mcp domain.
-func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params Params, result Result) error {
+func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params Params, result Result, cancelMeta Meta) error {
 	// The "%w"s in this function expose jsonrpc.Error as part of the API.
 	call := conn.Call(ctx, method, params)
 	err := call.Await(ctx, result)
@@ -295,7 +295,7 @@ func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params 
 		// Setting MCPGODEBUG=blockingcancelnotify=1 restores the previous
 		// behavior of waiting synchronously for delivery inside cancelCall.
 		if blockingcancelnotify == "1" {
-			err := cancelCall(ctx, conn, call)
+			err := cancelCall(ctx, conn, call, cancelMeta)
 			return errors.Join(ctx.Err(), err)
 		}
 		conn.Retire(call, ctx.Err())
@@ -303,6 +303,7 @@ func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params 
 			notifyCtx, stop := context.WithTimeout(context.WithoutCancel(ctx), notifyCancellationTimeout)
 			defer stop()
 			_ = conn.Notify(notifyCtx, notificationCancelled, &CancelledParams{
+				Meta:      cancelMeta,
 				Reason:    ctx.Err().Error(),
 				RequestID: call.ID().Raw(),
 			})
@@ -327,10 +328,11 @@ func call(ctx context.Context, conn *jsonrpc2.Connection, method string, params 
 // Therefore, we choose to eagerly retire calls, removing them from the
 // outgoingCalls map, when the caller context is cancelled: if the caller will
 // never receive the response, there's no need to track it.
-func cancelCall(ctx context.Context, conn *jsonrpc2.Connection, call *jsonrpc2.AsyncCall) error {
+func cancelCall(ctx context.Context, conn *jsonrpc2.Connection, call *jsonrpc2.AsyncCall, meta Meta) error {
 	notifyCtx, cancelNotify := context.WithTimeout(context.WithoutCancel(ctx), notifyCancellationTimeout)
 	defer cancelNotify()
 	err := conn.Notify(notifyCtx, notificationCancelled, &CancelledParams{
+		Meta:      meta,
 		Reason:    ctx.Err().Error(),
 		RequestID: call.ID().Raw(),
 	})


### PR DESCRIPTION
Fixes #1212.

The two cancellation-notify sites (`cancelCall` and the async-notify branch of `call`, both in `mcp/transport.go`) build `CancelledParams` directly, so they are the only client sends on a `2026-07-28` session that omit the SEP-2575 per-request `_meta` envelope. A conformant server rejects the notification with `-32602 "missing or invalid _meta field \"io.modelcontextprotocol/protocolVersion\""` over HTTP 400, and because that rejection responds to a notification its error body has no `id`, so `checkResponse` cannot classify it as a per-call rejection (#1118) and permanently fails the connection. Net effect: `ClientSession.Unsubscribe` — or canceling any in-flight call — poisons the whole stateless session (see #1212 for the wire trace).

This change computes the envelope once per send in `handleSend` (`cancellationMeta`, nil for server sessions and pre-2026 protocols, reusing `injectRequestMeta` so the envelope stays identical to every other send) and threads it through `call` / `callSubscriptionsListen` into the two notify sites. With it, the cancellation is accepted (202) and the session stays usable.

Tests: `TestSubscriptionsListen_CancellationCarriesMeta` drives a real stateless server through both triggers (Unsubscribe of a listen subscription, cancellation of an in-flight tool call) and asserts at the wire that each `notifications/cancelled` carries the `_meta` protocol version and is answered 202, then that the session still serves `tools/list`. On main it fails with `missing _meta "io.modelcontextprotocol/protocolVersion"`, `got HTTP 400, want 202`, and `slow tool never started — session unusable after Unsubscribe`; with this change it passes. `go test ./...` and `go vet ./...` are clean.
