### PR TITLE
all: do not allow OPTIONS method in CORS config

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -190,7 +190,7 @@ func ProtectedResourceMetadataHandler(metadata *oauthex.ProtectedResourceMetadat
 		// Set CORS headers for cross-origin client discovery.
 		// OAuth metadata is public information, so allowing any origin is safe.
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 
 		// Handle CORS preflight requests

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -148,8 +148,8 @@ func TestProtectedResourceMetadataHandler(t *testing.T) {
 				t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "*")
 			}
 
-			if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "GET, OPTIONS" {
-				t.Errorf("Access-Control-Allow-Methods = %q, want %q", got, "GET, OPTIONS")
+			if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "GET" {
+				t.Errorf("Access-Control-Allow-Methods = %q, want %q", got, "GET")
 			}
 
 			// Validate error response body for disallowed methods

--- a/examples/server/auth-middleware/README.md
+++ b/examples/server/auth-middleware/README.md
@@ -246,7 +246,7 @@ import "github.com/rs/cors"
 
 c := cors.New(cors.Options{
     AllowedOrigins: []string{"https://example.com"},
-    AllowedMethods: []string{"GET", "OPTIONS"},
+    AllowedMethods: []string{"GET"},
 })
 http.Handle("/.well-known/oauth-protected-resource",
     c.Handler(auth.ProtectedResourceMetadataHandler(metadata)))
@@ -258,7 +258,7 @@ import "github.com/jub0bs/cors"
 
 corsMiddleware, err := cors.NewMiddleware(cors.Config{
     Origins: []string{"https://example.com"},
-    Methods: []string{"GET", "OPTIONS"},
+    Methods: []string{"GET"},
 })
 http.Handle("/.well-known/oauth-protected-resource",
     corsMiddleware.Wrap(auth.ProtectedResourceMetadataHandler(metadata)))

--- a/internal/oauthtest/fake_authorization_server.go
+++ b/internal/oauthtest/fake_authorization_server.go
@@ -210,7 +210,7 @@ func (s *FakeAuthorizationServer) handleMetadata(w http.ResponseWriter, r *http.
 	}
 	// Set CORS headers for cross-origin client discovery.
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 
 	// Handle CORS preflight requests


### PR DESCRIPTION
Contrary to popular belief, listing OPTIONS as an allowed method in a server's CORS configuration is not necessary for CORS preflight to succeed. It is only required if server developers wish to allow clients to make explicit use of that method, e.g. via the following client code:

```javascript
fetch('//example.com', {method: 'OPTIONS'})
```

This commit drops OPTIONS from the list of allowed methods throughout.