### PR TITLE
mcp: ignore Last-Event-ID on a 2026-07-28 POST instead of rejecting it

### DIFF
--- a/mcp/streamable.go
+++ b/mcp/streamable.go
@@ -1438,7 +1438,15 @@ func (c *streamableServerConn) acquireStream(ctx context.Context, w http.Respons
 //
 // It returns an HTTP status code and error message.
 func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Request) {
-	if len(req.Header.Values(lastEventIDHeader)) > 0 {
+	protocolVersion := protocolVersionFromContext(req.Context())
+	if protocolVersion == "" {
+		protocolVersion = protocolVersion20250326
+	}
+
+	// Last-Event-ID has no meaning on a POST. Before 2026-07-28 it is rejected;
+	// that revision removed resumable streams, so a leftover header from an
+	// older client is ignored rather than failing the request.
+	if protocolVersion < protocolVersion20260728 && len(req.Header.Values(lastEventIDHeader)) > 0 {
 		http.Error(w, "can't send Last-Event-ID for POST request", http.StatusBadRequest)
 		return
 	}
@@ -1465,11 +1473,6 @@ func (c *streamableServerConn) servePOST(w http.ResponseWriter, req *http.Reques
 	if err != nil {
 		http.Error(w, fmt.Sprintf("malformed payload: %v", err), http.StatusBadRequest)
 		return
-	}
-
-	protocolVersion := protocolVersionFromContext(req.Context())
-	if protocolVersion == "" {
-		protocolVersion = protocolVersion20250326
 	}
 
 	if isBatch && protocolVersion >= protocolVersion20250618 {

--- a/mcp/streamable_test.go
+++ b/mcp/streamable_test.go
@@ -4264,3 +4264,48 @@ func TestStreamableSupportedProtocolVersions_Header(t *testing.T) {
 		}
 	})
 }
+
+// TestStreamablePOSTLastEventID verifies that a POST carrying a Last-Event-ID
+// header is rejected before 2026-07-28 but ignored on 2026-07-28, where
+// resumable streams were removed. Regression test for #1233.
+func TestStreamablePOSTLastEventID(t *testing.T) {
+	server := NewServer(testImpl, nil)
+	handler := NewStreamableHTTPHandler(func(*http.Request) *Server { return server }, nil)
+	httpServer := httptest.NewServer(mustNotPanic(t, handler))
+	defer httpServer.Close()
+
+	const rejection = "can't send Last-Event-ID"
+	tests := []struct {
+		name            string
+		protocolVersion string
+		wantRejected    bool
+	}{
+		{"2026-07-28 ignores Last-Event-ID", protocolVersion20260728, false},
+		{"pre-2026-07-28 rejects Last-Event-ID", protocolVersion20251125, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := jsonBody(t, req(1, "ping", nil))
+			r, err := http.NewRequest("POST", httpServer.URL, strings.NewReader(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("Accept", "application/json, text/event-stream")
+			r.Header.Set(protocolVersionHeader, tt.protocolVersion)
+			r.Header.Set(lastEventIDHeader, "42")
+
+			resp, err := http.DefaultClient.Do(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			b, _ := io.ReadAll(resp.Body)
+
+			if got := strings.Contains(string(b), rejection); got != tt.wantRejected {
+				t.Errorf("Last-Event-ID rejected = %v, want %v (status %d, body %q)",
+					got, tt.wantRejected, resp.StatusCode, strings.TrimSpace(string(b)))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The 2026-07-28 revision removed resumable streams, and its backward-compat guidance says a server should ignore a `Last-Event-ID` header left over from an older client rather than fail the request. `servePOST` rejected it with `400` for every protocol version.

This gates the rejection to pre-2026-07-28 and ignores the header otherwise. Added a test asserting the header is rejected before 2026-07-28 and ignored on it (red before, green after).

Fixes #1233
